### PR TITLE
example: Update to latest alpha release + example supporting different log storage

### DIFF
--- a/examples/docker-compose/compose-clickhouse.yml
+++ b/examples/docker-compose/compose-clickhouse.yml
@@ -1,0 +1,62 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:24-alpine
+    environment:
+      CLICKHOUSE_DB: outpost
+    ports:
+      # tcp
+      - 9000:9000
+      # # http
+      # - 8123:8123
+      # # postgresql
+      # - 9005:9005
+    volumes:
+      # optional to persist data locally
+      - ./data/clickhouse:/var/lib/clickhouse/
+      # optional to add own config
+      # - ./extra-config.xml:/etc/clickhouse-server/config.d/extra-config.xml
+      # optional to add users or enable settings for a default user
+      # - ./user.xml:/etc/clickhouse-server/users.d/user.xml
+      # qol to mount own sql scripts to run them from inside container with
+      # clickhouse client < /sql/myquery.sql
+      # - ./sql:/sql
+    # adjust mem_limit and cpus to machine
+    # mem_limit: 12G
+    # cpus: 4
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8123/ping"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+
+  api:
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    environment:
+      - CLICKHOUSE_ADDR=clickhouse:9000
+      - CLICKHOUSE_USERNAME=default
+      - CLICKHOUSE_DATABASE=outpost
+      - CLICKHOUSE_PASSWORD=
+  delivery:
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    environment:
+      - CLICKHOUSE_ADDR=clickhouse:9000
+      - CLICKHOUSE_USERNAME=default
+      - CLICKHOUSE_DATABASE=outpost
+      - CLICKHOUSE_PASSWORD=
+  log:
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    environment:
+      - CLICKHOUSE_ADDR=clickhouse:9000
+      - CLICKHOUSE_USERNAME=default
+      - CLICKHOUSE_DATABASE=outpost
+      - CLICKHOUSE_PASSWORD=

--- a/examples/docker-compose/compose-postgres.yml
+++ b/examples/docker-compose/compose-postgres.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: outpost
+      POSTGRES_PASSWORD: outpost
+      POSTGRES_DB: outpost
+    ports:
+      - 5432:5432
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "outpost", "-d", "outpost"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+
+  api:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRES_URL=postgres://outpost:outpost@postgres:5432/outpost?sslmode=disable
+  delivery:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRES_URL=postgres://outpost:outpost@postgres:5432/outpost?sslmode=disable
+  log:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRES_URL=postgres://outpost:outpost@postgres:5432/outpost?sslmode=disable

--- a/examples/docker-compose/compose.yml
+++ b/examples/docker-compose/compose.yml
@@ -6,8 +6,6 @@ services:
     depends_on:
       redis:
         condition: service_started
-      clickhouse:
-        condition: service_healthy
     volumes:
       - ./config/outpost:/config/outpost
     environment:
@@ -21,8 +19,6 @@ services:
     depends_on:
       redis:
         condition: service_started
-      clickhouse:
-        condition: service_healthy
     volumes:
       - ./config/outpost:/config/outpost
     environment:
@@ -34,8 +30,6 @@ services:
     depends_on:
       redis:
         condition: service_started
-      clickhouse:
-        condition: service_healthy
     volumes:
       - ./config/outpost:/config/outpost
     environment:
@@ -52,37 +46,3 @@ services:
         --requirepass ${REDIS_PASSWORD}
     volumes:
       - ./data/redis:/data
-
-  clickhouse:
-    image: clickhouse/clickhouse-server:24-alpine
-    environment:
-      CLICKHOUSE_DB: outpost
-    ports:
-      # tcp
-      - 9000:9000
-      # # http
-      # - 8123:8123
-      # # postgresql
-      # - 9005:9005
-    volumes:
-      # optional to persist data locally
-      - ./data/clickhouse:/var/lib/clickhouse/
-      # optional to add own config
-      # - ./extra-config.xml:/etc/clickhouse-server/config.d/extra-config.xml
-      # optional to add users or enable settings for a default user
-      # - ./user.xml:/etc/clickhouse-server/users.d/user.xml
-      # qol to mount own sql scripts to run them from inside container with
-      # clickhouse client < /sql/myquery.sql
-      # - ./sql:/sql
-    # adjust mem_limit and cpus to machine
-    # mem_limit: 12G
-    # cpus: 4
-    ulimits:
-      nofile:
-        soft: 262144
-        hard: 262144
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8123/ping"]
-      interval: 1s
-      timeout: 1s
-      retries: 30

--- a/examples/docker-compose/compose.yml
+++ b/examples/docker-compose/compose.yml
@@ -1,7 +1,7 @@
 name: outpost-example
 services:
   api:
-    image: hookdeck/outpost:v0.1.0-alpha.5
+    image: hookdeck/outpost:v0.1.0-alpha.6
     env_file: .env
     depends_on:
       redis:
@@ -14,7 +14,7 @@ services:
       - 3333:3333
 
   delivery:
-    image: hookdeck/outpost:v0.1.0-alpha.5
+    image: hookdeck/outpost:v0.1.0-alpha.6
     env_file: .env
     depends_on:
       redis:
@@ -25,7 +25,7 @@ services:
       SERVICE: delivery
 
   log:
-    image: hookdeck/outpost:v0.1.0-alpha.5
+    image: hookdeck/outpost:v0.1.0-alpha.6
     env_file: .env
     depends_on:
       redis:


### PR DESCRIPTION
Now, to start the example, you must specify the queue AND the log storage.

```
$ docker-compose -f compose.yml -f compose-rabbitmq.yml -f compose-postgres.yml up -d
```

Technically, the ClickHouse example is there too but I've disabled the CH support until the implementation is complete, so you should not be able to run the CH example with the latest alpha release.