### PR TITLE
feat: add PORTAL_REFRESH_URL for session authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,7 @@
 # PORTAL_ORGANIZATION_NAME="Acme"
 # PORTAL_PROXY_URL="http://portal:3334"
 # PORTAL_REFERER_URL="https://example.com"
+# PORTAL_REFRESH_URL="https://example.com/auth/refresh-portal"
 # PORTAL_FAVICON_URL="https://example.com/favicon.svg"
 # PORTAL_LOGO=""
 # PORTAL_LOGO_DARK=""

--- a/docs/pages/features/tenant-user-portal.mdx
+++ b/docs/pages/features/tenant-user-portal.mdx
@@ -18,9 +18,23 @@ The portal is a React SPA that is distributed via the API.
 
 ## Required Config
 
-`PORTAL_REFERER_URL` is used to redirect the user when the JWT token is expired or when the user clicks 'back'.
+`PORTAL_REFERER_URL` is used to redirect the user when the user clicks 'back'. Also used as a fallback redirect when the JWT token is expired and `PORTAL_REFRESH_URL` is not set.
 
 `PORTAL_ORGANIZATION_NAME` is used to display the name of the organization deploying the portal.
+
+## Session Refresh
+
+When a user accesses the portal without a valid session (no token or expired token), the portal redirects them to `PORTAL_REFRESH_URL` if configured, otherwise falls back to `PORTAL_REFERER_URL`.
+
+To enable session refresh, set `PORTAL_REFRESH_URL` to a URL in your application that:
+
+1. Authenticates the user via your own session/auth
+2. Generates a new portal JWT via the `GET /:tenant_id/portal` endpoint
+3. Redirects the user back to the portal with the new `?token=` query parameter
+
+Without this, users who navigate to the portal URL without a valid session (e.g. via a shared link or bookmark) will see a blank screen.
+
+**Security note:** The `PORTAL_REFRESH_URL` endpoint must independently authenticate the user and determine which tenant they belong to. Do not rely on any query parameters from the portal redirect for authorization decisions.
 
 ## Theming
 

--- a/internal/config/portal.go
+++ b/internal/config/portal.go
@@ -10,6 +10,7 @@ import (
 type PortalConfig struct {
 	ProxyURL                   string `yaml:"proxy_url" env:"PORTAL_PROXY_URL" desc:"URL to proxy the Outpost Portal through. If set, Outpost serves the portal assets, and this URL is used as the base. Must be a valid URL." required:"N"`
 	RefererURL                 string `yaml:"referer_url" env:"PORTAL_REFERER_URL" desc:"The URL where the user is redirected when the JWT token is expired or when the user clicks 'back'. Required if the Outpost Portal is enabled/used." required:"C"`
+	RefreshURL                 string `yaml:"refresh_url" env:"PORTAL_REFRESH_URL" desc:"URL to redirect unauthenticated portal users to for re-authentication. The page at this URL should generate a new portal JWT and redirect the user back to the portal with a ?token= query parameter. If not set, falls back to PORTAL_REFERER_URL." required:"N"`
 	FaviconURL                 string `yaml:"favicon_url" env:"PORTAL_FAVICON_URL" desc:"URL for the favicon to be used in the Outpost Portal." required:"N"`
 	BrandColor                 string `yaml:"brand_color" env:"PORTAL_BRAND_COLOR" desc:"Primary brand color (hex code) for theming the Outpost Portal (e.g., '#6122E7'). Also referred to as Accent Color in some contexts." required:"N"`
 	Logo                       string `yaml:"logo" env:"PORTAL_LOGO" desc:"URL for the light-mode logo to be displayed in the Outpost Portal." required:"N"`
@@ -28,6 +29,7 @@ func (c *Config) GetPortalConfig() portal.PortalConfig {
 		Configs: map[string]string{
 			"PROXY_URL":                     c.Portal.ProxyURL,
 			"REFERER_URL":                   c.Portal.RefererURL,
+			"REFRESH_URL":                   c.Portal.RefreshURL,
 			"FAVICON_URL":                   c.Portal.FaviconURL,
 			"BRAND_COLOR":                   c.Portal.BrandColor,
 			"LOGO":                          c.Portal.Logo,

--- a/internal/portal/src/app.tsx
+++ b/internal/portal/src/app.tsx
@@ -199,6 +199,10 @@ export function App() {
   );
 }
 
+function getRedirectURL() {
+  return CONFIGS.REFRESH_URL || CONFIGS.REFERER_URL;
+}
+
 function useToken() {
   const [token, setToken] = useState(sessionStorage.getItem("token"));
 
@@ -216,7 +220,7 @@ function useToken() {
   }, []);
 
   if (!token) {
-    window.location.replace(CONFIGS.REFERER_URL);
+    window.location.replace(getRedirectURL());
     return;
   }
 
@@ -241,7 +245,7 @@ function useTenant(token?: string): TenantResponse | undefined {
         headers: { Authorization: `Bearer ${token}` },
       }).then((res) => {
         if (!res.ok) {
-          window.location.replace(CONFIGS.REFERER_URL);
+          window.location.replace(getRedirectURL());
           throw new Error("Failed to fetch tenant");
         }
         return res.json();

--- a/internal/portal/src/config.ts
+++ b/internal/portal/src/config.ts
@@ -5,6 +5,7 @@ const CONFIGS =
     LOGO_DARK: string;
     FAVICON_URL: string;
     REFERER_URL: string;
+    REFRESH_URL: string;
     FORCE_THEME: string;
     TOPICS: string;
     DISABLE_OUTPOST_BRANDING: string;


### PR DESCRIPTION
When users access the portal without a valid session (e.g. via a shared link), they are redirected to PORTAL_REFRESH_URL where the host app can re-authenticate and redirect back with a new JWT. Falls back to PORTAL_REFERER_URL if not configured.

related: #298 