### PR TITLE
fix(spec): add key_value_map to DestinationSchemaField type enum

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2003,7 +2003,7 @@ components:
       properties:
         type:
           type: string
-          enum: [text, checkbox]
+          enum: [text, checkbox, key_value_map]
           example: "text"
         label:
           type: string


### PR DESCRIPTION
## Summary

- Add `key_value_map` to the `DestinationSchemaField.type` enum in the OpenAPI spec

PR #590 introduced the `key_value_map` config field type for webhook custom headers but did not update the OpenAPI spec. The enum was still `[text, checkbox]`, causing the TypeScript SDK's zod validation to reject the API response when `PORTAL_ENABLE_WEBHOOK_CUSTOM_HEADERS=true`.

Closes #760

## Test plan

- [ ] Regenerate TypeScript SDK from updated spec — verify `KeyValueMap: "key_value_map"` appears in `TypeEnum`
- [ ] With `PORTAL_ENABLE_WEBHOOK_CUSTOM_HEADERS=true`, call `sdk.schemas.listDestinationTypes()` — should succeed without zod validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)