### PR TITLE
fix(python-sdk): README-PYPI.md workaround for Speakeasy compile

### DIFF
--- a/sdks/outpost-python/.gitignore
+++ b/sdks/outpost-python/.gitignore
@@ -9,7 +9,7 @@ __pycache__/
 .python-version
 .DS_Store
 pyrightconfig.json
-README-PYPI.md
+# README-PYPI.md is committed as a temporary workaround for Speakeasy compile; overwritten by scripts/prepare_readme.py at publish.
 .DS_Store
 **/.speakeasy/temp/
 **/.speakeasy/logs/

--- a/sdks/outpost-python/README-PYPI.md
+++ b/sdks/outpost-python/README-PYPI.md
@@ -1,0 +1,5 @@
+# Outpost Python SDK
+
+Temporary workaround: `pyproject.toml` expects this file for the build/compile step. See [README.md](README.md) for full documentation.
+
+This file is overwritten by `scripts/prepare_readme.py` at publish time so the PyPI package gets the correct long description.


### PR DESCRIPTION
Adds a committed `README-PYPI.md` in the Python SDK so the Speakeasy build/compile step (and CI) succeeds. `pyproject.toml` expects this file.

- **sdks/outpost-python/.gitignore** – stop ignoring `README-PYPI.md` (with a comment that it's a temporary workaround, overwritten at publish).
- **sdks/outpost-python/README-PYPI.md** – short placeholder; `scripts/prepare_readme.py` overwrites it at publish so PyPI gets the correct long description.

Made with [Cursor](https://cursor.com)