### PR TITLE
fix: align OpenAPI spec security with implementation

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2184,8 +2184,6 @@ paths:
         The response includes lightweight tenant objects without computed fields like `destinations_count` and `topics`.
         Use `GET /tenants/{tenant_id}` to retrieve full tenant details including these fields.
       operationId: listTenants
-      security:
-        - AdminApiKey: []
       parameters:
         - name: limit
           in: query
@@ -2274,7 +2272,7 @@ paths:
                     type: string
                     example: "invalid cursor format"
         "401":
-          description: Unauthorized (Admin API Key missing or invalid).
+          description: Unauthorized (authentication missing or invalid).
         "501":
           description: List Tenants feature is not available. Requires Redis with RediSearch module.
           content:
@@ -2354,18 +2352,16 @@ paths:
           description: Tenant not found.
         # Add other error responses
 
-  # Admin-only endpoints (cross-tenant)
   /events:
     get:
       tags: [Events]
-      summary: List Events (Admin)
+      summary: List Events
       description: |
-        Retrieves a list of events across all tenants. This is an admin-only endpoint that requires the Admin API Key.
+        Retrieves a list of events.
 
-        When `tenant_id` is not provided, returns events from all tenants. When `tenant_id` is provided, returns only events for that tenant.
-      operationId: adminListEvents
-      security:
-        - AdminApiKey: []
+        When authenticated with a Tenant JWT, returns only events belonging to that tenant.
+        When authenticated with Admin API Key, returns events across all tenants. Use `tenant_id` query parameter to filter by tenant.
+      operationId: listEvents
       parameters:
         - name: tenant_id
           in: query
@@ -2464,7 +2460,7 @@ paths:
                       next: "MTcwNDA2NzIwMA=="
                       prev: null
         "401":
-          description: Unauthorized (Admin API Key missing or invalid).
+          description: Unauthorized (authentication missing or invalid).
         "422":
           description: Validation error (invalid query parameters).
           content:
@@ -2511,14 +2507,13 @@ paths:
   /attempts:
     get:
       tags: [Attempts]
-      summary: List Attempts (Admin)
+      summary: List Attempts
       description: |
-        Retrieves a paginated list of attempts across all tenants. This is an admin-only endpoint that requires the Admin API Key.
+        Retrieves a paginated list of attempts.
 
-        When `tenant_id` is not provided, returns attempts from all tenants. When `tenant_id` is provided, returns only attempts for that tenant.
-      operationId: adminListAttempts
-      security:
-        - AdminApiKey: []
+        When authenticated with a Tenant JWT, returns only attempts belonging to that tenant.
+        When authenticated with Admin API Key, returns attempts across all tenants. Use `tenant_id` query parameter to filter by tenant.
+      operationId: listAttempts
       parameters:
         - name: tenant_id
           in: query
@@ -2675,7 +2670,7 @@ paths:
                       next: null
                       prev: null
         "401":
-          description: Unauthorized (Admin API Key missing or invalid).
+          description: Unauthorized (authentication missing or invalid).
         "422":
           description: Validation error (invalid query parameters).
           content:
@@ -2767,8 +2762,10 @@ paths:
     get:
       tags: [Tenants]
       summary: Get Portal Redirect URL
-      description: Returns a redirect URL containing a JWT to authenticate the user with the portal.
+      description: Returns a redirect URL containing a JWT to authenticate the user with the portal. Requires Admin API Key.
       operationId: getTenantPortalUrl
+      security:
+        - AdminApiKey: []
       parameters:
         - name: theme
           in: query
@@ -2804,8 +2801,10 @@ paths:
     get:
       tags: [Tenants]
       summary: Get Tenant JWT Token
-      description: Returns a JWT token scoped to the tenant for safe browser API calls.
+      description: Returns a JWT token scoped to the tenant for safe browser API calls. Requires Admin API Key.
       operationId: getTenantToken
+      security:
+        - AdminApiKey: []
       responses:
         "200":
           description: Tenant JWT token.
@@ -3358,6 +3357,8 @@ paths:
       summary: Publish Event
       description: Publishes an event to the specified topic, potentially routed to a specific destination. Requires Admin API Key.
       operationId: publishEvent
+      security:
+        - AdminApiKey: []
       requestBody:
         required: true
         content:

--- a/sdks/schemas/speakeasy-modifications-overlay.yaml
+++ b/sdks/schemas/speakeasy-modifications-overlay.yaml
@@ -22,7 +22,7 @@ actions:
       x-speakeasy-name-override: list
     x-speakeasy-metadata:
       after: sdk.events.list()
-      before: sdk.Events.adminListEvents()
+      before: sdk.Events.listEvents()
       created_at: 1745611620645
       reviewed_at: 1745611624395
       type: method-name
@@ -40,7 +40,7 @@ actions:
       x-speakeasy-name-override: list
     x-speakeasy-metadata:
       after: sdk.attempts.list()
-      before: sdk.Attempts.adminListAttempts()
+      before: sdk.Attempts.listAttempts()
       created_at: 1745611620645
       reviewed_at: 1745611624395
       type: method-name


### PR DESCRIPTION
Audited all endpoints and fixed security mismatches between the OpenAPI spec and the actual Go router definitions:

- Remove admin-only restriction from GET /tenants, /events, /attempts (these accept both AdminApiKey and TenantJwt in the implementation)
- Add admin-only security to POST /publish, GET /tenants/{id}/token, GET /tenants/{id}/portal (these have AdminOnly: true in the router)
- Update operationIds, summaries, descriptions, and 401 messages
- Update Speakeasy overlay metadata for renamed operationIds

Aiming to fix some issues with the generated API reference like below

<img width="330" height="194" alt="CleanShot 2026-02-13 at 21 39 17" src="https://github.com/user-attachments/assets/d22642d2-2bc4-4077-8648-66fc23d1c72f" />
