### PR TITLE
fix(ci): workflow_dispatch boolean input for SDK generation

### DIFF
--- a/.github/workflows/sdk_generation_outpost_go.yaml
+++ b/.github/workflows/sdk_generation_outpost_go.yaml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/sdk-generate-one.yml
     with:
       target: outpost-go
-      force: ${{ github.event.inputs.force }}
+      force: ${{ github.event.inputs.force == 'true' }}
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk_generation_outpost_python.yaml
+++ b/.github/workflows/sdk_generation_outpost_python.yaml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/sdk-generate-one.yml
     with:
       target: outpost-python
-      force: ${{ github.event.inputs.force }}
+      force: ${{ github.event.inputs.force == 'true' }}
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk_generation_outpost_ts.yaml
+++ b/.github/workflows/sdk_generation_outpost_ts.yaml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/sdk-generate-one.yml
     with:
       target: outpost-ts
-      force: ${{ github.event.inputs.force }}
+      force: ${{ github.event.inputs.force == 'true' }}
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Manual SDK generation workflows (Generate OUTPOST-GO, OUTPOST-TS, OUTPOST-PYTHON) fail with:
```
evaluate reusable workflow inputs: Unexpected value 'false'
```
when run with the default **Force** checkbox unchecked.

`workflow_dispatch` inputs are always strings (`"true"` / `"false"`). Passing `force: ${{ github.event.inputs.force }}` sends the string `"false"` into the reusable workflow, which expects a boolean and rejects it.

## Fix

Convert the input to a boolean before passing to `sdk-generate-one.yml`:
```yaml
force: ${{ github.event.inputs.force == 'true' }}
```

Applied in all three manual workflows:
- `.github/workflows/sdk_generation_outpost_go.yaml`
- `.github/workflows/sdk_generation_outpost_ts.yaml`
- `.github/workflows/sdk_generation_outpost_python.yaml`

## Testing

Re-run [Generate OUTPOST-GO](https://github.com/hookdeck/outpost/actions/runs/23050934749) (or trigger manually) with Force unchecked; the workflow should start successfully.

Made with [Cursor](https://cursor.com)