### PR TITLE
fix(python-sdk): add compileCommand to workflow.lock for CI

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -74,6 +74,7 @@ workflow:
             target: python
             source: Outpost API (Python)
             output: ./sdks/outpost-python
+            compileCommand: "python scripts/patch_pyproject_readme.py && poetry build"
             publish:
                 pypi:
                     token: $pypi_token


### PR DESCRIPTION
Follow-up to the merged readme fix (PR #697). The Speakeasy CLI uses `.speakeasy/workflow.lock` during generation; the lock was missing `compileCommand` for outpost-python, so the **Compile SDK** step still used the default and failed on missing README-PYPI.md. This adds the same `compileCommand` as in workflow.yaml so the patch runs before `poetry build` in CI.

Made with [Cursor](https://cursor.com)