### PR TITLE
docs: add upgrade v0.13 guide to guides page and sidebar

### DIFF
--- a/docs/zudoku.config.ts
+++ b/docs/zudoku.config.ts
@@ -199,16 +199,6 @@ const config: ZudokuConfig = {
             label: "Schema Migration",
             id: "guides/migration",
           },
-          {
-            type: "doc",
-            label: "Upgrade to v0.12",
-            id: "guides/upgrade-v0.12",
-          },
-          {
-            type: "doc",
-            label: "Upgrade to v0.13",
-            id: "guides/upgrade-v0.13",
-          },
         ],
       },
       {


### PR DESCRIPTION
Add the v0.13 upgrade guide link to the guides landing page. This was missed in #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)