### PR TITLE
fix: enforce SQS 1 MB batch byte limit

### DIFF
--- a/internal/mqs/queue_awssqs.go
+++ b/internal/mqs/queue_awssqs.go
@@ -13,7 +13,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/awssnssqs"
+	"gocloud.dev/pubsub/batcher"
 )
+
+// sqsMaxBatchBytes is the maximum total payload size for an SQS SendMessageBatch
+// request. SQS rejects batches exceeding 256 KB per message and 1 MB per batch.
+// Setting this on the gocloud batcher prevents oversized batches from being sent.
+const sqsMaxBatchBytes = 1_048_576 // 1 MB
 
 type AWSSQSConfig struct {
 	Endpoint                  string // optional - dev-focused
@@ -56,7 +62,11 @@ func (q *AWSQueue) Init(ctx context.Context) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	q.topic = awssnssqs.OpenSQSTopicV2(ctx, q.sqsClient, q.sqsQueueURL, nil)
+	q.topic = awssnssqs.OpenSQSTopicV2(ctx, q.sqsClient, q.sqsQueueURL, &awssnssqs.TopicOptions{
+		BatcherOptions: batcher.Options{
+			MaxBatchByteSize: sqsMaxBatchBytes,
+		},
+	})
 	return func() {
 		q.topic.Shutdown(ctx)
 	}, nil


### PR DESCRIPTION
## Summary

gocloud.dev's SQS topic driver batches `Send()` calls via `SendMessageBatch` (up to 10 messages per batch) but does **not** enforce SQS's 1 MB total batch size limit — it relies on SQS to reject oversized batches at the API level.

When log entries carry large payloads (e.g., large request/response bodies), the combined batch can exceed 1 MB, causing SQS to reject the entire batch with `BatchRequestTooLong`. This failure cascades: the log entry never gets persisted, and the retry scheduler can't find a prior attempt in the logstore, triggering an infinite retry loop (see #663).

This PR sets `MaxBatchByteSize: 1_048_576` on the gocloud `TopicOptions` so the batcher splits oversized batches **before** they reach SQS. If a single message exceeds 1 MB, gocloud returns `ErrMessageTooLarge` instead of a cryptic SQS batch error.

## Changes

- Pass `TopicOptions` with `BatcherOptions.MaxBatchByteSize` set to 1 MB when opening SQS topics in `queue_awssqs.go`

## Test plan

- [x] Verified compilation
- [ ] Deploy to staging with SQS backend and send events with large payloads (>100 KB) at high concurrency to confirm batches are split correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)