### PR TITLE
feat: Support custom user-agent for HTTP-based destinations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,8 @@ type Config struct {
 	// Application
 	AESEncryptionSecret string   `yaml:"aes_encryption_secret" env:"AES_ENCRYPTION_SECRET"`
 	Topics              []string `yaml:"topics" env:"TOPICS" envSeparator:","`
+	OrganizationName    string   `yaml:"organization_name" env:"ORGANIZATION_NAME"`
+	HTTPUserAgent       string   `yaml:"http_user_agent" env:"HTTP_USER_AGENT"`
 
 	// Infrastructure
 	Redis       RedisConfig      `yaml:"redis"`
@@ -148,8 +150,7 @@ func (c *Config) InitDefaults() {
 
 	// Set defaults for Destinations config
 	c.Destinations = DestinationsConfig{
-		MetadataPath:     "config/outpost/destinations",
-		UserAgentProduct: "Outpost",
+		MetadataPath: "config/outpost/destinations",
 		Webhook: DestinationWebhookConfig{
 			HeaderPrefix: "x-outpost-",
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,7 +148,8 @@ func (c *Config) InitDefaults() {
 
 	// Set defaults for Destinations config
 	c.Destinations = DestinationsConfig{
-		MetadataPath: "config/outpost/destinations",
+		MetadataPath:     "config/outpost/destinations",
+		UserAgentProduct: "Outpost",
 		Webhook: DestinationWebhookConfig{
 			HeaderPrefix: "x-outpost-",
 		},

--- a/internal/config/destinations.go
+++ b/internal/config/destinations.go
@@ -9,15 +9,23 @@ import (
 
 // DestinationsConfig is the main configuration for all destination types
 type DestinationsConfig struct {
-	MetadataPath     string                      `yaml:"metadata_path" env:"DESTINATIONS_METADATA_PATH"`
-	UserAgentProduct string                      `yaml:"user_agent_product" env:"DESTINATIONS_USER_AGENT_PRODUCT"`
-	Webhook          DestinationWebhookConfig    `yaml:"webhook"`
-	AWSKinesis       DestinationAWSKinesisConfig `yaml:"aws_kinesis"`
+	MetadataPath string                      `yaml:"metadata_path" env:"DESTINATIONS_METADATA_PATH"`
+	Webhook      DestinationWebhookConfig    `yaml:"webhook"`
+	AWSKinesis   DestinationAWSKinesisConfig `yaml:"aws_kinesis"`
 }
 
-func (c *DestinationsConfig) ToConfig() destregistrydefault.RegisterDefaultDestinationOptions {
+func (c *DestinationsConfig) ToConfig(cfg *Config) destregistrydefault.RegisterDefaultDestinationOptions {
+	userAgent := cfg.HTTPUserAgent
+	if userAgent == "" {
+		if cfg.OrganizationName == "" {
+			userAgent = fmt.Sprintf("Outpost/%s", version.Version())
+		} else {
+			userAgent = fmt.Sprintf("%s/%s", cfg.OrganizationName, version.Version())
+		}
+	}
+
 	return destregistrydefault.RegisterDefaultDestinationOptions{
-		UserAgent:  fmt.Sprintf("%s/%s", c.UserAgentProduct, version.Version()),
+		UserAgent:  userAgent,
 		Webhook:    c.Webhook.toConfig(),
 		AWSKinesis: c.AWSKinesis.toConfig(),
 	}

--- a/internal/config/destinations.go
+++ b/internal/config/destinations.go
@@ -1,18 +1,23 @@
 package config
 
 import (
+	"fmt"
+
 	destregistrydefault "github.com/hookdeck/outpost/internal/destregistry/providers"
+	"github.com/hookdeck/outpost/internal/version"
 )
 
 // DestinationsConfig is the main configuration for all destination types
 type DestinationsConfig struct {
-	MetadataPath string                      `yaml:"metadata_path" env:"DESTINATIONS_METADATA_PATH"`
-	Webhook      DestinationWebhookConfig    `yaml:"webhook"`
-	AWSKinesis   DestinationAWSKinesisConfig `yaml:"aws_kinesis"`
+	MetadataPath     string                      `yaml:"metadata_path" env:"DESTINATIONS_METADATA_PATH"`
+	UserAgentProduct string                      `yaml:"user_agent_product" env:"DESTINATIONS_USER_AGENT_PRODUCT"`
+	Webhook          DestinationWebhookConfig    `yaml:"webhook"`
+	AWSKinesis       DestinationAWSKinesisConfig `yaml:"aws_kinesis"`
 }
 
 func (c *DestinationsConfig) ToConfig() destregistrydefault.RegisterDefaultDestinationOptions {
 	return destregistrydefault.RegisterDefaultDestinationOptions{
+		UserAgent:  fmt.Sprintf("%s/%s", c.UserAgentProduct, version.Version()),
 		Webhook:    c.Webhook.toConfig(),
 		AWSKinesis: c.AWSKinesis.toConfig(),
 	}

--- a/internal/destregistry/providers/default.go
+++ b/internal/destregistry/providers/default.go
@@ -26,6 +26,7 @@ type DestAWSKinesisConfig struct {
 }
 
 type RegisterDefaultDestinationOptions struct {
+	UserAgent  string
 	Webhook    *DestWebhookConfig
 	AWSKinesis *DestAWSKinesisConfig
 }
@@ -36,9 +37,11 @@ type RegisterDefaultDestinationOptions struct {
 func RegisterDefault(registry destregistry.Registry, opts RegisterDefaultDestinationOptions) error {
 	loader := registry.MetadataLoader()
 
-	webhookOpts := []destwebhook.Option{}
+	webhookOpts := []destwebhook.Option{
+		destwebhook.WithUserAgent(opts.UserAgent),
+	}
 	if opts.Webhook != nil {
-		webhookOpts = []destwebhook.Option{
+		webhookOpts = append(webhookOpts,
 			destwebhook.WithHeaderPrefix(opts.Webhook.HeaderPrefix),
 			destwebhook.WithDisableDefaultEventIDHeader(opts.Webhook.DisableDefaultEventIDHeader),
 			destwebhook.WithDisableDefaultSignatureHeader(opts.Webhook.DisableDefaultSignatureHeader),
@@ -48,7 +51,7 @@ func RegisterDefault(registry destregistry.Registry, opts RegisterDefaultDestina
 			destwebhook.WithSignatureHeaderTemplate(opts.Webhook.SignatureHeaderTemplate),
 			destwebhook.WithSignatureEncoding(opts.Webhook.SignatureEncoding),
 			destwebhook.WithSignatureAlgorithm(opts.Webhook.SignatureAlgorithm),
-		}
+		)
 	}
 	webhook, err := destwebhook.New(loader, webhookOpts...)
 	if err != nil {
@@ -56,7 +59,8 @@ func RegisterDefault(registry destregistry.Registry, opts RegisterDefaultDestina
 	}
 	registry.RegisterProvider("webhook", webhook)
 
-	hookdeck, err := desthookdeck.New(loader)
+	hookdeck, err := desthookdeck.New(loader,
+		desthookdeck.WithUserAgent(opts.UserAgent))
 	if err != nil {
 		return err
 	}

--- a/internal/destregistry/registry.go
+++ b/internal/destregistry/registry.go
@@ -104,7 +104,7 @@ func NewRegistry(cfg *Config, logger *logging.Logger) Registry {
 		}
 	}
 
-	cache := lru.New[string, Publisher](cfg.PublisherCacheSize, cfg.PublisherTTL, onEvict)
+	cache := lru.New(cfg.PublisherCacheSize, cfg.PublisherTTL, onEvict)
 
 	return &registry{
 		metadataLoader: metadata.NewMetadataLoader(cfg.DestinationMetadataPath),

--- a/internal/services/api/api.go
+++ b/internal/services/api/api.go
@@ -52,7 +52,7 @@ func NewService(ctx context.Context, wg *sync.WaitGroup, cfg *config.Config, log
 		DestinationMetadataPath: cfg.Destinations.MetadataPath,
 		DeliveryTimeout:         time.Duration(cfg.DeliveryTimeoutSeconds) * time.Second,
 	}, logger)
-	if err := destregistrydefault.RegisterDefault(registry, cfg.Destinations.ToConfig()); err != nil {
+	if err := destregistrydefault.RegisterDefault(registry, cfg.Destinations.ToConfig(cfg)); err != nil {
 		return nil, err
 	}
 

--- a/internal/services/delivery/delivery.go
+++ b/internal/services/delivery/delivery.go
@@ -64,7 +64,7 @@ func NewService(ctx context.Context,
 			DestinationMetadataPath: cfg.Destinations.MetadataPath,
 			DeliveryTimeout:         time.Duration(cfg.DeliveryTimeoutSeconds) * time.Second,
 		}, logger)
-		if err := destregistrydefault.RegisterDefault(registry, cfg.Destinations.ToConfig()); err != nil {
+		if err := destregistrydefault.RegisterDefault(registry, cfg.Destinations.ToConfig(cfg)); err != nil {
 			return nil, err
 		}
 		var eventTracer eventtracer.EventTracer


### PR DESCRIPTION
resolves #262 

The PR allows users to configure their user-agent headers for HTTP-based destinations.

The user agent template is `PRODUCT/VERSION`. Version is the Outpost service version. The PRODUCT is configurable, default to `Outpost`. The user can either use env `DESTINATIONS_USER_AGENT_PRODUCT=Acme` or the YAML config

```
destinations:
  user_agent_product: "Acme"
```

The thought process behind "user_agent_product" is that it's the [product](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent) part of the user agent, using terminology from the web platform (MDN). The prefix `destinations` is consistent with destinations-related configuration.