### PR TITLE
fix: bash arithmetic exit code in Redis migration script

### DIFF
--- a/scripts/issue-680/migrate.sh
+++ b/scripts/issue-680/migrate.sh
@@ -164,7 +164,7 @@ for DEPLOY_ID in "${DEPLOYMENT_IDS[@]}"; do
   if [[ -n "$INSTALLATION_ID" ]]; then
     target_key="${DEPLOY_ID}:outpost:installation_id"
     echo "SET ${target_key} ${INSTALLATION_ID}" >> "$PIPE_FILE"
-    ((CMD_COUNT++))
+    ((++CMD_COUNT))
   fi
 
   # Migration status keys (HSET is idempotent)
@@ -173,7 +173,7 @@ for DEPLOY_ID in "${DEPLOYMENT_IDS[@]}"; do
     hash_data="${MIGRATION_DATA[$old_key]}"
     if [[ -n "$hash_data" ]]; then
       echo "HSET ${new_key} ${hash_data}" >> "$PIPE_FILE"
-      ((CMD_COUNT++))
+      ((++CMD_COUNT))
     fi
   done
 done
@@ -182,15 +182,15 @@ done
 if $CLEANUP; then
   if [[ -n "$INSTALLATION_ID" ]]; then
     echo "DEL outpostrc" >> "$PIPE_FILE"
-    ((CMD_COUNT++))
+    ((++CMD_COUNT))
   fi
   for key in "${MIGRATION_KEYS[@]}"; do
     echo "DEL ${key}" >> "$PIPE_FILE"
-    ((CMD_COUNT++))
+    ((++CMD_COUNT))
   done
   if [[ "$LOCK_EXISTS" == "1" ]]; then
     echo "DEL .outpost:migration:lock" >> "$PIPE_FILE"
-    ((CMD_COUNT++))
+    ((++CMD_COUNT))
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Fix `(( CMD_COUNT++ ))` causing the migration script to exit immediately under `set -e`. When `CMD_COUNT` is 0, post-increment `(( 0++ ))` evaluates to 0 (falsy), returning exit code 1, which `set -e` treats as a failure. Replaced all 5 occurrences with pre-increment `(( ++CMD_COUNT ))`, which evaluates to 1 (truthy) on the first call.

## Test plan

- [ ] Run `bash -n scripts/issue-680/migrate.sh` to verify syntax
- [ ] Run `./migrate.sh` dry run against a Redis instance with at least one deployment to confirm `CMD_COUNT` increments correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)