### PR TITLE
fix(e2e): apply migrations before starting app in tests

### DIFF
--- a/cmd/e2e/configs/migrate.go
+++ b/cmd/e2e/configs/migrate.go
@@ -1,0 +1,64 @@
+package configs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/config"
+	"github.com/hookdeck/outpost/internal/logging"
+	"github.com/hookdeck/outpost/internal/migrator"
+	"github.com/hookdeck/outpost/internal/migrator/coordinator"
+	"github.com/hookdeck/outpost/internal/migrator/migrations"
+	"github.com/hookdeck/outpost/internal/redis"
+)
+
+// ApplyMigrations runs all pending SQL and Redis migrations for the given
+// config. E2E tests must call this before starting the app, since the app
+// refuses to start when migrations are pending.
+func ApplyMigrations(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	ctx := context.Background()
+
+	logger, err := logging.NewLogger(logging.WithLogLevel("warn"))
+	if err != nil {
+		t.Fatalf("create logger for migrations: %v", err)
+	}
+
+	// SQL migrator
+	opts := cfg.ToMigratorOpts()
+	var sqlMigrator *migrator.Migrator
+	if opts.PG.URL != "" || opts.CH.Addr != "" {
+		m, err := migrator.New(opts)
+		if err != nil {
+			t.Fatalf("create sql migrator: %v", err)
+		}
+		defer func() {
+			if sourceErr, dbErr := m.Close(ctx); sourceErr != nil || dbErr != nil {
+				t.Logf("close sql migrator: source=%v db=%v", sourceErr, dbErr)
+			}
+		}()
+		sqlMigrator = m
+	}
+
+	// Redis client
+	redisClient, err := redis.New(ctx, cfg.Redis.ToConfig())
+	if err != nil {
+		t.Fatalf("create redis client for migrations: %v", err)
+	}
+
+	redisMigrations := migrations.AllRedisMigrationsWithLogging(
+		redisClient, logger, false, cfg.DeploymentID,
+	)
+
+	coord := coordinator.New(coordinator.Config{
+		SQLMigrator:     sqlMigrator,
+		RedisClient:     redisClient,
+		RedisMigrations: redisMigrations,
+		DeploymentID:    cfg.DeploymentID,
+		Logger:          logger,
+	})
+
+	if err := coord.Apply(ctx, coordinator.ApplyOptions{}); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+}

--- a/cmd/e2e/regressions_test.go
+++ b/cmd/e2e/regressions_test.go
@@ -94,6 +94,7 @@ func TestE2E_Regression_AutoDisableWithoutCallbackURL(t *testing.T) {
 	cfg.Alert.ConsecutiveFailureCount = 20
 
 	require.NoError(t, cfg.Validate(config.Flags{}))
+	configs.ApplyMigrations(t, &cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -228,6 +229,7 @@ func TestE2E_ManualRetryScheduleInteraction(t *testing.T) {
 	cfg.LogBatchThresholdSeconds = 0 // Immediate flush so logstore queries work
 
 	require.NoError(t, cfg.Validate(config.Flags{}))
+	configs.ApplyMigrations(t, &cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -412,6 +414,7 @@ func TestE2E_Regression_RetryRaceCondition(t *testing.T) {
 	cfg.RetryVisibilityTimeoutSeconds = 2
 
 	require.NoError(t, cfg.Validate(config.Flags{}))
+	configs.ApplyMigrations(t, &cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/e2e/suites_test.go
+++ b/cmd/e2e/suites_test.go
@@ -111,6 +111,8 @@ func (suite *basicSuite) SetupSuite() {
 
 	require.NoError(t, cfg.Validate(config.Flags{}))
 
+	configs.ApplyMigrations(t, &cfg)
+
 	suite.e2eSuite = e2eSuite{
 		config:            cfg,
 		mockServerBaseURL: mockServerBaseURL,


### PR DESCRIPTION
## Summary
- The unified migration CLI (#816) added a startup gate that refuses to start when migrations are pending
- E2e tests create fresh databases but never applied migrations, so all e2e tests fail
- Added `configs.ApplyMigrations()` helper that runs the coordinator's `Apply()` before app startup in all e2e tests

## Test plan
- [x] `make test/e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)