### PR TITLE
fix: Destination config input supports parsing into map string

### DIFF
--- a/internal/models/destination.go
+++ b/internal/models/destination.go
@@ -164,38 +164,27 @@ func TopicsFromString(s string) Topics {
 	return Topics(strings.Split(s, ","))
 }
 
-type Config map[string]string
+type Config = MapStringString
+type Credentials = MapStringString
+type MapStringString map[string]string
 
-var _ encoding.BinaryMarshaler = &Config{}
-var _ encoding.BinaryUnmarshaler = &Config{}
+var _ encoding.BinaryMarshaler = &MapStringString{}
+var _ encoding.BinaryUnmarshaler = &MapStringString{}
+var _ json.Unmarshaler = &MapStringString{}
 
-func (c *Config) MarshalBinary() ([]byte, error) {
-	return json.Marshal(c)
+func (m *MapStringString) MarshalBinary() ([]byte, error) {
+	return json.Marshal(m)
 }
 
-func (c *Config) UnmarshalBinary(data []byte) error {
-	return json.Unmarshal(data, c)
+func (m *MapStringString) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, m)
 }
 
-type Credentials map[string]string
-
-var _ encoding.BinaryMarshaler = &Credentials{}
-var _ encoding.BinaryUnmarshaler = &Credentials{}
-var _ json.Unmarshaler = &Credentials{}
-
-func (c *Credentials) MarshalBinary() ([]byte, error) {
-	return json.Marshal(c)
-}
-
-func (c *Credentials) UnmarshalBinary(data []byte) error {
-	return json.Unmarshal(data, c)
-}
-
-func (c *Credentials) UnmarshalJSON(data []byte) error {
+func (m *MapStringString) UnmarshalJSON(data []byte) error {
 	// First try to unmarshal as map[string]string
 	var stringMap map[string]string
 	if err := json.Unmarshal(data, &stringMap); err == nil {
-		*c = stringMap
+		*m = stringMap
 		return nil
 	}
 
@@ -227,6 +216,6 @@ func (c *Credentials) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	*c = result
+	*m = result
 	return nil
 }

--- a/internal/services/api/destination_handlers.go
+++ b/internal/services/api/destination_handlers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"errors"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -73,7 +72,6 @@ func (h *DestinationHandlers) List(c *gin.Context) {
 func (h *DestinationHandlers) Create(c *gin.Context) {
 	var input CreateDestinationRequest
 	if err := c.ShouldBindJSON(&input); err != nil {
-		log.Println(err)
 		AbortWithValidationError(c, err)
 		return
 	}

--- a/internal/services/api/destination_handlers.go
+++ b/internal/services/api/destination_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -72,6 +73,7 @@ func (h *DestinationHandlers) List(c *gin.Context) {
 func (h *DestinationHandlers) Create(c *gin.Context) {
 	var input CreateDestinationRequest
 	if err := c.ShouldBindJSON(&input); err != nil {
+		log.Println(err)
 		AbortWithValidationError(c, err)
 		return
 	}
@@ -313,7 +315,7 @@ type CreateDestinationRequest struct {
 	ID          string             `json:"id" binding:"-"`
 	Type        string             `json:"type" binding:"required"`
 	Topics      models.Topics      `json:"topics" binding:"required"`
-	Config      map[string]string  `json:"config" binding:"required"`
+	Config      models.Config      `json:"config" binding:"required"`
 	Credentials models.Credentials `json:"credentials" binding:"-"`
 }
 
@@ -340,7 +342,7 @@ func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destina
 type UpdateDestinationRequest struct {
 	Type        string             `json:"type" binding:"-"`
 	Topics      models.Topics      `json:"topics" binding:"-"`
-	Config      map[string]string  `json:"config" binding:"-"`
+	Config      models.Config      `json:"config" binding:"-"`
 	Credentials models.Credentials `json:"credentials" binding:"-"`
 }
 


### PR DESCRIPTION
Destination `config` and `credentials` are both a string map. To support boolean better, we should automatically parse `true -> "true"`. This was already supported for credentials but not for config yet. This PR is to support both.

Example:

Before:

```
POST /:tenantID/destinations
{
  ...
  "config": {
    "bool": true,
    "obj" : { "hello": "world" }
  }
}

400 error
{
  "message": "invalid JSON"
}
```

With this PR, the destination above will be parsed into

```
{
  ...
  "config": {
    "bool": "true",
    "obj" : "{\"hello\":\"world\"}"
  }
}
```