### PR TITLE
fix: add new az params and update to v11

### DIFF
--- a/examples/azure/azure-deploy.sh
+++ b/examples/azure/azure-deploy.sh
@@ -35,7 +35,7 @@ az containerapp up \
   --resource-group $RESOURCE_GROUP \
   --location $LOCATION \
   --environment outpost-environment \
-  --image hookdeck/outpost:v0.4.0 \
+  --image hookdeck/outpost:v0.11.0 \
   --target-port 3333 \
   --ingress external \
   --env-vars "SERVICE=api" $ENV_VARS_STRING
@@ -47,7 +47,7 @@ az containerapp up \
   --resource-group $RESOURCE_GROUP \
   --location $LOCATION \
   --environment outpost-environment \
-  --image hookdeck/outpost:v0.4.0 \
+  --image hookdeck/outpost:v0.11.0 \
   --ingress internal \
   --env-vars "SERVICE=delivery" $ENV_VARS_STRING
 
@@ -58,7 +58,7 @@ az containerapp up \
   --resource-group $RESOURCE_GROUP \
   --location $LOCATION \
   --environment outpost-environment \
-  --image hookdeck/outpost:v0.4.0 \
+  --image hookdeck/outpost:v0.11.0 \
   --ingress internal \
   --env-vars "SERVICE=log" $ENV_VARS_STRING
 

--- a/examples/azure/dependencies.sh
+++ b/examples/azure/dependencies.sh
@@ -167,7 +167,9 @@ if ! az redisenterprise show --cluster-name "$REDIS_NAME" --resource-group "$RES
     --resource-group "$RESOURCE_GROUP" \
     --location "$LOCATION" \
     --sku Enterprise_E1 \
-    --minimum-tls-version "1.2"
+    --minimum-tls-version "1.2" \
+    --public-network-access "Enabled" \
+    --access-keys-auth "Enabled"
   
   echo "⏳ Waiting for cluster to be ready..."
   az redisenterprise wait --cluster-name "$REDIS_NAME" --resource-group "$RESOURCE_GROUP" --created

--- a/examples/azure/docker-compose.yml
+++ b/examples/azure/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: hookdeck/outpost:v0.4.0
+    image: hookdeck/outpost:v0.11.0
     container_name: outpost-api-azure
     env_file: .env.runtime
     environment:
@@ -9,14 +9,14 @@ services:
       - "3333:3333"
 
   delivery:
-    image: hookdeck/outpost:v0.4.0
+    image: hookdeck/outpost:v0.11.0
     container_name: outpost-delivery-azure
     env_file: .env.runtime
     environment:
       SERVICE: delivery
 
   log:
-    image: hookdeck/outpost:v0.4.0
+    image: hookdeck/outpost:v0.11.0
     container_name: outpost-log-azure
     env_file: .env.runtime
     environment:


### PR DESCRIPTION
Fixes a couple of warnings when trying out the Azure example

https://learn.microsoft.com/en-us/cli/azure/upcoming-breaking-changes?view=azure-cli-latest#redisenterprise-create
> The argument '--public-network-access' will become required in next breaking change release(2.79.0) scheduled for Nov 2025.
The default value of '--access-keys-auth' will be changed to 'Disabled' from 'Enabled' in next breaking change release(2.79.0) scheduled for Nov 2025.

and updates to the latest docker image