### PR TITLE
fix(build): include CA certificates in Docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,4 +10,5 @@ RUN go build -o ./bin/outpost ./cmd/outpost/main.go
 # Copy binary to a new image
 FROM scratch
 COPY --from=0 /app/bin/outpost /bin/outpost
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/bin/outpost"]


### PR DESCRIPTION
Ensure the image contains trusted CA certificates so the app can establish secure HTTPS connections to AWS services. Without them, TLS handshakes fail with **x509: certificate signed by unknown authority**:

`failed to check if infra exists: operation error SQS: GetQueueUrl, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , request send failed, Post "https://sqs.eu-west-1.amazonaws.com/": tls: failed to verify certificate: x509: certificate signed by unknown authority`