### PR TITLE
fix(spec): correct GET /events parameter indices in Python pagination overlay

### DIFF
--- a/sdks/schemas/pagination-fixes-overlay.yaml
+++ b/sdks/schemas/pagination-fixes-overlay.yaml
@@ -39,15 +39,15 @@ actions:
       type: parameter-name-override
       description: "Rename 'prev' query parameter to 'prev_cursor'"
 
-  # GET /events: next=6, prev=7
-  - target: $["paths"]["/events"]["get"]["parameters"][6]
+  # GET /events: tenant_id=0, topic=1, time[gte]=2, time[lte]=3, limit=4, next=5, prev=6 (destination_id removed in v0.13)
+  - target: $["paths"]["/events"]["get"]["parameters"][5]
     update:
       x-speakeasy-name-override: "next_cursor"
     x-speakeasy-metadata:
       type: parameter-name-override
       description: "Rename 'next' query parameter to 'next_cursor'"
 
-  - target: $["paths"]["/events"]["get"]["parameters"][7]
+  - target: $["paths"]["/events"]["get"]["parameters"][6]
     update:
       x-speakeasy-name-override: "prev_cursor"
     x-speakeasy-metadata:


### PR DESCRIPTION
After `destination_id` was removed from GET /events (v0.13), the `next` and `prev` query parameters moved to indices 5 and 6. The pagination-fixes overlay (used only by the Python SDK) was still targeting indices 6 and 7, which caused Python SDK generation to fail during the Compile SDK step.

This change updates the overlay to target parameters 5 and 6 for GET /events so the Python SDK builds successfully.

Made with [Cursor](https://cursor.com)