### PR TITLE
feat: add optional tenant_id query param to GetEvent and GetAttempt

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2839,6 +2839,13 @@ paths:
         When authenticated with a Tenant JWT, only events belonging to that tenant can be accessed.
         When authenticated with Admin API Key, events from any tenant can be accessed.
       operationId: getEvent
+      parameters:
+        - name: tenant_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by tenant ID. Returns 404 if the event does not belong to the specified tenant. Ignored when using Tenant JWT authentication.
       responses:
         "200":
           description: Event details.
@@ -3084,6 +3091,12 @@ paths:
         When authenticated with Admin API Key, attempts from any tenant can be accessed.
       operationId: getAttempt
       parameters:
+        - name: tenant_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by tenant ID. Returns 404 if the attempt does not belong to the specified tenant. Ignored when using Tenant JWT authentication.
         - name: include
           in: query
           required: false

--- a/internal/apirouter/log_handlers.go
+++ b/internal/apirouter/log_handlers.go
@@ -349,8 +349,10 @@ func (h *LogHandlers) listAttemptsInternal(c *gin.Context, tenantIDs []string, d
 
 // RetrieveEvent handles GET /events/:event_id
 func (h *LogHandlers) RetrieveEvent(c *gin.Context) {
-	// When using JWT auth we need to inject the tenant ID for access control in case the id doesn't belong to the tenant
 	ctxTenantID := tenantIDFromContext(c)
+	if ctxTenantID == "" {
+		ctxTenantID = c.Query("tenant_id")
+	}
 	eventID := c.Param("event_id")
 	event, err := h.logStore.RetrieveEvent(c.Request.Context(), logstore.RetrieveEventRequest{
 		TenantID: ctxTenantID,
@@ -378,8 +380,10 @@ func (h *LogHandlers) RetrieveEvent(c *gin.Context) {
 
 // RetrieveAttempt handles GET /attempts/:attempt_id
 func (h *LogHandlers) RetrieveAttempt(c *gin.Context) {
-	// When using JWT auth we need to inject the tenant ID for access control in case the id doesn't belong to the tenant
 	ctxTenantID := tenantIDFromContext(c)
+	if ctxTenantID == "" {
+		ctxTenantID = c.Query("tenant_id")
+	}
 	attemptID := c.Param("attempt_id")
 
 	attemptRecord, err := h.logStore.RetrieveAttempt(c.Request.Context(), logstore.RetrieveAttemptRequest{

--- a/internal/apirouter/log_handlers_test.go
+++ b/internal/apirouter/log_handlers_test.go
@@ -602,6 +602,38 @@ func TestAPI_Events(t *testing.T) {
 
 			require.Equal(t, http.StatusNotFound, resp.Code)
 		})
+
+		t.Run("api key with tenant_id query param filters event", func(t *testing.T) {
+			h := newAPITest(t)
+
+			e := ef.AnyPointer(ef.WithID("e1"), ef.WithTenantID("t1"))
+			require.NoError(t, h.logStore.InsertMany(t.Context(), []*models.LogEntry{
+				{Event: e, Attempt: attemptForEvent(e)},
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/events/e1?tenant_id=t1", nil)
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+
+			var event apirouter.APIEvent
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &event))
+			assert.Equal(t, "e1", event.ID)
+		})
+
+		t.Run("api key with wrong tenant_id query param returns 404", func(t *testing.T) {
+			h := newAPITest(t)
+
+			e := ef.AnyPointer(ef.WithID("e1"), ef.WithTenantID("t1"))
+			require.NoError(t, h.logStore.InsertMany(t.Context(), []*models.LogEntry{
+				{Event: e, Attempt: attemptForEvent(e)},
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/events/e1?tenant_id=t2", nil)
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusNotFound, resp.Code)
+		})
 	})
 
 	t.Run("no auth returns 401", func(t *testing.T) {
@@ -1114,6 +1146,40 @@ func TestAPI_Attempts(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/attempts/a1?tenant_id[0]=t2", nil)
 			resp := h.do(h.withJWT(req, "t1"))
+
+			require.Equal(t, http.StatusNotFound, resp.Code)
+		})
+
+		t.Run("api key with tenant_id query param filters attempt", func(t *testing.T) {
+			h := newAPITest(t)
+
+			e := ef.AnyPointer(ef.WithTenantID("t1"))
+			a := attemptForEvent(e, af.WithID("a1"))
+			require.NoError(t, h.logStore.InsertMany(t.Context(), []*models.LogEntry{
+				{Event: e, Attempt: a},
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/attempts/a1?tenant_id=t1", nil)
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+
+			var attempt apirouter.APIAttempt
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &attempt))
+			assert.Equal(t, "a1", attempt.ID)
+		})
+
+		t.Run("api key with wrong tenant_id query param returns 404", func(t *testing.T) {
+			h := newAPITest(t)
+
+			e := ef.AnyPointer(ef.WithTenantID("t1"))
+			a := attemptForEvent(e, af.WithID("a1"))
+			require.NoError(t, h.logStore.InsertMany(t.Context(), []*models.LogEntry{
+				{Event: e, Attempt: a},
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/attempts/a1?tenant_id=t2", nil)
+			resp := h.do(h.withAPIKey(req))
 
 			require.Equal(t, http.StatusNotFound, resp.Code)
 		})


### PR DESCRIPTION
## Summary
- `GET /events/:event_id?tenant_id=X` and `GET /attempts/:attempt_id?tenant_id=X` now return 404 if the resource doesn't belong to the specified tenant
- Only applies when using API key auth; JWT tenant always takes precedence
- No logstore changes — `RetrieveEventRequest.TenantID` and `RetrieveAttemptRequest.TenantID` already filter at the query level

## Test plan
- [x] API key + correct tenant_id → 200 (events + attempts)
- [x] API key + wrong tenant_id → 404 (events + attempts)
- [x] Existing JWT tests still pass (JWT takes precedence, query param ignored)
- [x] OpenAPI spec updated for both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)