### PR TITLE
refactor: rename operation events to operator events

### DIFF
--- a/cmd/e2e/helpers_test.go
+++ b/cmd/e2e/helpers_test.go
@@ -404,7 +404,7 @@ func (s *basicSuite) waitForNewDestinationDisabled(tenantID, destID string) {
 	s.Require().FailNowf("timeout", "timed out waiting for destination %s to be disabled", destID)
 }
 
-// waitForOpEvents polls until at least count operation events with the given topic exist.
+// waitForOpEvents polls until at least count operator events with the given topic exist.
 func (s *basicSuite) waitForOpEvents(topic string, count int) []opeventsmock.ReceivedEvent {
 	s.T().Helper()
 	timeout := alertPollTimeout

--- a/cmd/e2e/opevents/server.go
+++ b/cmd/e2e/opevents/server.go
@@ -14,15 +14,15 @@ import (
 	"time"
 )
 
-// ReceivedEvent is a single operation event received by the mock server.
+// ReceivedEvent is a single operator event received by the mock server.
 type ReceivedEvent struct {
-	Event     OperationEvent
+	Event     OperatorEvent
 	Signature string // raw X-Outpost-Signature header
 	Body      []byte // raw request body (for signature verification)
 }
 
-// OperationEvent mirrors internal/opevents.OperationEvent for test decoding.
-type OperationEvent struct {
+// OperatorEvent mirrors internal/opevents.OperatorEvent for test decoding.
+type OperatorEvent struct {
 	ID           string          `json:"id"`
 	Topic        string          `json:"topic"`
 	Time         time.Time       `json:"time"`
@@ -31,7 +31,7 @@ type OperationEvent struct {
 	Data         json.RawMessage `json:"data"`
 }
 
-// MockServer captures operation events sent to its HTTP endpoint.
+// MockServer captures operator events sent to its HTTP endpoint.
 type MockServer struct {
 	server *http.Server
 	events []ReceivedEvent
@@ -124,7 +124,7 @@ func (s *MockServer) handleEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var event OperationEvent
+	var event OperatorEvent
 	if err := json.Unmarshal(body, &event); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/cmd/e2e/suites_test.go
+++ b/cmd/e2e/suites_test.go
@@ -93,7 +93,7 @@ func (suite *basicSuite) SetupSuite() {
 	gin.SetMode(gin.TestMode)
 	mockServerBaseURL := testinfra.GetMockServer(t)
 
-	// Setup operation events mock server
+	// Setup operator events mock server
 	oeServer := opeventsmock.NewMockServer()
 	require.NoError(t, oeServer.Start())
 	suite.opeventsServer = oeServer
@@ -104,10 +104,10 @@ func (suite *basicSuite) SetupSuite() {
 		DeploymentID: suite.deploymentID,
 	})
 
-	// Configure operation events HTTP sink
-	cfg.OperationEvents.Topics = []string{"*"}
-	cfg.OperationEvents.HTTP.URL = oeServer.GetURL()
-	cfg.OperationEvents.HTTP.SigningSecret = "test-opevents-secret"
+	// Configure operator events HTTP sink
+	cfg.OperatorEvents.Topics = []string{"*"}
+	cfg.OperatorEvents.HTTP.URL = oeServer.GetURL()
+	cfg.OperatorEvents.HTTP.SigningSecret = "test-opevents-secret"
 
 	require.NoError(t, cfg.Validate(config.Flags{}))
 

--- a/docs/pages/features.mdx
+++ b/docs/pages/features.mdx
@@ -10,7 +10,7 @@ Outpost offers a range of features designed to provide a robust and flexible eve
 - **[Filters](./features/filter.mdx)**: Configure filters on destinations to selectively receive only events matching specific criteria.
 - **[Publishing Events](./features/publish-events.mdx)**: Learn how events are published, either to a configured message queue or via the publish API endpoint.
 - **[Delivery & Retries](./features/event-delivery.mdx)**: Understand how Outpost ensures reliable event delivery with support for various destination types, retries, and best practices.
-- **[Operation Events](./features/operation-events.mdx)**: Subscribe to lifecycle events (delivery failures, destination disabling, retry exhaustion, subscription changes) via HTTP, AWS SQS, GCP Pub/Sub, or RabbitMQ.
+- **[Operator Events](./features/operator-events.mdx)**: Subscribe to lifecycle events (delivery failures, destination disabling, retry exhaustion, subscription changes) via HTTP, AWS SQS, GCP Pub/Sub, or RabbitMQ.
 - **[Tenant User Portal](./features/tenant-user-portal.mdx)**: Provide your tenants with an optional portal to configure destinations and inspect events.
 - **[OpenTelemetry](./features/opentelemetry.mdx)**: Monitor key performance metrics using OpenTelemetry integration.
 - **[Logging](./features/logging.mdx)**: Control the verbosity of logs produced by Outpost services.

--- a/docs/pages/features/event-delivery.mdx
+++ b/docs/pages/features/event-delivery.mdx
@@ -16,4 +16,4 @@ Manual retries can be triggered for any given attempt via the [Attempts API](/do
 
 ## Disabled destinations
 
-If the destination for an event is disabled—through the API, user portal, or automatically because a [failure threshold](/docs/features/operation-events) has been reached—the event will be discarded and cannot be retried.
+If the destination for an event is disabled—through the API, user portal, or automatically because a [failure threshold](/docs/features/operator-events) has been reached—the event will be discarded and cannot be retried.

--- a/docs/pages/features/operator-events.mdx
+++ b/docs/pages/features/operator-events.mdx
@@ -1,19 +1,19 @@
 ---
-title: Operation Events
+title: Operator Events
 ---
 
-Operation events let you subscribe to lifecycle events from your Outpost deployment — delivery failures, destination disabling, retry exhaustion, and subscription changes. Use them to build alerting, auditing, or automation on top of Outpost.
+Operator events let you subscribe to lifecycle events from your Outpost deployment — delivery failures, destination disabling, retry exhaustion, and subscription changes. Use them to build alerting, auditing, or automation on top of Outpost.
 
 ## Configuration
 
-Enable operation events by specifying which topics to subscribe to and configuring a sink to receive them.
+Enable operator events by specifying which topics to subscribe to and configuring a sink to receive them.
 
 ### Topics
 
-Set `OPERATION_EVENTS_TOPICS` to a comma-separated list of topics, or `*` for all topics:
+Set `OPERATOR_EVENTS_TOPICS` to a comma-separated list of topics, or `*` for all topics:
 
 ```
-OPERATION_EVENTS_TOPICS=*
+OPERATOR_EVENTS_TOPICS=*
 ```
 
 Available topics:
@@ -25,7 +25,7 @@ Available topics:
 | `alert.attempt.exhausted_retries` | Delivery exhausts all retry attempts (deduplicated per event+destination) |
 | `tenant.subscription.updated` | Destination created, updated, deleted, disabled, or enabled (when topics or destination count changes) |
 
-If `OPERATION_EVENTS_TOPICS` is empty or unset, operation events are disabled. If topics are configured but no sink is set, Outpost will fail to start.
+If `OPERATOR_EVENTS_TOPICS` is empty or unset, operator events are disabled. If topics are configured but no sink is set, Outpost will fail to start.
 
 ### Sinks
 
@@ -36,8 +36,8 @@ Configure exactly one sink to receive events. Four sink types are supported:
 Sends events as POST requests to a URL, signed with HMAC-SHA256.
 
 ```
-OPERATION_EVENTS_HTTP_URL=https://example.com/outpost-events
-OPERATION_EVENTS_HTTP_SIGNING_SECRET=your-secret
+OPERATOR_EVENTS_HTTP_URL=https://example.com/outpost-events
+OPERATOR_EVENTS_HTTP_SIGNING_SECRET=your-secret
 ```
 
 The HTTP sink signs each request body and sends the signature in the `X-Outpost-Signature` header:
@@ -57,31 +57,31 @@ assert signature_header == f"v0={expected}"
 #### AWS SQS
 
 ```
-OPERATION_EVENTS_AWS_SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789/outpost-events
-OPERATION_EVENTS_AWS_SQS_ACCESS_KEY_ID=AKIA...
-OPERATION_EVENTS_AWS_SQS_SECRET_ACCESS_KEY=...
-OPERATION_EVENTS_AWS_SQS_REGION=us-east-1
-OPERATION_EVENTS_AWS_SQS_ENDPOINT=          # optional, for local dev
+OPERATOR_EVENTS_AWS_SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789/outpost-events
+OPERATOR_EVENTS_AWS_SQS_ACCESS_KEY_ID=AKIA...
+OPERATOR_EVENTS_AWS_SQS_SECRET_ACCESS_KEY=...
+OPERATOR_EVENTS_AWS_SQS_REGION=us-east-1
+OPERATOR_EVENTS_AWS_SQS_ENDPOINT=          # optional, for local dev
 ```
 
 #### GCP Pub/Sub
 
 ```
-OPERATION_EVENTS_GCP_PUBSUB_PROJECT_ID=my-project
-OPERATION_EVENTS_GCP_PUBSUB_TOPIC_ID=outpost-events
-OPERATION_EVENTS_GCP_PUBSUB_CREDENTIALS={"type":"service_account",...}
+OPERATOR_EVENTS_GCP_PUBSUB_PROJECT_ID=my-project
+OPERATOR_EVENTS_GCP_PUBSUB_TOPIC_ID=outpost-events
+OPERATOR_EVENTS_GCP_PUBSUB_CREDENTIALS={"type":"service_account",...}
 ```
 
 #### RabbitMQ
 
 ```
-OPERATION_EVENTS_RABBITMQ_SERVER_URL=amqp://guest:guest@localhost:5672
-OPERATION_EVENTS_RABBITMQ_EXCHANGE=outpost-events
+OPERATOR_EVENTS_RABBITMQ_SERVER_URL=amqp://guest:guest@localhost:5672
+OPERATOR_EVENTS_RABBITMQ_EXCHANGE=outpost-events
 ```
 
 ## Event Envelope
 
-All operation events share a common envelope:
+All operator events share a common envelope:
 
 ```json
 {
@@ -185,7 +185,7 @@ Emitted when a destination is created, updated, deleted, disabled, or enabled, a
 
 ## Delivery Guarantees
 
-Operation events are delivered on a best-effort basis with up to 3 attempts. Consumers should use the `id` field for deduplication.
+Operator events are delivered on a best-effort basis with up to 3 attempts. Consumers should use the `id` field for deduplication.
 
 ## Related Configuration
 

--- a/docs/pages/guides/upgrade-v0.16.mdx
+++ b/docs/pages/guides/upgrade-v0.16.mdx
@@ -12,7 +12,7 @@ This guide covers breaking changes and migration steps when upgrading from v0.15
 | [Event `destination_id` replaced with `matched_destination_ids`](#event-destination_id-replaced-with-matched_destination_ids) | Event API responses and queries | Update code that reads `destination_id` from events to use `matched_destination_ids` |
 | [Delivery metadata timestamp format](#delivery-metadata-timestamp-format) | Consumers of delivery metadata `timestamp` field | Update timestamp parsing from Unix seconds to ISO 8601 |
 | [Response data body stored as raw string](#response-data-body-stored-as-raw-string) | Consumers of `response_data.body` | Update code that treats `response_data.body` as a parsed JSON object |
-| [Alert callbacks replaced by operation events](#alert-callbacks-replaced-by-operation-events) | Users of `ALERT_CALLBACK_URL` | Migrate to `OPERATION_EVENTS_*` config |
+| [Alert callbacks replaced by operator events](#alert-callbacks-replaced-by-operator-events) | Users of `ALERT_CALLBACK_URL` | Migrate to `OPERATOR_EVENTS_*` config |
 
 ## Webhook Signing Secret Prefix Changed
 
@@ -111,13 +111,13 @@ The `attempts.response_data` column is migrated from JSONB to TEXT (migration `0
 
 **Action:** Update any code that reads `response_data.body` as a structured object. If you need the parsed object, parse the string with `JSON.parse()` (or equivalent) on the client side.
 
-## Alert Callbacks Replaced by Operation Events
+## Alert Callbacks Replaced by Operator Events
 
-The `ALERT_CALLBACK_URL` config has been removed. Alert notifications are now handled by the new **operation events** system, which supports multiple sink types and additional event topics.
+The `ALERT_CALLBACK_URL` config has been removed. Alert notifications are now handled by the new **operator events** system, which supports multiple sink types and additional event topics.
 
 ### Migration
 
-If you were using `ALERT_CALLBACK_URL` to receive alert callbacks via HTTP, migrate to the operation events HTTP sink:
+If you were using `ALERT_CALLBACK_URL` to receive alert callbacks via HTTP, migrate to the operator events HTTP sink:
 
 **v0.15:**
 ```
@@ -126,24 +126,24 @@ ALERT_CALLBACK_URL=https://example.com/alerts
 
 **v0.16:**
 ```
-OPERATION_EVENTS_TOPICS=*
-OPERATION_EVENTS_HTTP_URL=https://example.com/alerts
-OPERATION_EVENTS_HTTP_SIGNING_SECRET=your-secret
+OPERATOR_EVENTS_TOPICS=*
+OPERATOR_EVENTS_HTTP_URL=https://example.com/alerts
+OPERATOR_EVENTS_HTTP_SIGNING_SECRET=your-secret
 ```
 
 The HTTP sink signs payloads with HMAC-SHA256 and sends the signature in the `X-Outpost-Signature` header (format: `v0=<hex>`).
 
 ### New sink options
 
-In addition to HTTP, operation events can be sent to:
+In addition to HTTP, operator events can be sent to:
 
-- **AWS SQS** — `OPERATION_EVENTS_AWS_SQS_QUEUE_URL`, `OPERATION_EVENTS_AWS_SQS_ACCESS_KEY_ID`, `OPERATION_EVENTS_AWS_SQS_SECRET_ACCESS_KEY`, `OPERATION_EVENTS_AWS_SQS_REGION`
-- **GCP Pub/Sub** — `OPERATION_EVENTS_GCP_PUBSUB_PROJECT_ID`, `OPERATION_EVENTS_GCP_PUBSUB_TOPIC_ID`, `OPERATION_EVENTS_GCP_PUBSUB_CREDENTIALS`
-- **RabbitMQ** — `OPERATION_EVENTS_RABBITMQ_SERVER_URL`, `OPERATION_EVENTS_RABBITMQ_EXCHANGE`
+- **AWS SQS** — `OPERATOR_EVENTS_AWS_SQS_QUEUE_URL`, `OPERATOR_EVENTS_AWS_SQS_ACCESS_KEY_ID`, `OPERATOR_EVENTS_AWS_SQS_SECRET_ACCESS_KEY`, `OPERATOR_EVENTS_AWS_SQS_REGION`
+- **GCP Pub/Sub** — `OPERATOR_EVENTS_GCP_PUBSUB_PROJECT_ID`, `OPERATOR_EVENTS_GCP_PUBSUB_TOPIC_ID`, `OPERATOR_EVENTS_GCP_PUBSUB_CREDENTIALS`
+- **RabbitMQ** — `OPERATOR_EVENTS_RABBITMQ_SERVER_URL`, `OPERATOR_EVENTS_RABBITMQ_EXCHANGE`
 
 ### Event topics
 
-Use `OPERATION_EVENTS_TOPICS=*` for all topics, or specify a comma-separated list:
+Use `OPERATOR_EVENTS_TOPICS=*` for all topics, or specify a comma-separated list:
 
 - `alert.destination.consecutive_failure` — emitted at 50%, 70%, 90%, and 100% failure thresholds
 - `alert.destination.disabled` — emitted when a destination is auto-disabled
@@ -185,7 +185,7 @@ You can now disable the webhook header prefix by setting it to whitespace (e.g.,
    - [ ] Update code that reads `event.destination_id` to use `event.matched_destination_ids`
    - [ ] Update any timestamp metadata parsing from Unix seconds to ISO 8601
    - [ ] Update code that reads `response_data.body` as a parsed object — it is now a raw string
-   - [ ] If using `ALERT_CALLBACK_URL`, migrate to `OPERATION_EVENTS_*` config
+   - [ ] If using `ALERT_CALLBACK_URL`, migrate to `OPERATOR_EVENTS_*` config
    - [ ] Review alert default changes (consecutive failure count: 20→100, auto-disable: true→false) and set explicitly if needed
    - [ ] Update SDK dependencies to the latest version
 

--- a/docs/zudoku.config.ts
+++ b/docs/zudoku.config.ts
@@ -114,7 +114,7 @@ const config: ZudokuConfig = {
           { type: "doc", id: "features/filter" },
           { type: "doc", id: "features/publish-events" },
           { type: "doc", id: "features/event-delivery" },
-          { type: "doc", id: "features/operation-events" },
+          { type: "doc", id: "features/operator-events" },
           { type: "doc", id: "features/tenant-user-portal" },
           { type: "doc", id: "features/opentelemetry" },
           { type: "doc", id: "features/logging" },

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// SubscriptionEmitter emits operation events for subscription changes.
+// SubscriptionEmitter emits operator events for subscription changes.
 // Satisfied by opevents.Emitter.
 type SubscriptionEmitter interface {
 	Emit(ctx context.Context, topic string, tenantID string, data any) error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,8 +105,8 @@ type Config struct {
 	// Alert
 	Alert AlertConfig `yaml:"alert"`
 
-	// Operation Events
-	OperationEvents OperationEventsConfig `yaml:"operation_events"`
+	// Operator Events
+	OperatorEvents OperatorEventsConfig `yaml:"operator_events"`
 
 	// ID Generation
 	IDGen IDGenConfig `yaml:"idgen"`
@@ -410,39 +410,39 @@ func (c *ClickHouseConfig) ToConfig() *clickhouse.ClickHouseConfig {
 	}
 }
 
-type OperationEventsConfig struct {
-	Topics    []string                      `yaml:"topics" env:"OPERATION_EVENTS_TOPICS" envSeparator:"," desc:"Comma-separated list of operation event topics to emit. Use '*' for all topics. If empty, operation events are disabled." required:"N"`
-	HTTP      OperationEventsHTTPConfig     `yaml:"http"`
-	AWSSQS    OperationEventsAWSSQSConfig   `yaml:"aws_sqs"`
-	GCPPubSub OperationEventsGCPConfig      `yaml:"gcp_pubsub"`
-	RabbitMQ  OperationEventsRabbitMQConfig `yaml:"rabbitmq"`
+type OperatorEventsConfig struct {
+	Topics    []string                     `yaml:"topics" env:"OPERATOR_EVENTS_TOPICS" envSeparator:"," desc:"Comma-separated list of operator event topics to emit. Use '*' for all topics. If empty, operator events are disabled." required:"N"`
+	HTTP      OperatorEventsHTTPConfig     `yaml:"http"`
+	AWSSQS    OperatorEventsAWSSQSConfig   `yaml:"aws_sqs"`
+	GCPPubSub OperatorEventsGCPConfig      `yaml:"gcp_pubsub"`
+	RabbitMQ  OperatorEventsRabbitMQConfig `yaml:"rabbitmq"`
 }
 
-type OperationEventsHTTPConfig struct {
-	URL           string `yaml:"url" env:"OPERATION_EVENTS_HTTP_URL" desc:"URL to POST operation events to." required:"N"`
-	SigningSecret string `yaml:"signing_secret" env:"OPERATION_EVENTS_HTTP_SIGNING_SECRET" desc:"HMAC-SHA256 signing secret for operation event payloads." required:"N"`
+type OperatorEventsHTTPConfig struct {
+	URL           string `yaml:"url" env:"OPERATOR_EVENTS_HTTP_URL" desc:"URL to POST operator events to." required:"N"`
+	SigningSecret string `yaml:"signing_secret" env:"OPERATOR_EVENTS_HTTP_SIGNING_SECRET" desc:"HMAC-SHA256 signing secret for operator event payloads." required:"N"`
 }
 
-type OperationEventsAWSSQSConfig struct {
-	QueueURL        string `yaml:"queue_url" env:"OPERATION_EVENTS_AWS_SQS_QUEUE_URL" desc:"AWS SQS queue URL for operation events." required:"N"`
-	AccessKeyID     string `yaml:"access_key_id" env:"OPERATION_EVENTS_AWS_SQS_ACCESS_KEY_ID" desc:"AWS access key ID for SQS operation events sink." required:"N"`
-	SecretAccessKey string `yaml:"secret_access_key" env:"OPERATION_EVENTS_AWS_SQS_SECRET_ACCESS_KEY" desc:"AWS secret access key for SQS operation events sink." required:"N"`
-	Region          string `yaml:"region" env:"OPERATION_EVENTS_AWS_SQS_REGION" desc:"AWS region for SQS operation events sink." required:"N"`
-	Endpoint        string `yaml:"endpoint" env:"OPERATION_EVENTS_AWS_SQS_ENDPOINT" desc:"Custom AWS SQS endpoint for operation events. Optional, for local development." required:"N"`
+type OperatorEventsAWSSQSConfig struct {
+	QueueURL        string `yaml:"queue_url" env:"OPERATOR_EVENTS_AWS_SQS_QUEUE_URL" desc:"AWS SQS queue URL for operator events." required:"N"`
+	AccessKeyID     string `yaml:"access_key_id" env:"OPERATOR_EVENTS_AWS_SQS_ACCESS_KEY_ID" desc:"AWS access key ID for SQS operator events sink." required:"N"`
+	SecretAccessKey string `yaml:"secret_access_key" env:"OPERATOR_EVENTS_AWS_SQS_SECRET_ACCESS_KEY" desc:"AWS secret access key for SQS operator events sink." required:"N"`
+	Region          string `yaml:"region" env:"OPERATOR_EVENTS_AWS_SQS_REGION" desc:"AWS region for SQS operator events sink." required:"N"`
+	Endpoint        string `yaml:"endpoint" env:"OPERATOR_EVENTS_AWS_SQS_ENDPOINT" desc:"Custom AWS SQS endpoint for operator events. Optional, for local development." required:"N"`
 }
 
-type OperationEventsGCPConfig struct {
-	ProjectID   string `yaml:"project_id" env:"OPERATION_EVENTS_GCP_PUBSUB_PROJECT_ID" desc:"GCP project ID for Pub/Sub operation events sink." required:"N"`
-	TopicID     string `yaml:"topic_id" env:"OPERATION_EVENTS_GCP_PUBSUB_TOPIC_ID" desc:"GCP Pub/Sub topic ID for operation events." required:"N"`
-	Credentials string `yaml:"credentials" env:"OPERATION_EVENTS_GCP_PUBSUB_CREDENTIALS" desc:"GCP service account credentials JSON for Pub/Sub operation events sink." required:"N"`
+type OperatorEventsGCPConfig struct {
+	ProjectID   string `yaml:"project_id" env:"OPERATOR_EVENTS_GCP_PUBSUB_PROJECT_ID" desc:"GCP project ID for Pub/Sub operator events sink." required:"N"`
+	TopicID     string `yaml:"topic_id" env:"OPERATOR_EVENTS_GCP_PUBSUB_TOPIC_ID" desc:"GCP Pub/Sub topic ID for operator events." required:"N"`
+	Credentials string `yaml:"credentials" env:"OPERATOR_EVENTS_GCP_PUBSUB_CREDENTIALS" desc:"GCP service account credentials JSON for Pub/Sub operator events sink." required:"N"`
 }
 
-type OperationEventsRabbitMQConfig struct {
-	ServerURL string `yaml:"server_url" env:"OPERATION_EVENTS_RABBITMQ_SERVER_URL" desc:"RabbitMQ server URL for operation events sink." required:"N"`
-	Exchange  string `yaml:"exchange" env:"OPERATION_EVENTS_RABBITMQ_EXCHANGE" desc:"RabbitMQ exchange for operation events." required:"N"`
+type OperatorEventsRabbitMQConfig struct {
+	ServerURL string `yaml:"server_url" env:"OPERATOR_EVENTS_RABBITMQ_SERVER_URL" desc:"RabbitMQ server URL for operator events sink." required:"N"`
+	Exchange  string `yaml:"exchange" env:"OPERATOR_EVENTS_RABBITMQ_EXCHANGE" desc:"RabbitMQ exchange for operator events." required:"N"`
 }
 
-func (c *OperationEventsConfig) ToConfig() opevents.Config {
+func (c *OperatorEventsConfig) ToConfig() opevents.Config {
 	cfg := opevents.Config{
 		Topics: c.Topics,
 	}

--- a/internal/opevents/config.go
+++ b/internal/opevents/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hookdeck/outpost/internal/mqs"
 )
 
-// Config holds the configuration for the operation events system.
+// Config holds the configuration for the operator events system.
 // yaml/env tags live in internal/config; this is the domain-level struct.
 type Config struct {
 	Topics []string

--- a/internal/opevents/emitter.go
+++ b/internal/opevents/emitter.go
@@ -15,7 +15,7 @@ const (
 	backoffFactor = 2
 )
 
-// Emitter is the interface for emitting operation events.
+// Emitter is the interface for emitting operator events.
 type Emitter interface {
 	Emit(ctx context.Context, topic string, tenantID string, data any) error
 }
@@ -65,7 +65,7 @@ func (e *emitter) Emit(ctx context.Context, topic string, tenantID string, data 
 		return fmt.Errorf("opevents: failed to marshal data: %w", err)
 	}
 
-	event := &OperationEvent{
+	event := &OperatorEvent{
 		ID:           idgen.String(),
 		Topic:        topic,
 		Time:         time.Now(),
@@ -77,7 +77,7 @@ func (e *emitter) Emit(ctx context.Context, topic string, tenantID string, data 
 	return e.sendWithRetry(ctx, event)
 }
 
-func (e *emitter) sendWithRetry(ctx context.Context, event *OperationEvent) error {
+func (e *emitter) sendWithRetry(ctx context.Context, event *OperatorEvent) error {
 	delay := initialDelay
 	var lastErr error
 
@@ -101,7 +101,7 @@ func (e *emitter) sendWithRetry(ctx context.Context, event *OperationEvent) erro
 	return fmt.Errorf("opevents: send failed after %d attempts: %w", maxRetries, lastErr)
 }
 
-// noopEmitter discards all events. Used when operation events are disabled.
+// noopEmitter discards all events. Used when operator events are disabled.
 type noopEmitter struct{}
 
 func (e *noopEmitter) Emit(ctx context.Context, topic string, tenantID string, data any) error {

--- a/internal/opevents/emitter_test.go
+++ b/internal/opevents/emitter_test.go
@@ -15,7 +15,7 @@ import (
 // mockSink records events sent to it and can be configured to fail.
 type mockSink struct {
 	mu     sync.Mutex
-	events []*opevents.OperationEvent
+	events []*opevents.OperatorEvent
 	errs   []error // errors to return in order; nil entries mean success
 	calls  int
 }
@@ -23,7 +23,7 @@ type mockSink struct {
 func (s *mockSink) Init(ctx context.Context) error { return nil }
 func (s *mockSink) Close() error                   { return nil }
 
-func (s *mockSink) Send(ctx context.Context, event *opevents.OperationEvent) error {
+func (s *mockSink) Send(ctx context.Context, event *opevents.OperatorEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -37,10 +37,10 @@ func (s *mockSink) Send(ctx context.Context, event *opevents.OperationEvent) err
 	return nil
 }
 
-func (s *mockSink) sentEvents() []*opevents.OperationEvent {
+func (s *mockSink) sentEvents() []*opevents.OperatorEvent {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]*opevents.OperationEvent(nil), s.events...)
+	return append([]*opevents.OperatorEvent(nil), s.events...)
 }
 
 func TestEmitter_Emit(t *testing.T) {

--- a/internal/opevents/event.go
+++ b/internal/opevents/event.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Topic constants for operation events.
+// Topic constants for operator events.
 const (
 	TopicAlertConsecutiveFailure   = "alert.destination.consecutive_failure"
 	TopicAlertDestinationDisabled  = "alert.destination.disabled"
@@ -13,8 +13,8 @@ const (
 	TopicTenantSubscriptionUpdated = "tenant.subscription.updated"
 )
 
-// OperationEvent is the envelope for all operation events emitted by Outpost.
-type OperationEvent struct {
+// OperatorEvent is the envelope for all operator events emitted by Outpost.
+type OperatorEvent struct {
 	ID           string          `json:"id"`
 	Topic        string          `json:"topic"`
 	Time         time.Time       `json:"time"`

--- a/internal/opevents/sink.go
+++ b/internal/opevents/sink.go
@@ -2,9 +2,9 @@ package opevents
 
 import "context"
 
-// Sink is the interface for delivering operation events to an external system.
+// Sink is the interface for delivering operator events to an external system.
 type Sink interface {
 	Init(ctx context.Context) error
-	Send(ctx context.Context, event *OperationEvent) error
+	Send(ctx context.Context, event *OperatorEvent) error
 	Close() error
 }

--- a/internal/opevents/sink_http.go
+++ b/internal/opevents/sink_http.go
@@ -15,7 +15,7 @@ import (
 
 const signatureHeader = "X-Outpost-Signature"
 
-// HTTPSink sends operation events via HTTP POST with optional HMAC-SHA256 signing.
+// HTTPSink sends operator events via HTTP POST with optional HMAC-SHA256 signing.
 type HTTPSink struct {
 	url           string
 	signingSecret string
@@ -36,7 +36,7 @@ func NewHTTPSink(url, signingSecret string) *HTTPSink {
 func (s *HTTPSink) Init(ctx context.Context) error { return nil }
 func (s *HTTPSink) Close() error                   { return nil }
 
-func (s *HTTPSink) Send(ctx context.Context, event *OperationEvent) error {
+func (s *HTTPSink) Send(ctx context.Context, event *OperatorEvent) error {
 	body, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("opevents: failed to marshal event: %w", err)

--- a/internal/opevents/sink_http_test.go
+++ b/internal/opevents/sink_http_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testEvent() *opevents.OperationEvent {
-	return &opevents.OperationEvent{
+func testEvent() *opevents.OperatorEvent {
+	return &opevents.OperatorEvent{
 		ID:       "evt-1",
 		Topic:    opevents.TopicAlertConsecutiveFailure,
 		Time:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -54,7 +54,7 @@ func TestHTTPSink_Send(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify body is valid event JSON
-		var got opevents.OperationEvent
+		var got opevents.OperatorEvent
 		require.NoError(t, json.Unmarshal(receivedBody, &got))
 		assert.Equal(t, event.ID, got.ID)
 		assert.Equal(t, event.Topic, got.Topic)

--- a/internal/opevents/sink_mq.go
+++ b/internal/opevents/sink_mq.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hookdeck/outpost/internal/mqs"
 )
 
-// MQSink sends operation events to a message queue via mqs.Queue.
+// MQSink sends operator events to a message queue via mqs.Queue.
 type MQSink struct {
 	queue     mqs.Queue
 	cleanupFn func()
@@ -28,7 +28,7 @@ func (s *MQSink) Init(ctx context.Context) error {
 	return nil
 }
 
-func (s *MQSink) Send(ctx context.Context, event *OperationEvent) error {
+func (s *MQSink) Send(ctx context.Context, event *OperatorEvent) error {
 	data, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("opevents: failed to marshal event: %w", err)
@@ -47,7 +47,7 @@ func (s *MQSink) Close() error {
 	return nil
 }
 
-// eventMessage adapts a serialized OperationEvent to mqs.IncomingMessage.
+// eventMessage adapts a serialized OperatorEvent to mqs.IncomingMessage.
 type eventMessage struct {
 	data []byte
 }

--- a/internal/opevents/sink_mq_test.go
+++ b/internal/opevents/sink_mq_test.go
@@ -41,7 +41,7 @@ func TestMQSink_Send(t *testing.T) {
 
 		msg.Ack()
 
-		var got opevents.OperationEvent
+		var got opevents.OperatorEvent
 		require.NoError(t, json.Unmarshal(msg.Body, &got))
 		assert.Equal(t, event.ID, got.ID)
 		assert.Equal(t, event.Topic, got.Topic)

--- a/internal/opevents/sink_noop.go
+++ b/internal/opevents/sink_noop.go
@@ -6,5 +6,5 @@ import "context"
 type NoopSink struct{}
 
 func (s *NoopSink) Init(ctx context.Context) error                        { return nil }
-func (s *NoopSink) Send(ctx context.Context, event *OperationEvent) error { return nil }
+func (s *NoopSink) Send(ctx context.Context, event *OperatorEvent) error  { return nil }
 func (s *NoopSink) Close() error                                          { return nil }

--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -191,11 +191,11 @@ func (b *ServiceBuilder) BuildAPIWorkers(baseRouter *gin.Engine) error {
 	)
 	eventHandler := publishmq.NewEventHandler(b.logger, svc.deliveryMQ, svc.tenantStore, svc.eventTracer, b.cfg.Topics, publishIdempotence)
 
-	// Create operation events emitter for subscription updates
-	oeCfg := b.cfg.OperationEvents.ToConfig()
+	// Create operator events emitter for subscription updates
+	oeCfg := b.cfg.OperatorEvents.ToConfig()
 	oeSink, err := opevents.NewSink(oeCfg)
 	if err != nil {
-		return fmt.Errorf("failed to create operation events sink: %w", err)
+		return fmt.Errorf("failed to create operator events sink: %w", err)
 	}
 	subscriptionEmitter := opevents.NewEmitter(oeSink, b.cfg.DeploymentID, oeCfg.Topics)
 
@@ -343,11 +343,11 @@ func (b *ServiceBuilder) BuildLogWorker(baseRouter *gin.Engine) error {
 		return err
 	}
 
-	// Initialize alert monitor for operation events
-	oeCfg := b.cfg.OperationEvents.ToConfig()
+	// Initialize alert monitor for operator events
+	oeCfg := b.cfg.OperatorEvents.ToConfig()
 	sink, err := opevents.NewSink(oeCfg)
 	if err != nil {
-		return fmt.Errorf("failed to create operation events sink: %w", err)
+		return fmt.Errorf("failed to create operator events sink: %w", err)
 	}
 	emitter := opevents.NewEmitter(sink, b.cfg.DeploymentID, oeCfg.Topics)
 


### PR DESCRIPTION
## Summary
- Renames the v0.16 feature `operation events` → `operator events` throughout config, code, tests, and docs
- Public surface changes: env var prefix `OPERATION_EVENTS_*` → `OPERATOR_EVENTS_*`, yaml key `operation_events` → `operator_events`, Go field/types `OperationEvents*Config` → `OperatorEvents*Config`, envelope struct `OperationEvent` → `OperatorEvent`
- v0.16 has not been published yet, so no deprecation shim / alias is included

## Unchanged on purpose
- Go package name `opevents` and error prefix `opevents:` — the `op` abbreviation covers both terms and keeping it avoids import-path churn across 15+ files
- `/opevents` HTTP path and `cmd/e2e/opevents` mock package — internal test scaffolding, not user-facing
- Redis suppression key prefix `opevents:exhausted:*` — state at rest; renaming would orphan in-flight exhausted_retries suppression windows on upgrade and cause duplicate alerts
- Topic string constants (`alert.destination.consecutive_failure`, etc.)

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/opevents/... ./internal/config/... ./internal/alert/... ./internal/apirouter/...` — all pass
- [x] `go test -count=1 -run NONE ./cmd/e2e/... ./internal/...` — all tests compile
- [ ] Full e2e suite run in CI
- [ ] Docs preview: verify `features/operator-events` page + sidebar link + cross-link from `event-delivery`

🤖 Generated with [Claude Code](https://claude.com/claude-code)