### PR TITLE
fix(sdks): correct Python speakeasy pagination config to reference OpenAPI parameter name

### DIFF
--- a/sdks/schemas/pagination-fixes-overlay.yaml
+++ b/sdks/schemas/pagination-fixes-overlay.yaml
@@ -75,12 +75,14 @@ actions:
       description: "Rename 'prev' query parameter to 'prev_cursor' for consistency"
       
   # Add pagination configuration for events endpoint
+  # Note: The pagination config references the original parameter name 'next' (not 'next_cursor')
+  # because x-speakeasy-name-override only affects generated code, not the OpenAPI spec
   - target: $["paths"]["/tenants/{tenant_id}/events"]["get"]
     update:
       x-speakeasy-pagination:
         type: cursor
         inputs:
-          - name: next_cursor
+          - name: next
             in: parameters
             type: cursor
           - name: limit
@@ -93,13 +95,15 @@ actions:
       type: pagination-config
       description: "Configure cursor-based pagination for events listing"
       
-  # Add pagination configuration for destination events endpoint  
+  # Add pagination configuration for destination events endpoint
+  # Note: The pagination config references the original parameter name 'next' (not 'next_cursor')
+  # because x-speakeasy-name-override only affects generated code, not the OpenAPI spec
   - target: $["paths"]["/tenants/{tenant_id}/destinations/{destination_id}/events"]["get"]
     update:
       x-speakeasy-pagination:
         type: cursor
         inputs:
-          - name: next_cursor
+          - name: next
             in: parameters
             type: cursor
           - name: limit


### PR DESCRIPTION
The x-speakeasy-pagination configuration was referencing 'next_cursor' but should reference 'next' (the original OpenAPI parameter name) because x-speakeasy-name-override only affects generated code, not the OpenAPI spec itself. The pagination configuration is validated against the OpenAPI spec, so it must use the actual parameter names from the spec.