### PR TITLE
fix(sdks): extract shared pagination config from Python-only overlay

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -8,6 +8,7 @@ sources:
             - location: ./sdks/schemas/speakeasy-modifications-overlay.yaml
             - location: ./sdks/schemas/security-collapse-overlay.yaml
             - location: ./sdks/schemas/error-types.yaml
+            - location: ./sdks/schemas/pagination-config-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/hookdeck-dev/outpost/outpost-api
     Outpost API (Go):
@@ -17,6 +18,7 @@ sources:
             - location: ./sdks/schemas/speakeasy-modifications-overlay.yaml
             - location: ./sdks/schemas/security-collapse-overlay.yaml
             - location: ./sdks/schemas/error-types.yaml
+            - location: ./sdks/schemas/pagination-config-overlay.yaml
             - location: ./sdks/schemas/go-array-params-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/hookdeck-dev/outpost/outpost-api
@@ -27,6 +29,7 @@ sources:
             - location: ./sdks/schemas/speakeasy-modifications-overlay.yaml
             - location: ./sdks/schemas/security-collapse-overlay.yaml
             - location: ./sdks/schemas/error-types.yaml
+            - location: ./sdks/schemas/pagination-config-overlay.yaml
             - location: ./sdks/schemas/python-pagination-fixes-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/hookdeck-dev/outpost/outpost-api

--- a/sdks/schemas/pagination-config-overlay.yaml
+++ b/sdks/schemas/pagination-config-overlay.yaml
@@ -1,0 +1,85 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Pagination Config
+  version: 0.0.1
+  x-speakeasy-metadata:
+    type: pagination-config
+    description: "Configures cursor-based pagination for all list endpoints (shared across all SDKs)"
+extends: ../../docs/apis/openapi.yaml
+actions:
+  # Pagination config: GET /tenants
+  - target: $["paths"]["/tenants"]["get"]
+    update:
+      x-speakeasy-pagination:
+        type: cursor
+        inputs:
+          - name: next
+            in: parameters
+            type: cursor
+          - name: limit
+            in: parameters
+            type: limit
+        outputs:
+          nextCursor: $.pagination.next
+          results: $.models
+    x-speakeasy-metadata:
+      type: pagination-config
+      description: "Configure cursor-based pagination for tenants listing"
+
+  # Pagination config: GET /events
+  - target: $["paths"]["/events"]["get"]
+    update:
+      x-speakeasy-pagination:
+        type: cursor
+        inputs:
+          - name: next
+            in: parameters
+            type: cursor
+          - name: limit
+            in: parameters
+            type: limit
+        outputs:
+          nextCursor: $.pagination.next
+          results: $.models
+    x-speakeasy-metadata:
+      type: pagination-config
+      description: "Configure cursor-based pagination for events listing"
+
+  # Pagination config: GET /attempts
+  - target: $["paths"]["/attempts"]["get"]
+    update:
+      x-speakeasy-pagination:
+        type: cursor
+        inputs:
+          - name: next
+            in: parameters
+            type: cursor
+          - name: limit
+            in: parameters
+            type: limit
+        outputs:
+          nextCursor: $.pagination.next
+          results: $.models
+    x-speakeasy-metadata:
+      type: pagination-config
+      description: "Configure cursor-based pagination for attempts listing"
+
+  # Pagination config: GET /tenants/.../destinations/.../attempts
+  - target: $["paths"]["/tenants/{tenant_id}/destinations/{destination_id}/attempts"]["get"]
+    update:
+      x-speakeasy-pagination:
+        type: cursor
+        inputs:
+          - name: next
+            in: parameters
+            type: cursor
+          - name: limit
+            in: parameters
+            type: limit
+        outputs:
+          nextCursor: $.pagination.next
+          results: $.models
+    x-speakeasy-metadata:
+      type: pagination-config
+      description: "Configure cursor-based pagination for destination attempts listing"

--- a/sdks/schemas/python-pagination-fixes-overlay.yaml
+++ b/sdks/schemas/python-pagination-fixes-overlay.yaml
@@ -1,11 +1,11 @@
 overlay: 1.0.0
 x-speakeasy-jsonpath: rfc9535
 info:
-  title: Pagination Field Fixes
-  version: 0.0.3
+  title: Python Pagination Fixes
+  version: 0.0.4
   x-speakeasy-metadata:
-    type: pagination-fixes
-    description: "Fixes pagination field conflicts with Python built-ins; uses filter expressions instead of positional indices for resilience to parameter reordering"
+    type: python-pagination-fixes
+    description: "Renames fields that conflict with Python built-ins (dir, next, prev); uses filter expressions for resilience to parameter reordering"
 extends: ../../docs/apis/openapi.yaml
 actions:
   # Fix 'next' field in SeekPagination to avoid Python built-in next() conflict
@@ -110,79 +110,3 @@ actions:
     x-speakeasy-metadata:
       type: parameter-name-override
       description: "Rename 'prev' query parameter to 'prev_cursor'"
-
-  # Pagination config: GET /tenants (v0.13 envelope: models + pagination.next/prev)
-  - target: $["paths"]["/tenants"]["get"]
-    update:
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: next
-            in: parameters
-            type: cursor
-          - name: limit
-            in: parameters
-            type: limit
-        outputs:
-          nextCursor: $.pagination.next
-          results: $.models
-    x-speakeasy-metadata:
-      type: pagination-config
-      description: "Configure cursor-based pagination for tenants listing"
-
-  # Pagination config: GET /events
-  - target: $["paths"]["/events"]["get"]
-    update:
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: next
-            in: parameters
-            type: cursor
-          - name: limit
-            in: parameters
-            type: limit
-        outputs:
-          nextCursor: $.pagination.next
-          results: $.models
-    x-speakeasy-metadata:
-      type: pagination-config
-      description: "Configure cursor-based pagination for events listing"
-
-  # Pagination config: GET /attempts
-  - target: $["paths"]["/attempts"]["get"]
-    update:
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: next
-            in: parameters
-            type: cursor
-          - name: limit
-            in: parameters
-            type: limit
-        outputs:
-          nextCursor: $.pagination.next
-          results: $.models
-    x-speakeasy-metadata:
-      type: pagination-config
-      description: "Configure cursor-based pagination for attempts listing"
-
-  # Pagination config: GET /tenants/.../destinations/.../attempts
-  - target: $["paths"]["/tenants/{tenant_id}/destinations/{destination_id}/attempts"]["get"]
-    update:
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: next
-            in: parameters
-            type: cursor
-          - name: limit
-            in: parameters
-            type: limit
-        outputs:
-          nextCursor: $.pagination.next
-          results: $.models
-    x-speakeasy-metadata:
-      type: pagination-config
-      description: "Configure cursor-based pagination for destination attempts listing"


### PR DESCRIPTION
## Summary

The pagination cursor config (`x-speakeasy-pagination`) was bundled inside the Python-specific overlay, which only applies to the Python SDK source. After #744 split the Speakeasy sources by language, Go and TS SDKs lost auto-pagination support.

- Extract pagination config into a new shared `pagination-config-overlay.yaml` applied to all three sources
- Keep only Python builtin name overrides (`dir`→`direction`, `next`→`next_cursor`, `prev`→`prev_cursor`) in `python-pagination-fixes-overlay.yaml`
- Both overlays pass `speakeasy overlay validate`

## Test plan

- [x] `speakeasy overlay validate` passes for both overlays
- [x] `speakeasy overlay apply` confirms 4 pagination configs applied
- [ ] Re-run SDK generation after merge to verify pagination restored in Go/TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)