### PR TITLE
fix(destregistry): handle publisher creation errors as delivery failures

### DIFF
--- a/internal/destregistry/providers/destgcppubsub/destgcppubsub.go
+++ b/internal/destregistry/providers/destgcppubsub/destgcppubsub.go
@@ -53,7 +53,10 @@ func (d *GCPPubSubDestination) Validate(ctx context.Context, destination *models
 func (d *GCPPubSubDestination) CreatePublisher(ctx context.Context, destination *models.Destination) (destregistry.Publisher, error) {
 	cfg, creds, err := d.resolveMetadata(ctx, destination)
 	if err != nil {
-		return nil, err
+		return nil, destregistry.NewErrDestinationPublishAttempt(err, "gcp_pubsub", map[string]interface{}{
+			"error":   "validation_failed",
+			"message": err.Error(),
+		})
 	}
 
 	// Create Pub/Sub client options
@@ -74,7 +77,10 @@ func (d *GCPPubSubDestination) CreatePublisher(ctx context.Context, destination 
 	// Create the client
 	client, err := pubsub.NewClient(ctx, cfg.ProjectID, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Pub/Sub client: %w", err)
+		return nil, destregistry.NewErrDestinationPublishAttempt(err, "gcp_pubsub", map[string]interface{}{
+			"error":   "client_creation_failed",
+			"message": err.Error(),
+		})
 	}
 
 	// Get the topic
@@ -105,6 +111,15 @@ func (d *GCPPubSubDestination) resolveMetadata(ctx context.Context, destination 
 				{
 					Field: "credentials.service_account_json",
 					Type:  "format",
+				},
+			})
+		}
+		// Validate required GCP credential fields
+		if _, ok := jsonCheck["type"]; !ok {
+			return nil, nil, destregistry.NewErrDestinationValidation([]destregistry.ValidationErrorDetail{
+				{
+					Field: "credentials.service_account_json",
+					Type:  "missing_type",
 				},
 			})
 		}

--- a/internal/destregistry/providers/destgcppubsub/destgcppubsub_test.go
+++ b/internal/destregistry/providers/destgcppubsub/destgcppubsub_test.go
@@ -180,6 +180,30 @@ func TestValidate(t *testing.T) {
 			wantErr: false, // Emulator doesn't require valid JSON
 		},
 		{
+			name: "missing type field in service_account_json",
+			config: map[string]string{
+				"project_id": "my-project",
+				"topic":      "my-topic",
+			},
+			credentials: map[string]string{
+				"service_account_json": `{"project_id":"my-project","client_email":"test@test.iam.gserviceaccount.com"}`,
+			},
+			wantErr:     true,
+			errContains: "credentials.service_account_json",
+		},
+		{
+			name: "missing type field - but passes with emulator endpoint",
+			config: map[string]string{
+				"project_id": "my-project",
+				"topic":      "my-topic",
+				"endpoint":   "http://localhost:8085",
+			},
+			credentials: map[string]string{
+				"service_account_json": `{"project_id":"my-project"}`,
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid service account JSON with complete structure",
 			config: map[string]string{
 				"project_id": "my-project",

--- a/internal/destregistry/registry.go
+++ b/internal/destregistry/registry.go
@@ -138,6 +138,30 @@ func (r *registry) ValidateDestination(ctx context.Context, destination *models.
 func (r *registry) PublishEvent(ctx context.Context, destination *models.Destination, event *models.Event) (*models.Attempt, error) {
 	publisher, err := r.ResolvePublisher(ctx, destination)
 	if err != nil {
+		// If the provider already signaled a delivery error, create a failed attempt
+		// so it's visible to the customer (instead of silently nacking into DLQ).
+		var pubErr *ErrDestinationPublishAttempt
+		var valErr *ErrDestinationValidation
+		if errors.As(err, &pubErr) || errors.As(err, &valErr) {
+			attempt := &models.Attempt{
+				ID:              idgen.Attempt(),
+				DestinationID:   destination.ID,
+				DestinationType: destination.Type,
+				EventID:         event.ID,
+				Time:            time.Now(),
+				Status:          "failed",
+				Code:            "ERR",
+				ResponseData:    map[string]interface{}{"error": err.Error()},
+			}
+			if pubErr != nil {
+				return attempt, pubErr
+			}
+			return attempt, &ErrDestinationPublishAttempt{
+				Err:      err,
+				Provider: destination.Type,
+				Data:     map[string]interface{}{"error": "validation_failed", "message": err.Error()},
+			}
+		}
 		return nil, err
 	}
 

--- a/internal/destregistry/registry_test.go
+++ b/internal/destregistry/registry_test.go
@@ -773,6 +773,120 @@ func TestPublishEventCanceled(t *testing.T) {
 	})
 }
 
+func TestPublishEventResolvePublisherError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return failed attempt when CreatePublisher returns ErrDestinationPublishAttempt", func(t *testing.T) {
+		t.Parallel()
+
+		registry := destregistry.NewRegistry(&destregistry.Config{}, testutil.CreateTestLogger(t))
+
+		provider := &mockFailingProvider{
+			createErr: destregistry.NewErrDestinationPublishAttempt(
+				errors.New("missing 'type' field in credentials"),
+				"gcp_pubsub",
+				map[string]interface{}{"error": "client_creation_failed", "message": "missing 'type' field in credentials"},
+			),
+		}
+		err := registry.RegisterProvider("gcp_pubsub", provider)
+		require.NoError(t, err)
+
+		destination := &models.Destination{ID: "dest-1", Type: "gcp_pubsub"}
+		event := &models.Event{ID: "evt-1"}
+
+		attempt, err := registry.PublishEvent(context.Background(), destination, event)
+
+		require.Error(t, err)
+		require.NotNil(t, attempt, "should return a failed attempt, not nil")
+		assert.Equal(t, "failed", attempt.Status)
+		assert.Equal(t, "ERR", attempt.Code)
+		assert.Equal(t, "dest-1", attempt.DestinationID)
+		assert.Equal(t, "evt-1", attempt.EventID)
+
+		var pubErr *destregistry.ErrDestinationPublishAttempt
+		require.ErrorAs(t, err, &pubErr)
+		assert.Equal(t, "client_creation_failed", pubErr.Data["error"])
+	})
+
+	t.Run("should return failed attempt when CreatePublisher returns ErrDestinationValidation", func(t *testing.T) {
+		t.Parallel()
+
+		registry := destregistry.NewRegistry(&destregistry.Config{}, testutil.CreateTestLogger(t))
+
+		provider := &mockFailingProvider{
+			createErr: destregistry.NewErrDestinationValidation([]destregistry.ValidationErrorDetail{
+				{Field: "credentials.service_account_json", Type: "missing_type"},
+			}),
+		}
+		err := registry.RegisterProvider("gcp_pubsub", provider)
+		require.NoError(t, err)
+
+		destination := &models.Destination{ID: "dest-2", Type: "gcp_pubsub"}
+		event := &models.Event{ID: "evt-2"}
+
+		attempt, err := registry.PublishEvent(context.Background(), destination, event)
+
+		require.Error(t, err)
+		require.NotNil(t, attempt, "should return a failed attempt, not nil")
+		assert.Equal(t, "failed", attempt.Status)
+		assert.Equal(t, "ERR", attempt.Code)
+
+		var pubErr *destregistry.ErrDestinationPublishAttempt
+		require.ErrorAs(t, err, &pubErr)
+		assert.Equal(t, "validation_failed", pubErr.Data["error"])
+	})
+
+	t.Run("should return nil attempt for unknown errors", func(t *testing.T) {
+		t.Parallel()
+
+		registry := destregistry.NewRegistry(&destregistry.Config{}, testutil.CreateTestLogger(t))
+
+		provider := &mockFailingProvider{
+			createErr: errors.New("unexpected system error"),
+		}
+		err := registry.RegisterProvider("gcp_pubsub", provider)
+		require.NoError(t, err)
+
+		destination := &models.Destination{ID: "dest-3", Type: "gcp_pubsub"}
+		event := &models.Event{ID: "evt-3"}
+
+		attempt, err := registry.PublishEvent(context.Background(), destination, event)
+
+		require.Error(t, err)
+		assert.Nil(t, attempt, "should return nil attempt for unknown errors")
+	})
+}
+
+// mockFailingProvider simulates a provider whose CreatePublisher always fails
+type mockFailingProvider struct {
+	createErr error
+	*destregistry.BaseProvider
+}
+
+func (p *mockFailingProvider) Validate(ctx context.Context, dest *models.Destination) error {
+	return nil
+}
+
+func (p *mockFailingProvider) CreatePublisher(ctx context.Context, dest *models.Destination) (destregistry.Publisher, error) {
+	return nil, p.createErr
+}
+
+func (p *mockFailingProvider) ComputeTarget(dest *models.Destination) destregistry.DestinationTarget {
+	return destregistry.DestinationTarget{}
+}
+
+func (p *mockFailingProvider) Metadata() *metadata.ProviderMetadata {
+	return &metadata.ProviderMetadata{Type: "gcp_pubsub"}
+}
+
+func (p *mockFailingProvider) ObfuscateDestination(dest *models.Destination) *models.Destination {
+	return dest
+}
+
+func (p *mockFailingProvider) Preprocess(newDest *models.Destination, origDest *models.Destination, opts *destregistry.PreprocessDestinationOpts) error {
+	return nil
+}
+
 func TestDisplayDestination(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- When `CreatePublisher` fails (e.g. invalid GCP service account credentials missing the `type` field), the error was wrapped as a `PreDeliveryError` which caused a nack → retry loop until messages exhausted Pub/Sub max delivery attempts and landed in the DLQ — completely invisible to the customer
- Root cause: a customer configured a GCP Pub/Sub destination with invalid `service_account_json` (valid JSON but missing required GCP fields). The delivery worker couldn't create a Pub/Sub client, nacked every attempt, and the events silently went to DLQ after 6 retries
- Events were successfully delivered to the customer's other 3 destinations — only the misconfigured GCP Pub/Sub destination was affected

## Changes

**`destgcppubsub.go`** — Destination-level fixes:
- `CreatePublisher` now returns `ErrDestinationPublishAttempt` (instead of plain errors) for both `resolveMetadata` failures (`validation_failed`) and `pubsub.NewClient` failures (`client_creation_failed`), signaling to the registry that these are delivery errors
- `resolveMetadata` now validates that `service_account_json` contains the required `type` field, catching invalid credentials at destination creation time

**`registry.go`** — Registry-level safety net:
- `PublishEvent` now checks for `ErrDestinationPublishAttempt` and `ErrDestinationValidation` from `ResolvePublisher` and creates a failed attempt record instead of returning `nil` — this ensures the error flows through the `AttemptError` path (logged to ClickHouse, visible in dashboard, retry-scheduled then acked) instead of the `PreDeliveryError` path (nack → DLQ)

## Error flow before

```
CreatePublisher fails → plain error
  → ResolvePublisher returns (nil, err)
  → PublishEvent returns (nil, err)
  → doHandle sees nil attempt → PreDeliveryError
  → shouldNackError → nack → Pub/Sub retries 6x → DLQ
```

## Error flow after

```
CreatePublisher fails → ErrDestinationPublishAttempt
  → ResolvePublisher returns (nil, err)
  → PublishEvent detects ErrDestinationPublishAttempt → creates failed Attempt
  → doHandle sees non-nil attempt → AttemptError
  → logged to ClickHouse → retry scheduling → ack
  → customer sees failed attempt in dashboard
```

## Test plan

- [x] New validation test: `missing type field in service_account_json` — rejects at `Validate()` time
- [x] New validation test: `missing type field - but passes with emulator endpoint` — emulator skips credential validation
- [x] New registry test: `CreatePublisher` returning `ErrDestinationPublishAttempt` → failed attempt returned
- [x] New registry test: `CreatePublisher` returning `ErrDestinationValidation` → failed attempt returned
- [x] New registry test: `CreatePublisher` returning unknown error → nil attempt (existing behavior preserved)
- [x] All existing destregistry and deliverymq tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)