### PR TITLE
feat: destrabbitmq supports config.tls

### DIFF
--- a/internal/destregistry/metadata/providers/rabbitmq/metadata.json
+++ b/internal/destregistry/metadata/providers/rabbitmq/metadata.json
@@ -22,6 +22,13 @@
       "label": "Routing Key",
       "description": "The routing key for message routing",
       "required": false
+    },
+    {
+      "key": "tls",
+      "type": "checkbox",
+      "label": "TLS",
+      "description": "Enable TLS for the connection",
+      "default": "on"
     }
   ],
   "credential_fields": [

--- a/internal/destregistry/metadata/types.go
+++ b/internal/destregistry/metadata/types.go
@@ -23,6 +23,7 @@ type FieldSchema struct {
 	Description string  `json:"description"`
 	Key         string  `json:"key"`
 	Required    bool    `json:"required"`
+	Default     *string `json:"default,omitempty"`
 	Disabled    bool    `json:"disabled,omitempty"`
 	Sensitive   bool    `json:"sensitive,omitempty"` // Whether the field value should be obfuscated in API responses
 	Min         *int    `json:"min,omitempty"`       // Minimum value for numeric fields

--- a/internal/destregistry/providers/destrabbitmq/destrabbitmq.go
+++ b/internal/destregistry/providers/destrabbitmq/destrabbitmq.go
@@ -20,6 +20,7 @@ type RabbitMQDestinationConfig struct {
 	ServerURL  string // TODO: consider renaming
 	Exchange   string
 	RoutingKey string
+	UseTLS     bool
 }
 
 type RabbitMQDestinationCredentials struct {
@@ -38,13 +39,24 @@ func New(loader metadata.MetadataLoader) (*RabbitMQDestination, error) {
 }
 
 func (d *RabbitMQDestination) Validate(ctx context.Context, destination *models.Destination) error {
-	config, _, err := d.resolveMetadata(ctx, destination)
-	if err != nil {
+	if err := d.BaseProvider.Validate(ctx, destination); err != nil {
 		return err
 	}
 
+	// Validate TLS config if provided
+	if tlsStr, ok := destination.Config["tls"]; ok {
+		if tlsStr != "checked" && tlsStr != "true" && tlsStr != "false" {
+			return destregistry.NewErrDestinationValidation([]destregistry.ValidationErrorDetail{
+				{
+					Field: "config.tls",
+					Type:  "invalid",
+				},
+			})
+		}
+	}
+
 	// At least one of exchange or routing_key must be non-empty
-	if config.Exchange == "" && config.RoutingKey == "" {
+	if destination.Config["exchange"] == "" && destination.Config["routing_key"] == "" {
 		return destregistry.NewErrDestinationValidation([]destregistry.ValidationErrorDetail{
 			{
 				Field: "config.exchange",
@@ -74,14 +86,20 @@ func (d *RabbitMQDestination) CreatePublisher(ctx context.Context, destination *
 }
 
 func (d *RabbitMQDestination) resolveMetadata(ctx context.Context, destination *models.Destination) (*RabbitMQDestinationConfig, *RabbitMQDestinationCredentials, error) {
-	if err := d.BaseProvider.Validate(ctx, destination); err != nil {
+	if err := d.Validate(ctx, destination); err != nil {
 		return nil, nil, err
+	}
+
+	useTLS := true
+	if tlsStr, ok := destination.Config["tls"]; ok {
+		useTLS = tlsStr != "false" // "checked" or "true" are valid values
 	}
 
 	return &RabbitMQDestinationConfig{
 			ServerURL:  destination.Config["server_url"],
 			Exchange:   destination.Config["exchange"],
 			RoutingKey: destination.Config["routing_key"],
+			UseTLS:     useTLS,
 		}, &RabbitMQDestinationCredentials{
 			Username: destination.Credentials["username"],
 			Password: destination.Credentials["password"],
@@ -202,42 +220,11 @@ func (p *RabbitMQPublisher) ensureConnection(_ context.Context) error {
 }
 
 func rabbitURL(config *RabbitMQDestinationConfig, credentials *RabbitMQDestinationCredentials) string {
-	return "amqp://" + credentials.Username + ":" + credentials.Password + "@" + config.ServerURL
-}
-
-func publishEvent(ctx context.Context, url string, exchange string, event *models.Event) error {
-	dataBytes, err := json.Marshal(event.Data)
-	if err != nil {
-		return err
+	scheme := "amqp"
+	if config.UseTLS {
+		scheme = "amqps"
 	}
-
-	conn, err := amqp091.Dial(url)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	ch, err := conn.Channel()
-	if err != nil {
-		return err
-	}
-	defer ch.Close()
-
-	headers := make(amqp091.Table)
-	for k, v := range event.Metadata {
-		headers[k] = v
-	}
-
-	return ch.PublishWithContext(ctx,
-		exchange, // exchange
-		"",       // routing key
-		false,    // mandatory
-		false,    // immediate
-		amqp091.Publishing{
-			ContentType: "application/json",
-			Headers:     headers,
-			Body:        []byte(dataBytes),
-		},
-	)
+	return fmt.Sprintf("%s://%s:%s@%s", scheme, credentials.Username, credentials.Password, config.ServerURL)
 }
 
 // ===== TEST HELPERS =====

--- a/internal/destregistry/providers/destrabbitmq/destrabbitmq_publish_test.go
+++ b/internal/destregistry/providers/destrabbitmq/destrabbitmq_publish_test.go
@@ -142,6 +142,7 @@ func (s *RabbitMQPublishSuite) SetupSuite() {
 			"server_url":  testutil.ExtractRabbitURL(mqConfig.RabbitMQ.ServerURL),
 			"exchange":    mqConfig.RabbitMQ.Exchange,
 			"routing_key": mqConfig.RabbitMQ.Queue,
+			"tls":         "false",
 		}),
 		testutil.DestinationFactory.WithCredentials(map[string]string{
 			"username": testutil.ExtractRabbitUsername(mqConfig.RabbitMQ.ServerURL),

--- a/internal/destregistry/providers/destrabbitmq/destrabbitmq_publish_test.go
+++ b/internal/destregistry/providers/destrabbitmq/destrabbitmq_publish_test.go
@@ -142,7 +142,7 @@ func (s *RabbitMQPublishSuite) SetupSuite() {
 			"server_url":  testutil.ExtractRabbitURL(mqConfig.RabbitMQ.ServerURL),
 			"exchange":    mqConfig.RabbitMQ.Exchange,
 			"routing_key": mqConfig.RabbitMQ.Queue,
-			"tls":         "false",
+			// "tls":         "false", // should default to false if omitted
 		}),
 		testutil.DestinationFactory.WithCredentials(map[string]string{
 			"username": testutil.ExtractRabbitUsername(mqConfig.RabbitMQ.ServerURL),

--- a/internal/destregistry/providers/destrabbitmq/destrabbitmq_validate_test.go
+++ b/internal/destregistry/providers/destrabbitmq/destrabbitmq_validate_test.go
@@ -1,6 +1,8 @@
 package destrabbitmq_test
 
 import (
+	"context"
+	"maps"
 	"testing"
 
 	"github.com/hookdeck/outpost/internal/destregistry"
@@ -31,14 +33,16 @@ func TestRabbitMQDestination_Validate(t *testing.T) {
 
 	t.Run("should validate valid destination", func(t *testing.T) {
 		t.Parallel()
-		assert.NoError(t, rabbitmqDestination.Validate(nil, &validDestination))
+		assert.NoError(t, rabbitmqDestination.Validate(context.Background(), &validDestination))
 	})
 
 	t.Run("should validate invalid type", func(t *testing.T) {
 		t.Parallel()
-		invalidDestination := validDestination
-		invalidDestination.Type = "invalid"
-		err := rabbitmqDestination.Validate(nil, &invalidDestination)
+		dest := validDestination
+		dest.Config = maps.Clone(validDestination.Config)
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		dest.Type = "invalid"
+		err := rabbitmqDestination.Validate(context.Background(), &dest)
 		var validationErr *destregistry.ErrDestinationValidation
 		assert.ErrorAs(t, err, &validationErr)
 		assert.Equal(t, "type", validationErr.Errors[0].Field)
@@ -47,23 +51,24 @@ func TestRabbitMQDestination_Validate(t *testing.T) {
 
 	t.Run("should validate missing credentials", func(t *testing.T) {
 		t.Parallel()
-		invalidDestination := validDestination
-		invalidDestination.Credentials = map[string]string{}
-		err := rabbitmqDestination.Validate(nil, &invalidDestination)
+		dest := validDestination
+		dest.Config = maps.Clone(validDestination.Config)
+		dest.Credentials = map[string]string{}
+		err := rabbitmqDestination.Validate(context.Background(), &dest)
 		var validationErr *destregistry.ErrDestinationValidation
 		assert.ErrorAs(t, err, &validationErr)
-		// Could be either username or password that's reported first
 		assert.Contains(t, []string{"credentials.username", "credentials.password"}, validationErr.Errors[0].Field)
 		assert.Equal(t, "required", validationErr.Errors[0].Type)
 	})
 
 	t.Run("should validate missing server_url", func(t *testing.T) {
 		t.Parallel()
-		invalidDestination := validDestination
-		invalidDestination.Config = map[string]string{
+		dest := validDestination
+		dest.Config = map[string]string{
 			"exchange": "test-exchange",
 		}
-		err := rabbitmqDestination.Validate(nil, &invalidDestination)
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		err := rabbitmqDestination.Validate(context.Background(), &dest)
 		var validationErr *destregistry.ErrDestinationValidation
 		assert.ErrorAs(t, err, &validationErr)
 		assert.Equal(t, "config.server_url", validationErr.Errors[0].Field)
@@ -72,12 +77,13 @@ func TestRabbitMQDestination_Validate(t *testing.T) {
 
 	t.Run("should validate malformed server_url", func(t *testing.T) {
 		t.Parallel()
-		invalidDestination := validDestination
-		invalidDestination.Config = map[string]string{
+		dest := validDestination
+		dest.Config = map[string]string{
 			"server_url": "not-a-valid-url",
 			"exchange":   "test-exchange",
 		}
-		err := rabbitmqDestination.Validate(nil, &invalidDestination)
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		err := rabbitmqDestination.Validate(context.Background(), &dest)
 		var validationErr *destregistry.ErrDestinationValidation
 		assert.ErrorAs(t, err, &validationErr)
 		assert.Equal(t, "config.server_url", validationErr.Errors[0].Field)
@@ -86,45 +92,49 @@ func TestRabbitMQDestination_Validate(t *testing.T) {
 
 	t.Run("should validate valid destination without exchange", func(t *testing.T) {
 		t.Parallel()
-		validDestWithoutExchange := validDestination
-		validDestWithoutExchange.Config = map[string]string{
+		dest := validDestination
+		dest.Config = map[string]string{
 			"server_url":  "localhost:5672",
 			"routing_key": "test.key",
 		}
-		assert.NoError(t, rabbitmqDestination.Validate(nil, &validDestWithoutExchange))
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		assert.NoError(t, rabbitmqDestination.Validate(context.Background(), &dest))
 	})
 
 	t.Run("should validate empty routing_key as valid", func(t *testing.T) {
 		t.Parallel()
-		validDestWithEmptyRoutingKey := validDestination
-		validDestWithEmptyRoutingKey.Config = map[string]string{
+		dest := validDestination
+		dest.Config = map[string]string{
 			"server_url":  "localhost:5672",
 			"exchange":    "test-exchange",
 			"routing_key": "",
 		}
-		assert.NoError(t, rabbitmqDestination.Validate(nil, &validDestWithEmptyRoutingKey))
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		assert.NoError(t, rabbitmqDestination.Validate(context.Background(), &dest))
 	})
 
 	t.Run("should validate empty exchange as valid", func(t *testing.T) {
 		t.Parallel()
-		validDestWithEmptyExchange := validDestination
-		validDestWithEmptyExchange.Config = map[string]string{
+		dest := validDestination
+		dest.Config = map[string]string{
 			"server_url":  "localhost:5672",
 			"exchange":    "",
 			"routing_key": "test.key",
 		}
-		assert.NoError(t, rabbitmqDestination.Validate(nil, &validDestWithEmptyExchange))
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		assert.NoError(t, rabbitmqDestination.Validate(context.Background(), &dest))
 	})
 
 	t.Run("should validate empty exchange and routing_key as invalid", func(t *testing.T) {
 		t.Parallel()
-		invalidDest := validDestination
-		invalidDest.Config = map[string]string{
+		dest := validDestination
+		dest.Config = map[string]string{
 			"server_url":  "localhost:5672",
 			"exchange":    "",
 			"routing_key": "",
 		}
-		err := rabbitmqDestination.Validate(nil, &invalidDest)
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		err := rabbitmqDestination.Validate(context.Background(), &dest)
 		var validationErr *destregistry.ErrDestinationValidation
 		assert.ErrorAs(t, err, &validationErr)
 		assert.Len(t, validationErr.Errors, 2)
@@ -132,6 +142,72 @@ func TestRabbitMQDestination_Validate(t *testing.T) {
 		assert.Equal(t, "either_required", validationErr.Errors[0].Type)
 		assert.Equal(t, "config.routing_key", validationErr.Errors[1].Field)
 		assert.Equal(t, "either_required", validationErr.Errors[1].Type)
+	})
+
+	t.Run("should validate tls config values", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name        string
+			tlsValue    string
+			shouldError bool
+		}{
+			{
+				name:        "valid true value",
+				tlsValue:    "true",
+				shouldError: false,
+			},
+			{
+				name:        "valid false value",
+				tlsValue:    "false",
+				shouldError: false,
+			},
+			{
+				name:        "invalid value",
+				tlsValue:    "yes",
+				shouldError: true,
+			},
+			{
+				name:        "empty value",
+				tlsValue:    "",
+				shouldError: true,
+			},
+			{
+				name:        "case sensitive True",
+				tlsValue:    "True",
+				shouldError: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				dest := validDestination
+				dest.Config = maps.Clone(validDestination.Config)
+				dest.Credentials = maps.Clone(validDestination.Credentials)
+				dest.Config["tls"] = tc.tlsValue
+				err := rabbitmqDestination.Validate(context.Background(), &dest)
+				if tc.shouldError {
+					var validationErr *destregistry.ErrDestinationValidation
+					if !assert.ErrorAs(t, err, &validationErr) {
+						return
+					}
+					assert.Equal(t, "config.tls", validationErr.Errors[0].Field)
+					assert.Equal(t, "invalid", validationErr.Errors[0].Type)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("should allow tls to be omitted", func(t *testing.T) {
+		t.Parallel()
+		dest := validDestination
+		dest.Config = maps.Clone(validDestination.Config)
+		dest.Credentials = maps.Clone(validDestination.Credentials)
+		delete(dest.Config, "tls")
+		assert.NoError(t, rabbitmqDestination.Validate(context.Background(), &dest))
 	})
 }
 

--- a/internal/destregistry/providers/destrabbitmq/destrabbitmq_validate_test.go
+++ b/internal/destregistry/providers/destrabbitmq/destrabbitmq_validate_test.go
@@ -152,8 +152,13 @@ func TestRabbitMQDestination_Validate(t *testing.T) {
 			shouldError bool
 		}{
 			{
-				name:        "valid true value",
+				name:        "valid true value ('true')",
 				tlsValue:    "true",
+				shouldError: false,
+			},
+			{
+				name:        "valid true value ('on')",
+				tlsValue:    "on",
 				shouldError: false,
 			},
 			{

--- a/internal/portal/src/common/DestinationConfigFields/DestinationConfigFields.tsx
+++ b/internal/portal/src/common/DestinationConfigFields/DestinationConfigFields.tsx
@@ -77,8 +77,8 @@ const DestinationConfigFields = ({
                   "sensitive" in field && field.sensitive
                     ? unlockedFields[field.key]
                       ? ""
-                      : destination?.credentials[field.key] || ""
-                    : destination?.config[field.key] || ""
+                      : destination?.credentials[field.key] || field.default
+                    : destination?.config[field.key] || field.default
                 }
                 disabled={
                   "sensitive" in field && field.sensitive
@@ -111,6 +111,7 @@ const DestinationConfigFields = ({
               defaultChecked={
                 destination?.config[field.key] ??
                 destination?.credentials[field.key] ??
+                field.default == "on" ??
                 false
               }
               disabled={field.disabled}

--- a/internal/portal/src/typings/Destination.ts
+++ b/internal/portal/src/typings/Destination.ts
@@ -4,6 +4,7 @@ interface ConfigField {
   description: string;
   key: string;
   required: boolean;
+  default?: string;
   disabled?: boolean;
   min?: number;
   max?: number;


### PR DESCRIPTION
This PR adds a configuration for the RabbitMQ destination to support TLS connection.

The behavior is it will default to non-TLS if `config.tls` is omitted.

Accepted values for `config.tls`: `"on" | "true" | "false"`