### PR TITLE
fix: return JSON 404 for unmatched API routes

### DIFF
--- a/internal/portal/embed.go
+++ b/internal/portal/embed.go
@@ -47,8 +47,11 @@ func AddRoutes(router *gin.Engine, config PortalConfig) {
 		}
 		proxy := httputil.NewSingleHostReverseProxy(remote)
 		router.NoRoute(func(c *gin.Context) {
-			if strings.HasPrefix(c.Request.URL.Path, "/api") {
-				c.Next()
+			if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+				c.JSON(http.StatusNotFound, gin.H{
+					"status":  http.StatusNotFound,
+					"message": "not found",
+				})
 				return
 			}
 			if c.Request.Method != "GET" {
@@ -60,6 +63,14 @@ func AddRoutes(router *gin.Engine, config PortalConfig) {
 	} else {
 		embeddedBuildFolder := newStaticFileSystem()
 		fallbackFileSystem := newFallbackFileSystem(embeddedBuildFolder)
+		router.NoRoute(func(c *gin.Context) {
+			if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+				c.JSON(http.StatusNotFound, gin.H{
+					"status":  http.StatusNotFound,
+					"message": "not found",
+				})
+			}
+		})
 		router.Use(static.Serve("/", embeddedBuildFolder))
 		router.Use(static.Serve("/", fallbackFileSystem))
 	}

--- a/internal/portal/embed_test.go
+++ b/internal/portal/embed_test.go
@@ -1,0 +1,62 @@
+package portal
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestAddRoutes_NoRoute_APIReturnsJSON404(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded mode returns JSON 404 for unmatched API routes", func(t *testing.T) {
+		t.Parallel()
+
+		router := gin.New()
+		AddRoutes(router, PortalConfig{})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/nonexistent", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(http.StatusNotFound), response["status"])
+		assert.Equal(t, "not found", response["message"])
+	})
+
+	t.Run("proxy mode returns JSON 404 for unmatched API routes", func(t *testing.T) {
+		t.Parallel()
+
+		router := gin.New()
+		AddRoutes(router, PortalConfig{
+			ProxyURL: "http://localhost:19999",
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/v1/nonexistent", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(http.StatusNotFound), response["status"])
+		assert.Equal(t, "not found", response["message"])
+	})
+}


### PR DESCRIPTION
## Summary
- Unmatched `/api/...` routes now return `{"status": 404, "message": "not found"}` instead of Gin's default plain-text `404 page not found`
- Both portal modes (proxy and embedded) updated with `NoRoute` handlers that check for `/api/` prefix
- Non-API routes continue to work as before (SPA fallback or proxy passthrough)

## Test plan
- [x] Added `embed_test.go` covering both embedded and proxy modes
- [x] Manual: `GET /api/v1/nonexistent` returns JSON `{"status":404,"message":"not found"}` with `Content-Type: application/json`
- [x] Manual: Non-API routes still serve the portal SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)