### PR TITLE
fix: build full package in air.toml

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "tmp"
 [build]
   poll = true
   poll_interval = 500
-  cmd = "go build -o tmp/main cmd/outpost/main.go"
+  cmd = "go build -o tmp/main ./cmd/outpost"
   bin = "tmp/main"
   delay = 100
   exclude_dir = ["examples", "dist", "docs", "website", "loadtest", "sdks", "spec-sdk-tests", "internal/portal/node_modules", "internal/portal/src"]


### PR DESCRIPTION
## Summary
- `.air.toml` built only `cmd/outpost/main.go` instead of the full `./cmd/outpost` package
- PR #816 added `cmd/outpost/migrate.go` which broke `make up/outpost` with `undefined: newMigrateCommand`

One-line fix: `cmd/outpost/main.go` → `./cmd/outpost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)