### PR TITLE
chore: improve log lines metadata

### DIFF
--- a/internal/alert/monitor.go
+++ b/internal/alert/monitor.go
@@ -175,9 +175,10 @@ func (m *alertMonitor) HandleAttempt(ctx context.Context, attempt DeliveryAttemp
 		}
 
 		m.logger.Ctx(ctx).Audit("destination disabled",
-			zap.String("destination_id", attempt.Destination.ID),
+			zap.String("event_id", attempt.DeliveryEvent.Event.ID),
 			zap.String("tenant_id", attempt.Destination.TenantID),
-			zap.String("topic", alert.Topic),
+			zap.String("destination_id", attempt.Destination.ID),
+			zap.String("destination_type", attempt.Destination.Type),
 		)
 	}
 
@@ -185,18 +186,20 @@ func (m *alertMonitor) HandleAttempt(ctx context.Context, attempt DeliveryAttemp
 	if m.notifier != nil {
 		if err := m.notifier.Notify(ctx, alert); err != nil {
 			m.logger.Ctx(ctx).Error("failed to send alert",
-				zap.String("destination_id", attempt.Destination.ID),
-				zap.String("tenant_id", attempt.Destination.TenantID),
-				zap.String("topic", alert.Topic),
 				zap.Error(err),
+				zap.String("event_id", attempt.DeliveryEvent.Event.ID),
+				zap.String("tenant_id", attempt.Destination.TenantID),
+				zap.String("destination_id", attempt.Destination.ID),
+				zap.String("destination_type", attempt.Destination.Type),
 			)
 			return fmt.Errorf("failed to send alert: %w", err)
 		}
 
 		m.logger.Ctx(ctx).Audit("alert sent",
-			zap.String("destination_id", attempt.Destination.ID),
+			zap.String("event_id", attempt.DeliveryEvent.Event.ID),
 			zap.String("tenant_id", attempt.Destination.TenantID),
-			zap.String("topic", alert.Topic),
+			zap.String("destination_id", attempt.Destination.ID),
+			zap.String("destination_type", attempt.Destination.Type),
 		)
 	}
 

--- a/internal/apirouter/retry_handlers.go
+++ b/internal/apirouter/retry_handlers.go
@@ -72,7 +72,9 @@ func (h *RetryHandlers) Retry(c *gin.Context) {
 
 	h.logger.Ctx(c).Audit("manual retry initiated",
 		zap.String("event_id", event.ID),
-		zap.String("destination_id", destination.ID))
+		zap.String("tenant_id", tenantID),
+		zap.String("destination_id", destination.ID),
+		zap.String("destination_type", destination.Type))
 
 	c.JSON(http.StatusAccepted, gin.H{
 		"success": true,

--- a/internal/deliverymq/messagehandler.go
+++ b/internal/deliverymq/messagehandler.go
@@ -144,8 +144,9 @@ func (h *messageHandler) Handle(ctx context.Context, msg *mqs.Message) error {
 	}
 
 	h.logger.Ctx(ctx).Info("processing delivery event",
-		zap.String("delivery_event_id", deliveryEvent.ID),
 		zap.String("event_id", deliveryEvent.Event.ID),
+		zap.String("tenant_id", deliveryEvent.Event.TenantID),
+		zap.String("destination_id", deliveryEvent.DestinationID),
 		zap.Int("attempt", deliveryEvent.Attempt))
 
 	// Ensure event data
@@ -198,8 +199,10 @@ func (h *messageHandler) doHandle(ctx context.Context, deliveryEvent models.Deli
 
 		h.logger.Ctx(ctx).Error("failed to publish event",
 			zap.Error(err),
-			zap.String("delivery_event_id", deliveryEvent.ID),
-			zap.String("destination_id", destination.ID))
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
+			zap.String("destination_id", destination.ID),
+			zap.String("destination_type", destination.Type))
 		deliveryErr := &DeliveryError{err: err}
 
 		if h.shouldScheduleRetry(deliveryEvent, err) {
@@ -216,12 +219,18 @@ func (h *messageHandler) doHandle(ctx context.Context, deliveryEvent models.Deli
 		if err := h.retryScheduler.Cancel(ctx, deliveryEvent.GetRetryID()); err != nil {
 			h.logger.Ctx(ctx).Error("failed to cancel scheduled retry",
 				zap.Error(err),
-				zap.String("delivery_event_id", deliveryEvent.ID),
+				zap.String("event_id", deliveryEvent.Event.ID),
+				zap.String("tenant_id", deliveryEvent.Event.TenantID),
+				zap.String("destination_id", destination.ID),
+				zap.String("destination_type", destination.Type),
 				zap.String("retry_id", deliveryEvent.GetRetryID()))
 			return h.logDeliveryResult(ctx, &deliveryEvent, destination, delivery, err)
 		}
 		logger.Audit("scheduled retry canceled",
-			zap.String("delivery_event_id", deliveryEvent.ID),
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
+			zap.String("destination_id", destination.ID),
+			zap.String("destination_type", destination.Type),
 			zap.String("retry_id", deliveryEvent.GetRetryID()))
 	}
 	return h.logDeliveryResult(ctx, &deliveryEvent, destination, delivery, nil)
@@ -234,19 +243,22 @@ func (h *messageHandler) logDeliveryResult(ctx context.Context, deliveryEvent *m
 	deliveryEvent.Delivery = delivery
 
 	logger.Audit("event delivered",
-		zap.String("delivery_event_id", deliveryEvent.ID),
-		zap.String("destination_id", deliveryEvent.DestinationID),
 		zap.String("event_id", deliveryEvent.Event.ID),
+		zap.String("tenant_id", deliveryEvent.Event.TenantID),
+		zap.String("destination_id", destination.ID),
+		zap.String("destination_type", destination.Type),
 		zap.String("delivery_status", deliveryEvent.Delivery.Status),
 		zap.Int("attempt", deliveryEvent.Attempt),
-		zap.Bool("manual", deliveryEvent.Manual),
-		zap.String("destination_type", destination.Type))
+		zap.Bool("manual", deliveryEvent.Manual))
 
 	// Publish delivery log
 	if logErr := h.logMQ.Publish(ctx, *deliveryEvent); logErr != nil {
 		logger.Error("failed to publish delivery log",
 			zap.Error(logErr),
-			zap.String("delivery_event_id", deliveryEvent.ID))
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
+			zap.String("destination_id", destination.ID),
+			zap.String("destination_type", destination.Type))
 		if err != nil {
 			return &PostDeliveryError{err: errors.Join(err, logErr)}
 		}
@@ -315,14 +327,18 @@ func (h *messageHandler) handleAlertAttempt(ctx context.Context, deliveryEvent *
 	if monitorErr := h.alertMonitor.HandleAttempt(ctx, attempt); monitorErr != nil {
 		h.logger.Ctx(ctx).Error("failed to handle alert attempt",
 			zap.Error(monitorErr),
-			zap.String("delivery_event_id", deliveryEvent.ID),
-			zap.String("destination_id", destination.ID))
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", destination.TenantID),
+			zap.String("destination_id", destination.ID),
+			zap.String("destination_type", destination.Type))
 		return
 	}
 
 	h.logger.Ctx(ctx).Info("alert attempt handled",
-		zap.String("delivery_event_id", deliveryEvent.ID),
-		zap.String("destination_id", destination.ID))
+		zap.String("event_id", deliveryEvent.Event.ID),
+		zap.String("tenant_id", destination.TenantID),
+		zap.String("destination_id", destination.ID),
+		zap.String("destination_type", destination.Type))
 }
 
 func (h *messageHandler) shouldScheduleRetry(deliveryEvent models.DeliveryEvent, err error) bool {
@@ -395,14 +411,18 @@ func (h *messageHandler) scheduleRetry(ctx context.Context, deliveryEvent models
 	if err := h.retryScheduler.Schedule(ctx, retryMessageStr, backoffDuration, scheduler.WithTaskID(deliveryEvent.GetRetryID())); err != nil {
 		h.logger.Ctx(ctx).Error("failed to schedule retry",
 			zap.Error(err),
-			zap.String("delivery_event_id", deliveryEvent.ID),
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
+			zap.String("destination_id", deliveryEvent.DestinationID),
 			zap.Int("attempt", deliveryEvent.Attempt),
 			zap.Duration("backoff", backoffDuration))
 		return err
 	}
 
 	h.logger.Ctx(ctx).Audit("retry scheduled",
-		zap.String("delivery_event_id", deliveryEvent.ID),
+		zap.String("event_id", deliveryEvent.Event.ID),
+		zap.String("tenant_id", deliveryEvent.Event.TenantID),
+		zap.String("destination_id", deliveryEvent.DestinationID),
 		zap.Int("attempt", deliveryEvent.Attempt),
 		zap.Duration("backoff", backoffDuration))
 
@@ -438,8 +458,9 @@ func (h *messageHandler) ensurePublishableDestination(ctx context.Context, deliv
 		logger := h.logger.Ctx(ctx)
 		fields := []zap.Field{
 			zap.Error(err),
-			zap.String("destination_id", deliveryEvent.DestinationID),
+			zap.String("event_id", deliveryEvent.Event.ID),
 			zap.String("tenant_id", deliveryEvent.Event.TenantID),
+			zap.String("destination_id", deliveryEvent.DestinationID),
 		}
 
 		if errors.Is(err, models.ErrDestinationDeleted) {
@@ -452,12 +473,15 @@ func (h *messageHandler) ensurePublishableDestination(ctx context.Context, deliv
 	}
 	if destination == nil {
 		h.logger.Ctx(ctx).Info("destination not found",
-			zap.String("destination_id", deliveryEvent.DestinationID),
-			zap.String("tenant_id", deliveryEvent.Event.TenantID))
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
+			zap.String("destination_id", deliveryEvent.DestinationID))
 		return nil, models.ErrDestinationNotFound
 	}
 	if destination.DisabledAt != nil {
 		h.logger.Ctx(ctx).Info("skipping disabled destination",
+			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
 			zap.String("destination_id", destination.ID),
 			zap.String("destination_type", destination.Type),
 			zap.Time("disabled_at", *destination.DisabledAt))

--- a/internal/publishmq/eventhandler.go
+++ b/internal/publishmq/eventhandler.go
@@ -75,8 +75,8 @@ func (h *eventHandler) Handle(ctx context.Context, event *models.Event) (*Handle
 	logger.Audit("processing event",
 		zap.String("event_id", event.ID),
 		zap.String("tenant_id", event.TenantID),
-		zap.String("topic", event.Topic),
-		zap.String("destination_id", event.DestinationID))
+		zap.String("destination_id", event.DestinationID),
+		zap.String("topic", event.Topic))
 
 	var matchedDestinations []models.DestinationSummary
 	var err error
@@ -159,6 +159,8 @@ func (h *eventHandler) matchSpecificDestination(ctx context.Context, event *mode
 	if err != nil {
 		h.logger.Ctx(ctx).Warn("failed to retrieve destination",
 			zap.Error(err),
+			zap.String("event_id", event.ID),
+			zap.String("tenant_id", event.TenantID),
 			zap.String("destination_id", event.DestinationID))
 		return []models.DestinationSummary{}, nil
 	}
@@ -179,8 +181,8 @@ func (h *eventHandler) enqueueDeliveryEvent(ctx context.Context, deliveryEvent m
 	if err := h.deliveryMQ.Publish(ctx, deliveryEvent); err != nil {
 		h.logger.Ctx(ctx).Error("failed to enqueue delivery event",
 			zap.Error(err),
-			zap.String("delivery_event_id", deliveryEvent.ID),
 			zap.String("event_id", deliveryEvent.Event.ID),
+			zap.String("tenant_id", deliveryEvent.Event.TenantID),
 			zap.String("destination_id", deliveryEvent.DestinationID))
 		deliverySpan.RecordError(err)
 		deliverySpan.End()
@@ -188,8 +190,8 @@ func (h *eventHandler) enqueueDeliveryEvent(ctx context.Context, deliveryEvent m
 	}
 
 	h.logger.Ctx(ctx).Audit("delivery event enqueued",
-		zap.String("delivery_event_id", deliveryEvent.ID),
 		zap.String("event_id", deliveryEvent.Event.ID),
+		zap.String("tenant_id", deliveryEvent.Event.TenantID),
 		zap.String("destination_id", deliveryEvent.DestinationID))
 	deliverySpan.End()
 	return nil


### PR DESCRIPTION
addresses #605

## Summary

Standardizes logging across the event delivery pipeline to make debugging easier. All delivery-related logs now consistently include:

- `event_id` - the published event
- `tenant_id` - for multi-tenant filtering
- `destination_id` - target destination
- `destination_type` - type of destination (webhook, sqs, etc.)

## Log Fields

| Log Message | Level | event_id | tenant_id | destination_id | destination_type | Notes |
|-------------|-------|:--------:|:---------:|:--------------:|:----------------:|-------|
| `processing delivery event` | INFO | ✓ | ✓ | ✓ | - | |
| `failed to publish event` | ERROR | ✓ | ✓ | ✓ | ✓ | |
| `failed to cancel scheduled retry` | ERROR | ✓ | ✓ | ✓ | ✓ | + `retry_id` |
| `scheduled retry canceled` | AUDIT | ✓ | ✓ | ✓ | ✓ | + `retry_id` |
| `event delivered` | AUDIT | ✓ | ✓ | ✓ | ✓ | |
| `failed to publish delivery log` | ERROR | ✓ | ✓ | ✓ | ✓ | |
| `failed to handle alert attempt` | ERROR | ✓ | ✓ | ✓ | ✓ | |
| `alert attempt handled` | INFO | ✓ | ✓ | ✓ | ✓ | |
| `failed to schedule retry` | ERROR | ✓ | ✓ | ✓ | - | |
| `retry scheduled` | AUDIT | ✓ | ✓ | ✓ | - | |
| `destination deleted` | INFO | ✓ | ✓ | ✓ | - | |
| `failed to retrieve destination` | ERROR | ✓ | ✓ | ✓ | - | |
| `destination not found` | INFO | ✓ | ✓ | ✓ | - | |
| `skipping disabled destination` | INFO | ✓ | ✓ | ✓ | ✓ | |
| `processing event` | AUDIT | ✓ | ✓ | ✓ | - | |
| `failed to match event destinations` | ERROR | ✓ | ✓ | - | - | |
| `no matching destinations` | INFO | ✓ | ✓ | - | - | |
| `failed to retrieve destination` | WARN | ✓ | ✓ | ✓ | - | |
| `failed to enqueue delivery event` | ERROR | ✓ | ✓ | ✓ | - | |
| `delivery event enqueued` | AUDIT | ✓ | ✓ | ✓ | - | |
| `destination disabled` | AUDIT | ✓ | ✓ | ✓ | ✓ | |
| `failed to send alert` | ERROR | ✓ | ✓ | ✓ | ✓ | |
| `alert sent` | AUDIT | ✓ | ✓ | ✓ | ✓ | |
| `manual retry initiated` | AUDIT | ✓ | ✓ | ✓ | ✓ | |

Context-specific fields:
- `attempt` - for retry-related logs
- `manual` - for manual retry logs
- `delivery_status` - for completed deliveries
- `backoff` - for retry scheduling
- `error` - for error logs

**Do NOT include:**
- `delivery_event_id` - internal implementation detail, not an exposed entity