### PR TITLE
fix: delivery timestamp metadata in unix seconds

### DIFF
--- a/internal/destregistry/basepublisher.go
+++ b/internal/destregistry/basepublisher.go
@@ -37,7 +37,7 @@ func (p *BasePublisher) StartClose() {
 
 func (p *BasePublisher) MakeMetadata(event *models.Event, timestamp time.Time) map[string]string {
 	systemMetadata := map[string]string{
-		"timestamp": fmt.Sprintf("%d", timestamp.UnixMilli()),
+		"timestamp": fmt.Sprintf("%d", timestamp.Unix()),
 		"event-id":  event.ID,
 		"topic":     event.Topic,
 	}

--- a/internal/destregistry/providers/destawskinesis/destawskinesis_publish_test.go
+++ b/internal/destregistry/providers/destawskinesis/destawskinesis_publish_test.go
@@ -204,6 +204,7 @@ func (a *KinesisAsserter) AssertMessage(t testsuite.TestingT, msg testsuite.Mess
 
 	// Verify system metadata
 	assert.NotEmpty(t, metadata["timestamp"], "timestamp should be present")
+	testsuite.AssertTimestampIsUnixSeconds(t, metadata["timestamp"])
 	assert.Equal(t, event.ID, metadata["event-id"], "event-id should match")
 	assert.Equal(t, event.Topic, metadata["topic"], "topic should match")
 

--- a/internal/destregistry/providers/destawss3/destawss3_publish_test.go
+++ b/internal/destregistry/providers/destawss3/destawss3_publish_test.go
@@ -140,6 +140,7 @@ func (a *S3Asserter) AssertMessage(t testsuite.TestingT, msg testsuite.Message, 
 	// 2. Assert system metadata is present
 	metadata := msg.Metadata
 	assert.NotEmpty(t, metadata["timestamp"], "timestamp should be present")
+	testsuite.AssertTimestampIsUnixSeconds(t, metadata["timestamp"])
 	assert.Equal(t, event.ID, metadata["event-id"], "event-id should match")
 	assert.Equal(t, event.Topic, metadata["topic"], "topic should match")
 

--- a/internal/destregistry/providers/destawssqs/destawssqs_publish_test.go
+++ b/internal/destregistry/providers/destawssqs/destawssqs_publish_test.go
@@ -94,6 +94,7 @@ func (a *SQSAsserter) AssertMessage(t testsuite.TestingT, msg testsuite.Message,
 
 	// Verify system metadata
 	assert.NotEmpty(t, metadata["timestamp"], "timestamp should be present")
+	testsuite.AssertTimestampIsUnixSeconds(t, metadata["timestamp"])
 	assert.Equal(t, event.ID, metadata["event-id"], "event-id should match")
 	assert.Equal(t, event.Topic, metadata["topic"], "topic should match")
 

--- a/internal/destregistry/providers/destazureservicebus/destazureservicebus_publish_test.go
+++ b/internal/destregistry/providers/destazureservicebus/destazureservicebus_publish_test.go
@@ -119,6 +119,7 @@ func (a *AzureServiceBusAsserter) AssertMessage(t testsuite.TestingT, msg testsu
 
 	// Verify system metadata
 	assert.NotEmpty(t, metadata["timestamp"], "timestamp should be present")
+	testsuite.AssertTimestampIsUnixSeconds(t, metadata["timestamp"])
 	assert.Equal(t, event.ID, metadata["event-id"], "event-id should match")
 	assert.Equal(t, event.Topic, metadata["topic"], "topic should match")
 

--- a/internal/destregistry/providers/destrabbitmq/destrabbitmq_publish_test.go
+++ b/internal/destregistry/providers/destrabbitmq/destrabbitmq_publish_test.go
@@ -147,6 +147,7 @@ func (a *RabbitMQAsserter) AssertMessage(t testsuite.TestingT, msg testsuite.Mes
 	// Verify system metadata
 	metadata := msg.Metadata
 	assert.NotEmpty(t, metadata["timestamp"], "timestamp should be present")
+	testsuite.AssertTimestampIsUnixSeconds(t, metadata["timestamp"])
 	assert.Equal(t, event.ID, metadata["event-id"], "event-id should match")
 	assert.Equal(t, event.Topic, metadata["topic"], "topic should match")
 

--- a/internal/destregistry/providers/destwebhook/destwebhook.go
+++ b/internal/destregistry/providers/destwebhook/destwebhook.go
@@ -559,7 +559,7 @@ func (p *WebhookPublisher) Format(ctx context.Context, event *models.Event) (*ht
 
 	// Add default headers unless disabled
 	if !p.disableTimestampHeader {
-		req.Header.Set(p.headerPrefix+"timestamp", fmt.Sprintf("%d", now.UnixMilli()))
+		req.Header.Set(p.headerPrefix+"timestamp", fmt.Sprintf("%d", now.Unix()))
 	}
 	if !p.disableEventIDHeader {
 		req.Header.Set(p.headerPrefix+"event-id", event.ID)


### PR DESCRIPTION
resolves #412

**Breaking Change**: This PR fixes a timestamp format inconsistency where X-Outpost-Timestamp header and metadata timestamps were using Unix milliseconds while signatures used Unix seconds. All timestamps now consistently use Unix seconds to align with the signature format. Applications parsing these timestamps will need to update their logic to expect seconds instead of milliseconds.

We need to make sure this breaking change is communicated in the upcoming release.