### PR TITLE
fix(api): publish response to 202. Tenant response can be 200 or 201

### DIFF
--- a/cmd/e2e/alert_test.go
+++ b/cmd/e2e/alert_test.go
@@ -101,7 +101,7 @@ func (suite *basicSuite) TestConsecutiveFailuresAlert() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		})
@@ -226,7 +226,7 @@ func (suite *basicSuite) TestConsecutiveFailuresAlertReset() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		})
@@ -254,7 +254,7 @@ func (suite *basicSuite) TestConsecutiveFailuresAlertReset() {
 		}),
 		Expected: APITestExpectation{
 			Match: &httpclient.Response{
-				StatusCode: http.StatusOK,
+				StatusCode: http.StatusAccepted,
 			},
 		},
 	})
@@ -281,7 +281,7 @@ func (suite *basicSuite) TestConsecutiveFailuresAlertReset() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		})

--- a/cmd/e2e/destwebhook_test.go
+++ b/cmd/e2e/destwebhook_test.go
@@ -103,7 +103,7 @@ func (suite *basicSuite) TestDestwebhookPublish() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		},
@@ -187,7 +187,7 @@ func (suite *basicSuite) TestDestwebhookPublish() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		},
@@ -270,7 +270,7 @@ func (suite *basicSuite) TestDestwebhookPublish() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		},
@@ -352,7 +352,7 @@ func (suite *basicSuite) TestDestwebhookPublish() {
 			}),
 			Expected: APITestExpectation{
 				Match: &httpclient.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 				},
 			},
 		},

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -709,7 +709,6 @@ components:
     PublishRequest:
       type: object
       required:
-        - topic
         - data
       properties:
         id:
@@ -1410,6 +1409,8 @@ paths:
           description: Unauthorized (Admin API Key missing or invalid).
         "409":
           description: Conflict. An event with the provided `id` already exists.
+        "422":
+          description: Unprocessable Entity. The event topic was either required or was invalid.
         # Add other error responses
 
   # Schemas (Tenant Specific - Admin or JWT)

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -725,7 +725,7 @@ components:
           example: "<DESTINATION_ID>"
         topic:
           type: string
-          description: Topic name for the event.
+          description: Topic name for the event. Required if Outpost has been configured with topics.
           example: "topic.name"
         eligible_for_retry:
           type: boolean

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -709,9 +709,7 @@ components:
     PublishRequest:
       type: object
       required:
-        - tenant_id
         - topic
-        - eligible_for_retry
         - data
       properties:
         id:

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -714,6 +714,10 @@ components:
         - eligible_for_retry
         - data
       properties:
+        id:
+          type: string
+          description: Optional. A unique identifier for the event. If not provided, a UUID will be generated.
+          example: "evt_custom_123"
         tenant_id:
           type: string
           description: The ID of the tenant to publish for.
@@ -1406,6 +1410,8 @@ paths:
           description: Invalid request body.
         "401":
           description: Unauthorized (Admin API Key missing or invalid).
+        "409":
+          description: Conflict. An event with the provided `id` already exists.
         # Add other error responses
 
   # Schemas (Tenant Specific - Admin or JWT)

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -951,7 +951,20 @@ paths:
       operationId: upsertTenant
       responses:
         "200":
-          description: Tenant details.
+          description: Tenant updated details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tenant"
+              examples:
+                TenantExample:
+                  value:
+                    id: "tenant_123"
+                    destinations_count: 5
+                    topics: ["user.created", "user.deleted"]
+                    created_at: "2024-01-01T00:00:00Z"
+        "201":
+          description: Tenant created details.
           content:
             application/json:
               schema:
@@ -1387,7 +1400,7 @@ paths:
             schema:
               $ref: "#/components/schemas/PublishRequest"
       responses:
-        "202": # Accepted seems appropriate as processing is likely async
+        "202":
           description: Event accepted for publishing. Empty body.
         "400":
           description: Invalid request body.

--- a/internal/services/api/publish_handlers.go
+++ b/internal/services/api/publish_handlers.go
@@ -61,7 +61,7 @@ func (h *PublishHandlers) Ingest(c *gin.Context) {
 		}
 		return
 	}
-	c.Status(http.StatusAccepted)
+	c.JSON(http.StatusAccepted, gin.H{"id": event.ID})
 }
 
 type PublishedEvent struct {

--- a/internal/services/api/publish_handlers.go
+++ b/internal/services/api/publish_handlers.go
@@ -61,7 +61,7 @@ func (h *PublishHandlers) Ingest(c *gin.Context) {
 		}
 		return
 	}
-	c.Status(http.StatusOK)
+	c.Status(http.StatusAccepted)
 }
 
 type PublishedEvent struct {

--- a/internal/services/api/publish_handlers_test.go
+++ b/internal/services/api/publish_handlers_test.go
@@ -39,6 +39,6 @@ func TestPublishHandlers(t *testing.T) {
 		var response map[string]any
 		json.Unmarshal(w.Body.Bytes(), &response)
 
-		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, http.StatusAccepted, w.Code)
 	})
 }


### PR DESCRIPTION
The `202` response from the `/publish` endpoint seems appropriate because it's an async ingestion and no body contents is provided.

@alexbouchardd - let me know what you think?
@alexluong - will this change impact any of the integration tests?