### PR TITLE
chore: Obfuscate field by repeating * with character length

### DIFF
--- a/internal/destregistry/baseprovider.go
+++ b/internal/destregistry/baseprovider.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hookdeck/outpost/internal/models"
 )
 
-// ObfuscateValue masks a sensitive value. For strings:
-// - Less than 10 characters: return "****" to avoid revealing length
-// - 10 or more characters: show first 4 characters + asterisks for the rest
+// ObfuscateValue masks a sensitive value with the following rules:
+// - For strings with length >= 10: show first 4 characters + asterisks for the rest
+// - For strings with length < 10: replace each character with an asterisk
 func ObfuscateValue(value string) string {
 	if len(value) < 10 {
 		return strings.Repeat("*", len(value))

--- a/internal/destregistry/registry_test.go
+++ b/internal/destregistry/registry_test.go
@@ -530,22 +530,22 @@ func TestObfuscateValue(t *testing.T) {
 		{
 			name:     "empty string",
 			input:    "",
-			expected: "****",
+			expected: "",
 		},
 		{
 			name:     "single character",
 			input:    "a",
-			expected: "****",
+			expected: "*",
 		},
 		{
 			name:     "short string",
 			input:    "abc123",
-			expected: "****",
+			expected: "******",
 		},
 		{
 			name:     "9 characters",
 			input:    "123456789",
-			expected: "****",
+			expected: "*********",
 		},
 		{
 			name:     "10 characters",
@@ -600,11 +600,11 @@ func TestObfuscateDestination(t *testing.T) {
 	assert.Equal(t, "visible-value", obfuscated.Config["public_key"])
 
 	// Sensitive fields should be obfuscated according to length:
-	// - Less than 10 chars: "****"
+	// - Less than 10 chars: replace each character with an asterisk
 	// - 10+ chars: first 4 chars + asterisks
 	assert.Equal(t, "sens***************", obfuscated.Config["secret_key"]) // 19 chars
 	assert.Equal(t, "abcd************", obfuscated.Credentials["api_key"])  // 16 chars
-	assert.Equal(t, "****", obfuscated.Credentials["token"])                // 3 chars
+	assert.Equal(t, "***", obfuscated.Credentials["token"])                 // 3 chars
 	assert.Equal(t, "****", obfuscated.Credentials["code"])                 // 4 chars
 }
 
@@ -716,7 +716,7 @@ func TestDisplayDestination(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "mock-target", display.Target)
 	assert.Equal(t, "value", display.Config["public_key"])
-	assert.Equal(t, "****", display.Config["secret_key"])
+	assert.Equal(t, "******", display.Config["secret_key"])
 	assert.Equal(t, "secr******", display.Credentials["api_key"])
 }
 


### PR DESCRIPTION
I reverted some changes that broke the test suite. This commit is the code that was reverted. I'd love to have a discussion here to align, and if we want to proceed with this then we can adjust the tests before merging.

This change is around field obfuscation.

## Current behavior
The current logic in `main` is that:
- If the length of a sensitive field is longer than 10 character, then we keep the first 4 characters and obfuscate the rest by replacing each character with `*`. The end result is an obfuscated string with the same length as the original.
- If the field length is less than 10, then we replace by `****`, exactly 4 characters regardless of how long the original string is.

## Change

The code change is to update the obfuscation logic of sensitive string less than 10 characters to repeat `*` by the length of the string.

## Consideration

Ultimately, this is a relatively small change so either approach should be okay. I have 2 concerns with this change:

1: If the field is empty, then the obfuscated string is also empty. That sort of reveal what the original value is, even though it's supposed to be a secret.
2: If we show how long the secret is, it could be considered a security concern given it's a bit too revealing. It's okay to reveal the length if the secret is long because it's stronger and harder to brute-force. When a secret is 2 characters, for example, revealing the length seems to expose more risk. Ultimately though, this may or may not be a significant concern.

## Previous discussion

We briefly discussed this in the [original issue](https://github.com/hookdeck/outpost/issues/148). Just want to leave the link here in case you want to revisit that conversation.