### PR TITLE
perf(portal): skip redundant destination-types refetch on mount

### DIFF
--- a/internal/portal/src/destination-types.tsx
+++ b/internal/portal/src/destination-types.tsx
@@ -11,6 +11,7 @@ export function useDestinationTypes(): Record<
   const { data } = useSWR<DestinationTypeReference[]>(
     "destination-types",
     (path: string) => apiClient.fetchRoot(path),
+    { revalidateIfStale: false },
   );
   if (!data) {
     return {};


### PR DESCRIPTION
Destination types are static data that don't change at runtime. Adding revalidateIfStale: false prevents SWR from refetching on every component mount while still revalidating on focus/reconnect.