### PR TITLE
fix(portal): handle empty custom_headers in create destination flow

### DIFF
--- a/internal/portal/src/scenes/CreateDestination/CreateDestination.tsx
+++ b/internal/portal/src/scenes/CreateDestination/CreateDestination.tsx
@@ -315,11 +315,24 @@ export default function CreateDestination() {
           topics: topics,
           ...(filter && Object.keys(filter).length > 0 ? { filter } : {}),
           config: Object.fromEntries(
-            Object.entries(values).filter(([key]) =>
-              destination_type?.config_fields.some(
-                (field) => field.key === key,
-              ),
-            ),
+            Object.entries(values)
+              .filter(([key]) =>
+                destination_type?.config_fields.some(
+                  (field) => field.key === key,
+                ),
+              )
+              .map(([key, value]) => {
+                let configValue = String(value);
+                // Webhook custom_headers must have at least one header or be null/empty
+                if (
+                  destination_type?.type === "webhook" &&
+                  key === "custom_headers" &&
+                  (configValue === "{}" || configValue === "")
+                ) {
+                  configValue = "";
+                }
+                return [key, configValue];
+              }),
           ),
           credentials: Object.fromEntries(
             Object.entries(values).filter(([key]) =>


### PR DESCRIPTION
Apply the same empty `custom_headers` handling from #674 to the create destination flow. The update flow already converts `"{}"` to `""`, but the create flow was missing this, causing validation failures when no custom headers are set.

Ref #707