### PR TITLE
docs: add Upgrade to v0.14 to sidebar navigation

### DIFF
--- a/docs/zudoku.config.ts
+++ b/docs/zudoku.config.ts
@@ -209,6 +209,11 @@ const config: ZudokuConfig = {
             label: "Upgrade to v0.13",
             id: "guides/upgrade-v0.13",
           },
+          {
+            type: "doc",
+            label: "Upgrade to v0.14",
+            id: "guides/upgrade-v0.14",
+          },
         ],
       },
       {


### PR DESCRIPTION
Adds the Upgrade to v0.14 guide to the sidebar in `docs/zudoku.config.ts` so it appears in the nav alongside v0.12 and v0.13.

Made with [Cursor](https://cursor.com)