### PR TITLE
docs: add v0.17 upgrade guide and update migration docs

### DIFF
--- a/docs/content/nav.json
+++ b/docs/content/nav.json
@@ -216,6 +216,10 @@
             {
               "slug": "self-hosting/upgrade-v0.16",
               "title": "Upgrade to v0.16"
+            },
+            {
+              "slug": "self-hosting/changelog/upgrade-v0.17",
+              "title": "Upgrade to v0.17"
             }
           ]
         ]

--- a/docs/content/self-hosting/changelog/upgrade-v0.17.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v0.17.mdoc
@@ -1,0 +1,112 @@
+---
+title: "Upgrade to v0.17"
+description: "Breaking changes and migration steps for upgrading Outpost from v0.16 to v0.17."
+---
+
+This guide covers breaking changes and migration steps when upgrading from v0.16 to v0.17.
+
+## Breaking Changes Overview
+
+| Change | Impact | Action Required |
+| --- | --- | --- |
+| [Migrations no longer auto-apply at startup](#migrations-no-longer-auto-apply-at-startup) | Deployment workflows | Run `outpost migrate apply --yes` before `outpost serve` |
+
+## Migrations No Longer Auto-Apply at Startup
+
+Starting in v0.17, the Outpost server **refuses to start** if there are pending database migrations. Previously, migrations were applied automatically during startup.
+
+To keep Outpost up to date, the recommendation is to run `outpost migrate apply --yes` before starting the server. This applies all pending SQL and Redis migrations. It is safe to run on every startup, including the very first one — on a fresh database it applies the initial schema, and on subsequent starts with no pending migrations it exits immediately.
+
+:::note
+`outpost migrate apply` mutates your database. If you prefer to review changes before applying, use `outpost migrate plan` to see what would run, then `outpost migrate apply` interactively (without `--yes`) for a confirmation prompt.
+:::
+
+### Recommended deployment flow
+
+The simplest approach is to always run migrations before starting the server:
+
+```bash
+outpost migrate apply --yes
+outpost serve
+```
+
+How you integrate this depends on your deployment setup. Below are some common patterns.
+
+### Docker Compose
+
+Use a `migrate` service that runs before the main service:
+
+```yaml
+services:
+  outpost-migrate:
+    image: hookdeck/outpost
+    command: ["migrate", "apply", "--yes"]
+    env_file: .env
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  outpost:
+    image: hookdeck/outpost
+    command: ["serve"]
+    env_file: .env
+    depends_on:
+      outpost-migrate:
+        condition: service_completed_successfully
+```
+
+### Kubernetes
+
+Use an init container on the Outpost deployment:
+
+```yaml
+spec:
+  initContainers:
+    - name: migrate
+      image: hookdeck/outpost
+      command: ["outpost", "migrate", "apply", "--yes"]
+      envFrom:
+        - secretRef:
+            name: outpost-config
+  containers:
+    - name: outpost
+      image: hookdeck/outpost
+      command: ["outpost", "serve"]
+      envFrom:
+        - secretRef:
+            name: outpost-config
+```
+
+Alternatively, run migrations as a separate Kubernetes Job before rolling out the new version.
+
+### CI/CD pipeline
+
+Add a migration step before deploying the new version:
+
+```bash
+# 1. Run migrations against production databases
+docker run --rm --env-file .env \
+  hookdeck/outpost migrate apply --yes
+
+# 2. Deploy the new version
+# (your deploy command here)
+```
+
+### Other approaches
+
+The examples above are recommendations — run migrations however fits your infrastructure. The only requirement is that `outpost migrate apply` completes before `outpost serve` starts. Some teams prefer a wrapper script in their entrypoint, others run it as a pre-deploy hook. Any approach works as long as migrations finish first.
+
+## Upgrade Checklist
+
+1. **Before upgrading:**
+   - [ ] Update your deployment workflow to run `outpost migrate apply --yes` before `outpost serve`
+   - [ ] If you run multiple Outpost replicas, ensure only one instance runs migrations at a time (the migration tool uses distributed locks, but running it from a single place is simpler)
+
+2. **Upgrade:**
+   - [ ] Update Outpost to v0.17
+   - [ ] Run `outpost migrate apply --yes`
+   - [ ] Start Outpost with `outpost serve`
+
+3. **After upgrading:**
+   - [ ] Verify Outpost starts without migration errors
+   - [ ] Optionally run `outpost migrate verify` to confirm migration state

--- a/docs/content/self-hosting/guides/migration.mdoc
+++ b/docs/content/self-hosting/guides/migration.mdoc
@@ -5,7 +5,7 @@ description: "Plan, apply, verify, and clean up Outpost schema migrations safely
 
 Outpost stores tenant, destination, event, and delivery data using configurable storage backends. You can choose from various options including Redis, Postgres, ClickHouse, and more, depending on your infrastructure and requirements.
 
-When upgrading Outpost, we handle data migrations automatically during startup whenever possible. However, some migrations require manual intervention due to their complexity or impact. For these cases, we provide the `outpost migrate` tool.
+When upgrading Outpost, database migrations must be applied explicitly before starting the server — Outpost will refuse to start if any migrations are pending. The `outpost migrate` tool handles both SQL and Redis migrations through a unified interface.
 
 ## Migration Tool
 
@@ -15,15 +15,72 @@ Ensure you're using the correct version by specifying the Docker tag:
 
 ```bash
 # Use a specific version tag
-docker run --rm hookdeck/outpost:v1.2.3 --version
-
-# Or use latest (verify the version before running migrations)
-docker run --rm hookdeck/outpost:latest --version
+docker run --rm hookdeck/outpost --version
 ```
 
 ## Migration Workflow
 
-When Outpost starts up, it can automatically check and run migrations using `migrate init --current --log-format=json`. However, for production environments with critical data, manual migration using the steps below is recommended.
+The recommended approach is to run `outpost migrate apply --yes` before every `outpost serve`. This is safe to run on every startup — if there are no pending migrations, the command exits immediately. See the [Upgrade to v0.17](/self-hosting/changelog/upgrade-v0.17) guide for more details on this change.
+
+How you integrate this depends on your deployment setup. Below are some common patterns.
+
+**Docker Compose** — use a `migrate` service that runs before the main service:
+
+```yaml
+services:
+  outpost-migrate:
+    image: hookdeck/outpost
+    command: ["migrate", "apply", "--yes"]
+    env_file: .env
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  outpost:
+    image: hookdeck/outpost
+    command: ["serve"]
+    env_file: .env
+    depends_on:
+      outpost-migrate:
+        condition: service_completed_successfully
+```
+
+**Kubernetes** — use an init container on the Outpost deployment:
+
+```yaml
+spec:
+  initContainers:
+    - name: migrate
+      image: hookdeck/outpost
+      command: ["outpost", "migrate", "apply", "--yes"]
+      envFrom:
+        - secretRef:
+            name: outpost-config
+  containers:
+    - name: outpost
+      image: hookdeck/outpost
+      command: ["outpost", "serve"]
+      envFrom:
+        - secretRef:
+            name: outpost-config
+```
+
+**CI/CD pipeline** — add a migration step before deploying the new version:
+
+```bash
+# 1. Run migrations against production databases
+docker run --rm --env-file .env \
+  hookdeck/outpost migrate apply --yes
+
+# 2. Deploy the new version
+# (your deploy command here)
+```
+
+The examples above are recommendations — run migrations however fits your infrastructure. The only requirement is that `outpost migrate apply` completes before `outpost serve` starts. Some teams prefer a wrapper script in their entrypoint, others run it as a pre-deploy hook. Any approach works as long as migrations finish first.
+
+### Manual Migration
+
+For production environments where you want to review changes before applying, use the manual steps below.
 
 ### Execute a Migration
 
@@ -40,14 +97,10 @@ docker run --rm hookdeck/outpost migrate plan
 Execute the migration (creates new structures, preserves old ones):
 
 ```bash
-# Apply the next pending migration
 docker run --rm -it hookdeck/outpost migrate apply
-
-# Or apply all pending migrations in sequence
-docker run --rm -it hookdeck/outpost migrate apply --all
 ```
 
-The `--all` flag runs each pending migration in version order, automatically verifying each one before proceeding to the next. If any migration fails verification, the process stops immediately.
+This applies all pending migrations in order (SQL first, then Redis).
 
 :::info
 The `-it` flags enable interactive mode for confirmation prompts. Add `--yes` to skip confirmations in automated environments.
@@ -67,17 +120,6 @@ This performs spot-checks on a sample of migrated data to ensure integrity. Addi
 - Verify critical workflows
 - Monitor for any errors
 
-#### Step 4: Cleanup Old Data
-
-Once verified, remove the old data structures:
-
-```bash
-docker run --rm -it hookdeck/outpost migrate cleanup
-```
-
-:::warning
-Cleanup is irreversible. Ensure thorough testing before running cleanup as this removes all rollback capability.
-:::
 
 ## Safety Features
 
@@ -93,20 +135,6 @@ Migrations use distributed locks to prevent concurrent execution:
 docker run --rm -it hookdeck/outpost migrate unlock --yes
 ```
 
-### Non-Destructive Application
-
-The Apply phase creates new data structures without removing old ones:
-
-- Allows rollback by pointing application back to old structures
-- Provides time for thorough testing
-- Cleanup is an explicit separate step
-
-### Automatic Verification
-
-Cleanup operations require successful verification by default:
-
-- Prevents accidental data loss
-- Can be overridden with `--force` flag (use with caution)
 
 ## Running in Private Environments
 
@@ -126,7 +154,7 @@ ssh your-server
 docker run --rm -it \
   -e REDIS_HOST=redis.internal \
   -e REDIS_PASSWORD=... \
-  hookdeck/outpost:v0.12.0 migrate apply --all
+  hookdeck/outpost migrate apply --yes
 ```
 
 **Kubernetes:**
@@ -135,10 +163,10 @@ Run the migration as a one-off pod in the same namespace/cluster:
 
 ```bash
 kubectl run outpost-migrate --rm -it --restart=Never \
-  --image=hookdeck/outpost:v0.12.0 \
+  --image=hookdeck/outpost \
   --env="REDIS_HOST=redis.internal" \
   --env="REDIS_PASSWORD=..." \
-  -- migrate apply --all
+  -- migrate apply --yes
 ```
 
 **Port forwarding:**
@@ -153,7 +181,7 @@ ssh -L 6379:redis.internal:6379 bastion-host
 docker run --rm -it \
   -e REDIS_HOST=host.docker.internal \
   -e REDIS_PORT=6379 \
-  hookdeck/outpost:v0.12.0 migrate apply --all
+  hookdeck/outpost migrate apply --yes
 ```
 
 :::tip
@@ -208,10 +236,3 @@ If a migration fails during application:
 2. The migration can be safely retried (idempotent)
 3. Partial progress is preserved between attempts
 
-### Rollback Before Cleanup
-
-If issues are discovered after applying but before cleanup:
-
-1. Stop using the new Outpost version
-2. Deploy the previous version (will use old data structures)
-3. Debug and resolve issues before retrying


### PR DESCRIPTION
## Summary

- Adds upgrade guide for v0.17 covering the migration workflow breaking change (server now refuses to start with pending migrations)
- Updates the migration guide to reflect the unified `outpost migrate` CLI
- Adds v0.17 to nav.json changelog section

### Upgrade guide covers

- Explanation of the new explicit migration requirement
- Recommended deployment flow (`outpost migrate apply --yes` before `outpost serve`)
- Deployment examples: Docker Compose, Kubernetes init container, CI/CD pipeline
- Upgrade checklist

### Migration guide changes

- Removed "auto-apply at startup" language
- Removed references to `cleanup`, `init --current`, `--all` flag
- Updated examples to use `--yes` instead of `--all`

## Test plan

- [ ] Verify upgrade guide renders correctly on docs site
- [ ] Verify migration guide renders correctly on docs site
- [ ] Verify nav.json changelog section shows v0.17 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)