### PR TITLE
chore: Include event data & metadata in alert payload

### DIFF
--- a/internal/alert/monitor.go
+++ b/internal/alert/monitor.go
@@ -147,6 +147,11 @@ func (m *alertMonitor) HandleAttempt(ctx context.Context, attempt DeliveryAttemp
 	}
 
 	alert := NewConsecutiveFailureAlert(ConsecutiveFailureData{
+		Event: AlertedEvent{
+			Topic:    attempt.DeliveryEvent.Event.Topic,
+			Metadata: attempt.DeliveryEvent.Event.Metadata,
+			Data:     attempt.DeliveryEvent.Event.Data,
+		},
 		MaxConsecutiveFailures: m.autoDisableFailureCount,
 		ConsecutiveFailures:    count,
 		WillDisable:            m.disabler != nil && level == 100,

--- a/internal/alert/notifier.go
+++ b/internal/alert/notifier.go
@@ -42,13 +42,20 @@ func NotifierWithBearerToken(token string) NotifierOption {
 	}
 }
 
+type AlertedEvent struct {
+	Topic    string                 `json:"topic"`    // event topic
+	Metadata map[string]string      `json:"metadata"` // event metadata
+	Data     map[string]interface{} `json:"data"`     // event payload
+}
+
 // ConsecutiveFailureData represents the data needed for a consecutive failure alert
 type ConsecutiveFailureData struct {
+	Event                  AlertedEvent           `json:"event"`
 	MaxConsecutiveFailures int                    `json:"max_consecutive_failures"`
 	ConsecutiveFailures    int                    `json:"consecutive_failures"`
 	WillDisable            bool                   `json:"will_disable"`
 	Destination            *models.Destination    `json:"destination"`
-	Data                   map[string]interface{} `json:"data"`
+	Data                   map[string]interface{} `json:"data"` // alert data, i.e. error message, etc.
 }
 
 // ConsecutiveFailureAlert represents an alert for consecutive failures


### PR DESCRIPTION
resolves #403 

This PR includes an `event` object within the alert payload with some content from the event triggering the alert.

```json
{
  "topic": "alert.consecutive-failure",
  "timestamp": "2025-05-29T05:07:09.269672003Z",
  "data": {
    "event": {
      "topic": "user.created",
      "metadata": {} // ...
      "data": {} // ...
    },
    "max_consecutive_failures": 3,
    "consecutive_failures": 3,
    "will_disable": false,
    "destination": {}, // ...
    "data": {
      "body": "{\"success\":false,\"verified\":false,\"payload\":{\"user_id\":\"userid\"}}",
      "status": 400
    }
  }
}
```

Since this is an addition to the payload, I'd consider this a non-breaking change. With that said, we can also add an opt-in configuration for this (`alert.include_event`) to maintain existing behavior. I do think this is probably safe so maybe we don't need that step, but do let me know if you think it would be helpful!