### PR TITLE
fix(portal): fill metrics grid for non-webhook destinations

### DIFF
--- a/internal/portal/src/scenes/Destination/Destination.scss
+++ b/internal/portal/src/scenes/Destination/Destination.scss
@@ -192,5 +192,9 @@
       height: 238px;
       grid-column: span 2;
     }
+
+    &--row2-half {
+      grid-column: span 3;
+    }
   }
 }

--- a/internal/portal/src/scenes/Destination/DestinationMetrics.tsx
+++ b/internal/portal/src/scenes/Destination/DestinationMetrics.tsx
@@ -165,7 +165,7 @@ const DestinationMetrics: React.FC<DestinationMetricsProps> = ({
         </div>
 
         {/* Row 2 — Error Breakdown (3 columns) */}
-        <div className="metrics-container__cell metrics-container__cell--row2">
+        <div className={`metrics-container__cell metrics-container__cell--row2${destination.type !== "webhook" ? " metrics-container__cell--row2-half" : ""}`}>
           <MetricsChart
             title="Errors"
             subtitle="rate"
@@ -214,7 +214,7 @@ const DestinationMetrics: React.FC<DestinationMetricsProps> = ({
             />
           </div>
         )}
-        <div className="metrics-container__cell metrics-container__cell--row2">
+        <div className={`metrics-container__cell metrics-container__cell--row2${destination.type !== "webhook" ? " metrics-container__cell--row2-half" : ""}`}>
           <MetricsBreakdown
             title="Events count by topic"
             data={by_topic.data?.data}


### PR DESCRIPTION
## Summary
- When the "Events count by status code" chart is hidden for non-webhook destinations, the bottom row only had 2 charts spanning 4 of 6 grid columns, leaving an awkward gap
- Bottom charts now span 3 columns each (instead of 2) for non-webhook destinations, filling the full row width
- Webhook destinations are unaffected — they still show all 3 bottom charts at 2 columns each

## Test plan
- [ ] View metrics for a non-webhook destination — bottom row should have 2 equal-width charts filling the full width
- [ ] View metrics for a webhook destination — bottom row should still show 3 charts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)