### PR TITLE
Fix regex pattern for webhook URL validation

### DIFF
--- a/internal/destregistry/metadata/providers/webhook/metadata.json
+++ b/internal/destregistry/metadata/providers/webhook/metadata.json
@@ -7,7 +7,7 @@
       "label": "Webhook URL",
       "description": "The URL to send webhook events to via HTTP POST",
       "required": true,
-      "pattern": "^https?:\\/\\/[\\w\\-]+(?:\\.[\\w\\-]+)*(?::\\d{1,5})?(?:\\/[\\w\\-\\/\\.~:?#\\[\\]@!$&'\\(\\)*+,;=]*)?$"
+      "pattern": "^https?:\\/\\/[\\w\\-]+(?:\\.[\\w\\-]+)*(?::\\d{1,5})?(?:\\/[\\w\\-\\/\\.~:%:?#\\[\\]@!$&'\\(\\)*+,;=]*)?$"
     },
     {
       "key": "custom_headers",


### PR DESCRIPTION
- when using azure workflows, the generated URL has a query parameter with encoded forward slash
- the original regex pattern did not like this
- testing it with url https://prod-742.westeurope.logic.azure.com:443/workflows/9d2c41b7f8e54a3c9b0a4c2e6e71a8f3/triggers/When_an_HTTP_request_is_received/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2FWhen_an_HTTP_request_is_received%2Frun&sv=1.0&sig=Qm4nZ8pL2tVx7cRd1sYkH3aB9uE0iJ5wX6gN7hK8mPq makes this regex accept the webhook