### PR TITLE
chore: destawssqs target_url

### DIFF
--- a/internal/destregistry/providers/destawssqs/destawssqs.go
+++ b/internal/destregistry/providers/destawssqs/destawssqs.go
@@ -208,6 +208,6 @@ func ParseQueueURL(queueURL string) (baseURL string, region string, err error) {
 func (d *AWSSQSDestination) ComputeTarget(destination *models.Destination) destregistry.DestinationTarget {
 	return destregistry.DestinationTarget{
 		Target:    destination.Config["queue_url"],
-		TargetURL: "",
+		TargetURL: destination.Config["queue_url"],
 	}
 }


### PR DESCRIPTION
This PR supports destawssqs to use the target_url field which enable the dashboard to use the `a` tag for the queue target.

![CleanShot 2025-05-29 at 12 27 40@2x](https://github.com/user-attachments/assets/714686fe-aef9-4d98-ac35-208512d3874a)

One difference between the Hookdeck destination which also uses the target_url mechanism is that the Hookdeck target_url is a link to the Hookdeck dashboard, whereas AWS SQS target_url is just the queue URL which is not something you want to visit from the browser. Because of that, I'm not 100% sure if this is necessary. Since it's a small change, I figured I'd create a PR and we can evaluate / discuss this here.

cc @alexbouchardd @leggetter 