### PR TITLE
fix: normalize PG logstore timestamps to UTC

### DIFF
--- a/internal/logstore/pglogstore/pglogstore.go
+++ b/internal/logstore/pglogstore/pglogstore.go
@@ -245,6 +245,9 @@ func scanEvents(rows pgx.Rows) ([]eventWithPosition, error) {
 			return nil, fmt.Errorf("scan failed: %w", err)
 		}
 
+		// Normalize to UTC for consistent behavior across backends.
+		eventTime = eventTime.UTC()
+
 		results = append(results, eventWithPosition{
 			Event: &models.Event{
 				ID:               id,
@@ -479,6 +482,10 @@ func scanAttemptRecords(rows pgx.Rows) ([]attemptRecordWithPosition, error) {
 			return nil, fmt.Errorf("scan failed: %w", err)
 		}
 
+		// Normalize to UTC for consistent behavior across backends.
+		attemptTime = attemptTime.UTC()
+		eventTime = eventTime.UTC()
+
 		results = append(results, attemptRecordWithPosition{
 			AttemptRecord: &driver.AttemptRecord{
 				Attempt: &models.Attempt{
@@ -565,6 +572,7 @@ func (s *logStore) RetrieveEvent(ctx context.Context, req driver.RetrieveEventRe
 		return nil, fmt.Errorf("scan failed: %w", err)
 	}
 
+	event.Time = event.Time.UTC()
 	return event, nil
 }
 
@@ -648,6 +656,10 @@ func (s *logStore) RetrieveAttempt(ctx context.Context, req driver.RetrieveAttem
 	if err != nil {
 		return nil, fmt.Errorf("scan failed: %w", err)
 	}
+
+	// Normalize to UTC for consistent behavior across backends.
+	attemptTime = attemptTime.UTC()
+	eventTime = eventTime.UTC()
 
 	return &driver.AttemptRecord{
 		Attempt: &models.Attempt{


### PR DESCRIPTION
## Summary
- PG logstore returns timestamps in the server's local timezone (e.g., `+07:00`), while ClickHouse always returns UTC
- When these timestamps are round-tripped into URL query params (`time[gte]=2026-03-01T07:08:04+07:00`), the `+` is interpreted as a space by URL parsing → 422 validation error
- Normalizes all PG-scanned timestamps to UTC (`.UTC()`) at the scan boundary in `scanEvents`, `scanAttemptRecords`, `RetrieveEvent`, and `RetrieveAttempt`

## Context
To be fair it's not 100% an issue. It's only a problem when the response timestamp is used directly as a URL query parameter, since the `+` in the timezone offset gets interpreted as a space. This happened in our e2e test but isn't typical user behavior, so not technically a bug. Normalizing to UTC keeps things consistent with ClickHouse and avoids the footgun.

## User-facing change
The `time` field in API responses now always uses UTC (`Z` suffix) instead of the server's local timezone offset. Only affects PostgreSQL backend — ClickHouse already returned UTC.

- Before: `"time": "2026-03-01T07:08:04+07:00"`
- After: `"time": "2026-03-01T00:08:04Z"`

These represent the same instant — no data change.

## Test plan
- [x] `make test` — all unit tests pass
- [x] `TESTCOMPAT=1 make test/e2e` — all e2e compat tests pass (including the previously failing `TestE2E_Compat_Postgres/TestLogQueries_Pagination/cursor_pagination_with_time_filter`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)