### PR TITLE
feat: RFC 7396 JSON merge-patch for destination update

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -182,7 +182,7 @@ components:
         Optional JSON schema filter for event matching. Events must match this filter to be delivered to this destination.
         Supports operators: $eq, $neq, $gt, $gte, $lt, $lte, $in, $nin, $startsWith, $endsWith, $exist, $or, $and, $not.
         If null or empty, all events matching the topic filter will be delivered.
-        To remove an existing filter when updating a destination, set filter to an empty object `{}`.
+        Uses full-replacement semantics on update: send a new object to replace, null or `{}` to clear, omit for no change.
       example:
         data:
           amount:
@@ -1481,16 +1481,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
     DestinationUpdateAWSSQS:
       type: object
@@ -1507,16 +1519,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
     DestinationUpdateRabbitMQ:
       type: object
@@ -1533,16 +1557,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
     DestinationUpdateHookdeck:
       type: object
@@ -1558,16 +1594,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
     DestinationUpdateAWSKinesis:
       type: object
@@ -1584,16 +1632,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
     DestinationUpdateAzureServiceBus:
       type: object
@@ -1610,16 +1670,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
 
     DestinationUpdateAWSS3:
@@ -1637,16 +1709,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
     DestinationUpdateGCPPubSub:
       type: object
@@ -1663,16 +1747,28 @@ components:
         delivery_metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Static key-value pairs merged into event metadata on every attempt.
+          description: >-
+            Static key-value pairs merged into event metadata on every attempt.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "app-id": "my-app", "region": "us-east-1" }
         metadata:
           type: object
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: "null"
           nullable: true
-          description: Arbitrary contextual information stored with the destination.
+          description: >-
+            Arbitrary contextual information stored with the destination.
+            Uses JSON merge-patch semantics (RFC 7396): send keys to add/update,
+            null values to delete keys, null for entire field to clear all.
+            Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
 
     # Polymorphic Destination Update Schema (for Request Bodies)

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -2,7 +2,9 @@ package apirouter
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
@@ -164,22 +166,61 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 		AbortWithValidationError(c, errors.New("type cannot be updated"))
 		return
 	}
-	if input.Config != nil {
-		shouldRevalidate = true
-		updatedDestination.Config = maputil.MergeStringMaps(originalDestination.Config, input.Config)
+
+	// Config (merge-patch)
+	configResult, configChanged, err := applyMergePatchStringMap(originalDestination.Config, input.Config)
+	if err != nil {
+		AbortWithValidationError(c, fmt.Errorf("invalid config: %w", err))
+		return
 	}
-	if input.Credentials != nil {
+	if configChanged {
 		shouldRevalidate = true
-		updatedDestination.Credentials = maputil.MergeStringMaps(originalDestination.Credentials, input.Credentials)
+		updatedDestination.Config = configResult
 	}
+
+	// Credentials (merge-patch)
+	credsResult, credsChanged, err := applyMergePatchStringMap(originalDestination.Credentials, input.Credentials)
+	if err != nil {
+		AbortWithValidationError(c, fmt.Errorf("invalid credentials: %w", err))
+		return
+	}
+	if credsChanged {
+		shouldRevalidate = true
+		updatedDestination.Credentials = credsResult
+	}
+
+	// Filter (full replacement)
 	if input.Filter != nil {
-		updatedDestination.Filter = input.Filter
+		if isJSONNull(input.Filter) {
+			updatedDestination.Filter = nil
+		} else {
+			var filter models.Filter
+			if err := json.Unmarshal(input.Filter, &filter); err != nil {
+				AbortWithValidationError(c, fmt.Errorf("invalid filter: %w", err))
+				return
+			}
+			updatedDestination.Filter = filter
+		}
 	}
-	if input.DeliveryMetadata != nil {
-		updatedDestination.DeliveryMetadata = maputil.MergeStringMaps(originalDestination.DeliveryMetadata, input.DeliveryMetadata)
+
+	// DeliveryMetadata (merge-patch)
+	dmResult, dmChanged, err := applyMergePatchStringMap(originalDestination.DeliveryMetadata, input.DeliveryMetadata)
+	if err != nil {
+		AbortWithValidationError(c, fmt.Errorf("invalid delivery_metadata: %w", err))
+		return
 	}
-	if input.Metadata != nil {
-		updatedDestination.Metadata = maputil.MergeStringMaps(originalDestination.Metadata, input.Metadata)
+	if dmChanged {
+		updatedDestination.DeliveryMetadata = dmResult
+	}
+
+	// Metadata (merge-patch)
+	metaResult, metaChanged, err := applyMergePatchStringMap(originalDestination.Metadata, input.Metadata)
+	if err != nil {
+		AbortWithValidationError(c, fmt.Errorf("invalid metadata: %w", err))
+		return
+	}
+	if metaChanged {
+		updatedDestination.Metadata = metaResult
 	}
 
 	// Always preprocess before updating
@@ -356,13 +397,41 @@ func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destina
 }
 
 type UpdateDestinationRequest struct {
-	Type             string                  `json:"type" binding:"-"`
-	Topics           models.Topics           `json:"topics" binding:"-"`
-	Filter           models.Filter           `json:"filter,omitempty" binding:"-"`
-	Config           models.Config           `json:"config" binding:"-"`
-	Credentials      models.Credentials      `json:"credentials" binding:"-"`
-	DeliveryMetadata models.DeliveryMetadata `json:"delivery_metadata,omitempty" binding:"-"`
-	Metadata         models.Metadata         `json:"metadata,omitempty" binding:"-"`
+	Type             string          `json:"type" binding:"-"`
+	Topics           models.Topics   `json:"topics" binding:"-"`
+	Filter           json.RawMessage `json:"filter" binding:"-"`
+	Config           json.RawMessage `json:"config" binding:"-"`
+	Credentials      json.RawMessage `json:"credentials" binding:"-"`
+	DeliveryMetadata json.RawMessage `json:"delivery_metadata" binding:"-"`
+	Metadata         json.RawMessage `json:"metadata" binding:"-"`
+}
+
+// isJSONNull checks if raw JSON bytes represent a JSON null literal.
+func isJSONNull(raw json.RawMessage) bool {
+	return len(raw) == 4 && string(raw) == "null"
+}
+
+// applyMergePatchStringMap applies RFC 7396 merge-patch semantics for a map[string]string field.
+// Returns (result, changed, error):
+//   - raw is nil (field omitted): returns original unchanged
+//   - raw is "null": returns nil (clear field)
+//   - raw is "{}": returns original unchanged (empty merge = no-op)
+//   - raw is an object: merge-patch into original
+func applyMergePatchStringMap(original map[string]string, raw json.RawMessage) (map[string]string, bool, error) {
+	if raw == nil {
+		return original, false, nil
+	}
+	if isJSONNull(raw) {
+		return nil, true, nil
+	}
+	var patch map[string]any
+	if err := json.Unmarshal(raw, &patch); err != nil {
+		return nil, false, err
+	}
+	if len(patch) == 0 {
+		return original, false, nil
+	}
+	return maputil.MergePatchStringMap(original, patch), true, nil
 }
 
 // tenantSnapshot captures the tenant's derived state before a destination mutation.

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -327,6 +327,479 @@ func TestAPI_Destinations(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, resp.Code)
 		})
+
+		// ── Merge-patch semantics (RFC 7396) for map fields ──
+
+		t.Run("metadata merge adds key preserving existing", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"env": "prod"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"metadata": map[string]any{"team": "platform"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Metadata{"env": "prod", "team": "platform"}, dest.Metadata)
+		})
+
+		t.Run("metadata merge updates existing key", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"env": "prod"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"metadata": map[string]any{"env": "staging"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Metadata{"env": "staging"}, dest.Metadata)
+		})
+
+		t.Run("metadata delete key via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"env": "prod", "region": "us-east-1"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"metadata": map[string]any{"region": nil},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Metadata{"env": "prod"}, dest.Metadata)
+		})
+
+		t.Run("metadata clear entire field via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"env": "prod"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"metadata": nil,
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.True(t, dest.Metadata == nil || len(dest.Metadata) == 0)
+		})
+
+		t.Run("metadata empty object is no-op", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"env": "prod"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"metadata": map[string]any{},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Metadata{"env": "prod"}, dest.Metadata)
+		})
+
+		t.Run("metadata unchanged when omitted", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"env": "prod"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"topics": []string{"user.created"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Metadata{"env": "prod"}, dest.Metadata)
+		})
+
+		t.Run("metadata mixed add update delete", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithMetadata(map[string]string{"keep": "v", "remove": "v", "update": "old"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"metadata": map[string]any{"remove": nil, "update": "new", "add": "v"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Metadata{"keep": "v", "update": "new", "add": "v"}, dest.Metadata)
+		})
+
+		// ── delivery_metadata merge-patch ──
+
+		t.Run("delivery_metadata merge adds key preserving existing", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithDeliveryMetadata(map[string]string{"source": "outpost"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"delivery_metadata": map[string]any{"version": "1.0"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.DeliveryMetadata{"source": "outpost", "version": "1.0"}, dest.DeliveryMetadata)
+		})
+
+		t.Run("delivery_metadata delete key via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithDeliveryMetadata(map[string]string{"source": "outpost", "version": "1.0"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"delivery_metadata": map[string]any{"version": nil},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.DeliveryMetadata{"source": "outpost"}, dest.DeliveryMetadata)
+		})
+
+		t.Run("delivery_metadata clear via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithDeliveryMetadata(map[string]string{"source": "outpost"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"delivery_metadata": nil,
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.True(t, dest.DeliveryMetadata == nil || len(dest.DeliveryMetadata) == 0)
+		})
+
+		t.Run("delivery_metadata empty object is no-op", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithDeliveryMetadata(map[string]string{"source": "outpost"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"delivery_metadata": map[string]any{},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.DeliveryMetadata{"source": "outpost"}, dest.DeliveryMetadata)
+		})
+
+		t.Run("delivery_metadata unchanged when omitted", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithDeliveryMetadata(map[string]string{"source": "outpost"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"topics": []string{"user.created"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.DeliveryMetadata{"source": "outpost"}, dest.DeliveryMetadata)
+		})
+
+		// ── config merge-patch ──
+
+		t.Run("config merge adds key preserving existing", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithConfig(map[string]string{"url": "https://example.com/hook"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"config": map[string]any{"custom_header": "X-Custom"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "https://example.com/hook", dest.Config["url"])
+			assert.Equal(t, "X-Custom", dest.Config["custom_header"])
+		})
+
+		t.Run("config delete key via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithConfig(map[string]string{"url": "https://example.com/hook", "extra": "val"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"config": map[string]any{"extra": nil},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "https://example.com/hook", dest.Config["url"])
+			_, hasExtra := dest.Config["extra"]
+			assert.False(t, hasExtra, "extra key should be removed")
+		})
+
+		t.Run("config clear via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithConfig(map[string]string{"url": "https://example.com/hook"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"config": nil,
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.True(t, dest.Config == nil || len(dest.Config) == 0)
+		})
+
+		t.Run("config empty object is no-op", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithConfig(map[string]string{"url": "https://example.com/hook"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"config": map[string]any{},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "https://example.com/hook", dest.Config["url"])
+		})
+
+		t.Run("config unchanged when omitted", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithConfig(map[string]string{"url": "https://example.com/hook"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"topics": []string{"user.created"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "https://example.com/hook", dest.Config["url"])
+		})
+
+		// ── credentials merge-patch ──
+
+		t.Run("credentials merge adds key preserving existing", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithCredentials(map[string]string{"secret": "s1"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"credentials": map[string]any{"previous_secret": "s0"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "s1", dest.Credentials["secret"])
+			assert.Equal(t, "s0", dest.Credentials["previous_secret"])
+		})
+
+		t.Run("credentials delete key via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithCredentials(map[string]string{"secret": "s1", "previous_secret": "s0"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"credentials": map[string]any{"previous_secret": nil},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "s1", dest.Credentials["secret"])
+			_, hasPrev := dest.Credentials["previous_secret"]
+			assert.False(t, hasPrev, "previous_secret should be removed")
+		})
+
+		t.Run("credentials clear via null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithCredentials(map[string]string{"secret": "s1"}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"credentials": nil,
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.True(t, dest.Credentials == nil || len(dest.Credentials) == 0)
+		})
+
+		// ── filter replacement semantics ──
+
+		t.Run("filter replaced not merged", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithFilter(models.Filter{"body": map[string]any{"user_id": "usr_123"}}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"filter": map[string]any{"body": map[string]any{"status": "active"}},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Nil(t, dest.Filter["body"].(map[string]any)["user_id"], "old key should not be present")
+			assert.Equal(t, "active", dest.Filter["body"].(map[string]any)["status"])
+		})
+
+		t.Run("filter cleared with empty object", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithFilter(models.Filter{"body": map[string]any{"user_id": "usr_123"}}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"filter": map[string]any{},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.True(t, dest.Filter == nil || len(dest.Filter) == 0, "filter should be cleared")
+		})
+
+		t.Run("filter cleared with null", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithFilter(models.Filter{"body": map[string]any{"user_id": "usr_123"}}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"filter": nil,
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.True(t, dest.Filter == nil || len(dest.Filter) == 0, "filter should be cleared")
+		})
+
+		t.Run("filter unchanged when omitted", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"),
+				df.WithFilter(models.Filter{"body": map[string]any{"user_id": "usr_123"}}),
+			))
+
+			req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+				"topics": []string{"user.created"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, "usr_123", dest.Filter["body"].(map[string]any)["user_id"])
+		})
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/internal/util/maputil/maputil.go
+++ b/internal/util/maputil/maputil.go
@@ -1,5 +1,10 @@
 package maputil
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // MergeStringMaps merges two string maps, with input taking precedence over original.
 // This is useful for partial updates where we want to merge new values with existing ones.
 func MergeStringMaps(original, input map[string]string) map[string]string {
@@ -11,4 +16,46 @@ func MergeStringMaps(original, input map[string]string) map[string]string {
 		merged[k] = v
 	}
 	return merged
+}
+
+// MergePatchStringMap applies RFC 7396 JSON merge-patch semantics to a map[string]string.
+// The patch uses map[string]interface{} to preserve null values:
+//   - nil value means delete the key
+//   - non-nil value is converted to string and set
+//
+// Returns nil when all keys are removed (consistent with Go zero-value conventions).
+func MergePatchStringMap(original map[string]string, patch map[string]any) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range original {
+		merged[k] = v
+	}
+	for k, v := range patch {
+		if v == nil {
+			delete(merged, k)
+		} else {
+			merged[k] = toStringValue(v)
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// toStringValue converts a JSON-deserialized value to a string,
+// mirroring the coercion logic in MapStringString.UnmarshalJSON.
+func toStringValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case bool:
+		return fmt.Sprintf("%v", val)
+	case float64:
+		return fmt.Sprintf("%v", val)
+	default:
+		if b, err := json.Marshal(val); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", val)
+	}
 }

--- a/internal/util/maputil/maputil_test.go
+++ b/internal/util/maputil/maputil_test.go
@@ -1,0 +1,102 @@
+package maputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergePatchStringMap(t *testing.T) {
+	t.Run("add new key preserves existing", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"a": "1"},
+			map[string]any{"b": "2"},
+		)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, result)
+	})
+
+	t.Run("update existing key", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"a": "1"},
+			map[string]any{"a": "2"},
+		)
+		assert.Equal(t, map[string]string{"a": "2"}, result)
+	})
+
+	t.Run("delete key via null", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"a": "1", "b": "2"},
+			map[string]any{"a": nil},
+		)
+		assert.Equal(t, map[string]string{"b": "2"}, result)
+	})
+
+	t.Run("delete nonexistent key is no-op", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"a": "1"},
+			map[string]any{"z": nil},
+		)
+		assert.Equal(t, map[string]string{"a": "1"}, result)
+	})
+
+	t.Run("delete all keys returns nil", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"a": "1"},
+			map[string]any{"a": nil},
+		)
+		assert.Nil(t, result)
+	})
+
+	t.Run("mixed add update delete", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"keep": "v", "remove": "v", "update": "old"},
+			map[string]any{"remove": nil, "update": "new", "add": "v"},
+		)
+		assert.Equal(t, map[string]string{"keep": "v", "update": "new", "add": "v"}, result)
+	})
+
+	t.Run("nil original treated as empty", func(t *testing.T) {
+		result := MergePatchStringMap(
+			nil,
+			map[string]any{"a": "1"},
+		)
+		assert.Equal(t, map[string]string{"a": "1"}, result)
+	})
+
+	t.Run("empty patch is no-op", func(t *testing.T) {
+		result := MergePatchStringMap(
+			map[string]string{"a": "1"},
+			map[string]any{},
+		)
+		assert.Equal(t, map[string]string{"a": "1"}, result)
+	})
+
+	t.Run("nil original and empty patch returns nil", func(t *testing.T) {
+		result := MergePatchStringMap(nil, map[string]any{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("type coercion float64", func(t *testing.T) {
+		result := MergePatchStringMap(
+			nil,
+			map[string]any{"num": float64(42)},
+		)
+		assert.Equal(t, map[string]string{"num": "42"}, result)
+	})
+
+	t.Run("type coercion bool", func(t *testing.T) {
+		result := MergePatchStringMap(
+			nil,
+			map[string]any{"flag": true},
+		)
+		assert.Equal(t, map[string]string{"flag": "true"}, result)
+	})
+
+	t.Run("type coercion float with decimal", func(t *testing.T) {
+		result := MergePatchStringMap(
+			nil,
+			map[string]any{"pi": float64(3.14)},
+		)
+		assert.Equal(t, map[string]string{"pi": "3.14"}, result)
+	})
+}

--- a/sdks/outpost-go/.speakeasy/gen.yaml
+++ b/sdks/outpost-go/.speakeasy/gen.yaml
@@ -29,7 +29,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 go:
-  version: 0.9.0
+  version: 0.9.1
   additionalDependencies: {}
   allowUnknownFieldsInWeakUnions: false
   baseErrorName: OutpostError
@@ -56,7 +56,7 @@ go:
   methodArguments: require-security-and-request
   modulePath: ""
   multipartArrayFormat: legacy
-  nullableOptionalWrapper: false
+  nullableOptionalWrapper: true
   outputModelSuffix: output
   packageName: github.com/hookdeck/outpost/sdks/outpost-go
   respectRequiredFields: false

--- a/spec-sdk-tests/tests/destinations/go.mod
+++ b/spec-sdk-tests/tests/destinations/go.mod
@@ -1,0 +1,17 @@
+module github.com/hookdeck/outpost/spec-sdk-tests/tests/destinations
+
+go 1.22
+
+replace github.com/hookdeck/outpost/sdks/outpost-go => ../../../sdks/outpost-go
+
+require (
+	github.com/hookdeck/outpost/sdks/outpost-go v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spyzhov/ajson v0.8.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/spec-sdk-tests/tests/destinations/go.sum
+++ b/spec-sdk-tests/tests/destinations/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spyzhov/ajson v0.8.0 h1:sFXyMbi4Y/BKjrsfkUZHSjA2JM1184enheSjjoT/zCc=
+github.com/spyzhov/ajson v0.8.0/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/spec-sdk-tests/tests/destinations/test_webhook_merge_patch.py
+++ b/spec-sdk-tests/tests/destinations/test_webhook_merge_patch.py
@@ -1,0 +1,191 @@
+"""Tests for webhook destination merge-patch semantics (RFC 7396) via Python SDK."""
+
+import os
+import pytest
+from outpost_sdk import Outpost
+from outpost_sdk.models import (
+    DestinationCreateWebhook,
+    DestinationUpdateWebhook,
+    WebhookConfig,
+)
+from outpost_sdk.types.basemodel import Unset
+
+API_KEY = os.getenv("API_KEY", "test-api-key")
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:3333/api/v1")
+TENANT_ID = "python-merge-patch-test"
+
+
+def is_empty_or_unset(val):
+    if val is None or isinstance(val, Unset):
+        return True
+    if isinstance(val, dict) and len(val) == 0:
+        return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def client():
+    return Outpost(api_key=API_KEY, server_url=API_BASE_URL)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_tenant(client):
+    client.tenants.upsert(tenant_id=TENANT_ID)
+    yield
+    try:
+        client.tenants.delete(tenant_id=TENANT_ID)
+    except Exception:
+        pass
+
+
+def create_dest(client, *, filter_=None, metadata=None, delivery_metadata=None):
+    kwargs = {
+        "type": "webhook",
+        "topics": ["*"],
+        "config": WebhookConfig(url="https://example.com/webhook"),
+    }
+    if filter_ is not None:
+        kwargs["filter_"] = filter_
+    if metadata is not None:
+        kwargs["metadata"] = metadata
+    if delivery_metadata is not None:
+        kwargs["delivery_metadata"] = delivery_metadata
+
+    return client.destinations.create(tenant_id=TENANT_ID, body=DestinationCreateWebhook(**kwargs))
+
+
+def update_dest(client, dest_id, **kwargs):
+    return client.destinations.update(
+        tenant_id=TENANT_ID,
+        destination_id=dest_id,
+        body=DestinationUpdateWebhook(**kwargs),
+    )
+
+
+def get_dest(client, dest_id):
+    return client.destinations.get(tenant_id=TENANT_ID, destination_id=dest_id)
+
+
+def delete_dest(client, dest_id):
+    try:
+        client.destinations.delete(tenant_id=TENANT_ID, destination_id=dest_id)
+    except Exception:
+        pass
+
+
+# ── metadata merge-patch ──
+
+
+class TestMetadataMergePatch:
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        self.client = client
+        dest = create_dest(client, metadata={"env": "prod", "region": "us-east-1"})
+        self.dest_id = dest.id
+        yield
+        delete_dest(client, self.dest_id)
+
+    def test_add_key_preserving_existing(self):
+        updated = update_dest(self.client, self.dest_id, metadata={"env": "prod", "region": "us-east-1", "team": "platform"})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.metadata == {"env": "prod", "region": "us-east-1", "team": "platform"}
+
+    def test_update_existing_key(self):
+        updated = update_dest(self.client, self.dest_id, metadata={"env": "staging"})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.metadata["env"] == "staging"
+        assert dest.metadata["region"] == "us-east-1"
+
+    def test_delete_key_via_null(self):
+        updated = update_dest(self.client, self.dest_id, metadata={"env": "prod", "region": None})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.metadata == {"env": "prod"}
+        assert "region" not in dest.metadata
+
+    def test_clear_entire_field_via_null(self):
+        update_dest(self.client, self.dest_id, metadata=None)
+        dest = get_dest(self.client, self.dest_id)
+        assert is_empty_or_unset(dest.metadata)
+
+    def test_empty_object_is_noop(self):
+        update_dest(self.client, self.dest_id, metadata={})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.metadata == {"env": "prod", "region": "us-east-1"}
+
+    def test_omitted_is_noop(self):
+        update_dest(self.client, self.dest_id, topics=["*"])
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.metadata == {"env": "prod", "region": "us-east-1"}
+
+    def test_mixed_add_update_delete(self):
+        dest = create_dest(self.client, metadata={"keep": "v", "remove": "v", "update": "old"})
+        try:
+            update_dest(self.client, dest.id, metadata={"keep": "v", "remove": None, "update": "new", "add": "v"})
+            got = get_dest(self.client, dest.id)
+            assert got.metadata == {"keep": "v", "update": "new", "add": "v"}
+            assert "remove" not in got.metadata
+        finally:
+            delete_dest(self.client, dest.id)
+
+
+# ── delivery_metadata merge-patch ──
+
+
+class TestDeliveryMetadataMergePatch:
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        self.client = client
+        dest = create_dest(client, delivery_metadata={"source": "outpost", "version": "1.0"})
+        self.dest_id = dest.id
+        yield
+        delete_dest(client, self.dest_id)
+
+    def test_delete_key_via_null(self):
+        update_dest(self.client, self.dest_id, delivery_metadata={"source": "outpost", "version": None})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.delivery_metadata == {"source": "outpost"}
+
+    def test_clear_via_null(self):
+        update_dest(self.client, self.dest_id, delivery_metadata=None)
+        dest = get_dest(self.client, self.dest_id)
+        assert is_empty_or_unset(dest.delivery_metadata)
+
+    def test_empty_object_is_noop(self):
+        update_dest(self.client, self.dest_id, delivery_metadata={})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.delivery_metadata == {"source": "outpost", "version": "1.0"}
+
+
+# ── filter replacement ──
+
+
+class TestFilterReplacement:
+    @pytest.fixture(autouse=True)
+    def setup(self, client):
+        self.client = client
+        dest = create_dest(client, filter_={"body": {"user_id": "usr_123"}})
+        self.dest_id = dest.id
+        yield
+        delete_dest(client, self.dest_id)
+
+    def test_replace_entirely(self):
+        update_dest(self.client, self.dest_id, filter_={"body": {"status": "active"}})
+        dest = get_dest(self.client, self.dest_id)
+        assert dest.filter_["body"]["status"] == "active"
+        assert "user_id" not in dest.filter_.get("body", {})
+
+    def test_clear_with_empty_object(self):
+        update_dest(self.client, self.dest_id, filter_={})
+        dest = get_dest(self.client, self.dest_id)
+        assert is_empty_or_unset(dest.filter_)
+
+    def test_clear_with_null(self):
+        update_dest(self.client, self.dest_id, filter_=None)
+        dest = get_dest(self.client, self.dest_id)
+        assert is_empty_or_unset(dest.filter_)
+
+    def test_unchanged_when_omitted(self):
+        update_dest(self.client, self.dest_id, topics=["*"])
+        dest = get_dest(self.client, self.dest_id)
+        assert not isinstance(dest.filter_, Unset)
+        assert dest.filter_["body"]["user_id"] == "usr_123"

--- a/spec-sdk-tests/tests/destinations/webhook-merge-patch.test.ts
+++ b/spec-sdk-tests/tests/destinations/webhook-merge-patch.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, before, after } from 'mocha';
+import { expect } from 'chai';
+import { SdkClient, createSdkClient } from '../../utils/sdk-client';
+import { createWebhookDestination } from '../../factories/destination.factory';
+/* eslint-disable no-console */
+/* eslint-disable no-undef */
+
+describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
+  let client: SdkClient;
+  const createdDestinations: string[] = [];
+
+  before(async () => {
+    client = createSdkClient();
+    try {
+      await client.upsertTenant();
+    } catch (error) {
+      console.warn('Failed to create tenant (may already exist):', error);
+    }
+  });
+
+  after(async () => {
+    for (const id of createdDestinations) {
+      try {
+        await client.deleteDestination(id);
+      } catch {}
+    }
+    try {
+      await client.deleteTenant();
+    } catch {}
+  });
+
+  async function createDest(overrides?: Record<string, any>): Promise<string> {
+    const dest = await client.createDestination(createWebhookDestination(overrides));
+    createdDestinations.push(dest.id);
+    return dest.id;
+  }
+
+  // ── metadata merge-patch ──
+
+  describe('metadata merge-patch', () => {
+    it('should add key while preserving existing', async () => {
+      const id = await createDest({ metadata: { env: 'prod' } });
+
+      const updated = await client.updateDestination(id, {
+        metadata: { env: 'prod', team: 'platform' },
+      });
+
+      expect(updated.metadata).to.deep.equal({ env: 'prod', team: 'platform' });
+    });
+
+    it('should update existing key', async () => {
+      const id = await createDest({ metadata: { env: 'prod' } });
+
+      const updated = await client.updateDestination(id, {
+        metadata: { env: 'staging' },
+      });
+
+      expect(updated.metadata).to.deep.include({ env: 'staging' });
+    });
+
+    it('should delete key via null value', async () => {
+      const id = await createDest({ metadata: { env: 'prod', region: 'us-east-1' } });
+
+      const updated = await client.updateDestination(id, {
+        metadata: { env: 'prod', region: null },
+      });
+
+      expect(updated.metadata).to.deep.equal({ env: 'prod' });
+      expect(updated.metadata).to.not.have.property('region');
+    });
+
+    it('should clear entire field via null', async () => {
+      const id = await createDest({ metadata: { env: 'prod' } });
+
+      const updated = await client.updateDestination(id, {
+        metadata: null,
+      });
+
+      const isEmpty =
+        updated.metadata === null ||
+        updated.metadata === undefined ||
+        (typeof updated.metadata === 'object' && Object.keys(updated.metadata).length === 0);
+      expect(isEmpty).to.be.true;
+    });
+
+    it('should not change when empty object sent', async () => {
+      const id = await createDest({ metadata: { env: 'prod' } });
+
+      const updated = await client.updateDestination(id, {
+        metadata: {},
+      });
+
+      expect(updated.metadata).to.deep.equal({ env: 'prod' });
+    });
+
+    it('should not change when field omitted', async () => {
+      const id = await createDest({ metadata: { env: 'prod' } });
+
+      const updated = await client.updateDestination(id, {
+        topics: ['*'],
+      });
+
+      expect(updated.metadata).to.deep.equal({ env: 'prod' });
+    });
+
+    it('should handle mixed add/update/delete', async () => {
+      const id = await createDest({
+        metadata: { keep: 'v', remove: 'v', update: 'old' },
+      });
+
+      const updated = await client.updateDestination(id, {
+        metadata: { keep: 'v', remove: null, update: 'new', add: 'v' },
+      });
+
+      expect(updated.metadata).to.deep.equal({ keep: 'v', update: 'new', add: 'v' });
+      expect(updated.metadata).to.not.have.property('remove');
+    });
+  });
+
+  // ── delivery_metadata merge-patch ──
+
+  describe('delivery_metadata merge-patch', () => {
+    it('should add key while preserving existing', async () => {
+      const id = await createDest({ deliveryMetadata: { source: 'outpost' } });
+
+      const updated = await client.updateDestination(id, {
+        deliveryMetadata: { source: 'outpost', version: '1.0' },
+      });
+
+      expect(updated.deliveryMetadata).to.deep.equal({ source: 'outpost', version: '1.0' });
+    });
+
+    it('should delete key via null value', async () => {
+      const id = await createDest({
+        deliveryMetadata: { source: 'outpost', version: '1.0' },
+      });
+
+      const updated = await client.updateDestination(id, {
+        deliveryMetadata: { source: 'outpost', version: null },
+      });
+
+      expect(updated.deliveryMetadata).to.deep.equal({ source: 'outpost' });
+    });
+
+    it('should clear entire field via null', async () => {
+      const id = await createDest({ deliveryMetadata: { source: 'outpost' } });
+
+      const updated = await client.updateDestination(id, {
+        deliveryMetadata: null,
+      });
+
+      const isEmpty =
+        updated.deliveryMetadata === null ||
+        updated.deliveryMetadata === undefined ||
+        (typeof updated.deliveryMetadata === 'object' &&
+          Object.keys(updated.deliveryMetadata).length === 0);
+      expect(isEmpty).to.be.true;
+    });
+
+    it('should not change when empty object sent', async () => {
+      const id = await createDest({ deliveryMetadata: { source: 'outpost' } });
+
+      const updated = await client.updateDestination(id, {
+        deliveryMetadata: {},
+      });
+
+      expect(updated.deliveryMetadata).to.deep.equal({ source: 'outpost' });
+    });
+  });
+
+  // ── filter replacement ──
+
+  describe('filter replacement', () => {
+    it('should replace filter entirely', async () => {
+      const id = await createDest({
+        filter: { body: { user_id: 'usr_123' } },
+      });
+
+      const updated = await client.updateDestination(id, {
+        filter: { body: { status: 'active' } },
+      });
+
+      expect(updated.filter).to.deep.equal({ body: { status: 'active' } });
+    });
+
+    it('should clear filter with empty object', async () => {
+      const id = await createDest({
+        filter: { body: { user_id: 'usr_123' } },
+      });
+
+      const updated = await client.updateDestination(id, {
+        filter: {},
+      });
+
+      const isEmpty =
+        updated.filter === null ||
+        updated.filter === undefined ||
+        (typeof updated.filter === 'object' && Object.keys(updated.filter).length === 0);
+      expect(isEmpty).to.be.true;
+    });
+
+    it('should clear filter with null', async () => {
+      const id = await createDest({
+        filter: { body: { user_id: 'usr_123' } },
+      });
+
+      const updated = await client.updateDestination(id, {
+        filter: null,
+      });
+
+      const isEmpty =
+        updated.filter === null ||
+        updated.filter === undefined ||
+        (typeof updated.filter === 'object' && Object.keys(updated.filter).length === 0);
+      expect(isEmpty).to.be.true;
+    });
+
+    it('should not change filter when omitted', async () => {
+      const id = await createDest({
+        filter: { body: { user_id: 'usr_123' } },
+      });
+
+      const updated = await client.updateDestination(id, {
+        topics: ['*'],
+      });
+
+      expect(updated.filter).to.deep.include({ body: { user_id: 'usr_123' } });
+    });
+  });
+});

--- a/spec-sdk-tests/tests/destinations/webhook_merge_patch_test.go
+++ b/spec-sdk-tests/tests/destinations/webhook_merge_patch_test.go
@@ -1,0 +1,226 @@
+package destinations_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	outpostgo "github.com/hookdeck/outpost/sdks/outpost-go"
+	"github.com/hookdeck/outpost/sdks/outpost-go/models/components"
+	"github.com/hookdeck/outpost/sdks/outpost-go/optionalnullable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func getClient(t *testing.T) *outpostgo.Outpost {
+	t.Helper()
+	apiKey := os.Getenv("API_KEY")
+	if apiKey == "" {
+		apiKey = "apikey"
+	}
+	baseURL := os.Getenv("API_BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:3333/api/v1"
+	}
+	return outpostgo.New(
+		outpostgo.WithSecurity(apiKey),
+		outpostgo.WithServerURL(baseURL),
+	)
+}
+
+const testTenantID = "go-merge-patch-test"
+
+func setupTenant(t *testing.T, client *outpostgo.Outpost) {
+	t.Helper()
+	_, err := client.Tenants.Upsert(context.Background(), testTenantID, nil)
+	require.NoError(t, err)
+}
+
+func cleanupTenant(t *testing.T, client *outpostgo.Outpost) {
+	t.Helper()
+	_, _ = client.Tenants.Delete(context.Background(), testTenantID)
+}
+
+func webhookCreate(metadata map[string]string) components.DestinationCreateWebhook {
+	create := components.DestinationCreateWebhook{
+		Type:   components.DestinationCreateWebhookTypeWebhook,
+		Topics: components.CreateTopicsArrayOfStr([]string{"*"}),
+		Config: components.WebhookConfig{URL: "https://example.com/webhook"},
+	}
+	if metadata != nil {
+		create.Metadata = optionalnullable.From(&metadata)
+	}
+	return create
+}
+
+func createDest(t *testing.T, client *outpostgo.Outpost, create components.DestinationCreateWebhook) string {
+	t.Helper()
+	resp, err := client.Destinations.Create(context.Background(), testTenantID,
+		components.CreateDestinationCreateWebhook(create))
+	require.NoError(t, err)
+	wh := resp.GetDestinationWebhook()
+	require.NotNil(t, wh)
+	return wh.ID
+}
+
+func getDest(t *testing.T, client *outpostgo.Outpost, id string) *components.DestinationWebhook {
+	t.Helper()
+	resp, err := client.Destinations.Get(context.Background(), testTenantID, id)
+	require.NoError(t, err)
+	wh := resp.Destination.DestinationWebhook
+	require.NotNil(t, wh)
+	return wh
+}
+
+func updateDest(t *testing.T, client *outpostgo.Outpost, id string, update components.DestinationUpdateWebhook) {
+	t.Helper()
+	_, err := client.Destinations.Update(context.Background(), testTenantID, id,
+		components.CreateDestinationUpdateDestinationUpdateWebhook(update))
+	require.NoError(t, err)
+}
+
+func deleteDest(t *testing.T, client *outpostgo.Outpost, id string) {
+	t.Helper()
+	_, _ = client.Destinations.Delete(context.Background(), testTenantID, id)
+}
+
+// ── metadata merge-patch ──
+
+func TestMetadataMergePatch(t *testing.T) {
+	client := getClient(t)
+	setupTenant(t, client)
+	defer cleanupTenant(t, client)
+
+	t.Run("add key preserving existing", func(t *testing.T) {
+		id := createDest(t, client, webhookCreate(map[string]string{"env": "prod"}))
+		defer deleteDest(t, client, id)
+
+		updateDest(t, client, id, components.DestinationUpdateWebhook{
+			Metadata: optionalnullable.From(&map[string]*string{
+				"team": ptr("platform"),
+			}),
+		})
+
+		got := getDest(t, client, id)
+		m, ok := got.Metadata.GetOrZero()
+		require.True(t, ok)
+		assert.Equal(t, "prod", m["env"])
+		assert.Equal(t, "platform", m["team"])
+	})
+
+	t.Run("delete key via null value", func(t *testing.T) {
+		id := createDest(t, client, webhookCreate(map[string]string{"env": "prod", "region": "us-east-1"}))
+		defer deleteDest(t, client, id)
+
+		updateDest(t, client, id, components.DestinationUpdateWebhook{
+			Metadata: optionalnullable.From(&map[string]*string{
+				"region": nil, // null = delete key
+			}),
+		})
+
+		got := getDest(t, client, id)
+		m, ok := got.Metadata.GetOrZero()
+		require.True(t, ok)
+		assert.Equal(t, "prod", m["env"])
+		_, hasRegion := m["region"]
+		assert.False(t, hasRegion, "region should be deleted")
+	})
+
+	t.Run("clear entire field via null", func(t *testing.T) {
+		id := createDest(t, client, webhookCreate(map[string]string{"env": "prod"}))
+		defer deleteDest(t, client, id)
+
+		updateDest(t, client, id, components.DestinationUpdateWebhook{
+			Metadata: optionalnullable.From[map[string]*string](nil), // null = clear all
+		})
+
+		got := getDest(t, client, id)
+		m, _ := got.Metadata.GetOrZero()
+		assert.True(t, got.Metadata.IsNull() || len(m) == 0,
+			"metadata should be cleared")
+	})
+
+	t.Run("omitted field is no-op", func(t *testing.T) {
+		id := createDest(t, client, webhookCreate(map[string]string{"env": "prod"}))
+		defer deleteDest(t, client, id)
+
+		// Update with no metadata field set
+		updateDest(t, client, id, components.DestinationUpdateWebhook{})
+
+		got := getDest(t, client, id)
+		m, ok := got.Metadata.GetOrZero()
+		require.True(t, ok)
+		assert.Equal(t, "prod", m["env"])
+	})
+
+	t.Run("mixed add update delete", func(t *testing.T) {
+		id := createDest(t, client, webhookCreate(map[string]string{
+			"keep": "v", "remove": "v", "update": "old",
+		}))
+		defer deleteDest(t, client, id)
+
+		updateDest(t, client, id, components.DestinationUpdateWebhook{
+			Metadata: optionalnullable.From(&map[string]*string{
+				"remove": nil,
+				"update": ptr("new"),
+				"add":    ptr("v"),
+			}),
+		})
+
+		got := getDest(t, client, id)
+		m, ok := got.Metadata.GetOrZero()
+		require.True(t, ok)
+		assert.Equal(t, "v", m["keep"])
+		assert.Equal(t, "new", m["update"])
+		assert.Equal(t, "v", m["add"])
+		_, hasRemove := m["remove"]
+		assert.False(t, hasRemove, "remove key should be deleted")
+	})
+}
+
+// ── filter replacement ──
+
+func TestFilterReplacement(t *testing.T) {
+	client := getClient(t)
+	setupTenant(t, client)
+	defer cleanupTenant(t, client)
+
+	t.Run("clear filter with null", func(t *testing.T) {
+		create := webhookCreate(nil)
+		create.Filter = optionalnullable.From(&map[string]any{
+			"body": map[string]any{"user_id": "usr_123"},
+		})
+		id := createDest(t, client, create)
+		defer deleteDest(t, client, id)
+
+		updateDest(t, client, id, components.DestinationUpdateWebhook{
+			Filter: optionalnullable.From[map[string]any](nil),
+		})
+
+		got := getDest(t, client, id)
+		f, _ := got.Filter.GetOrZero()
+		assert.True(t, got.Filter.IsNull() || len(f) == 0,
+			"filter should be cleared")
+	})
+
+	t.Run("clear filter with empty map", func(t *testing.T) {
+		create := webhookCreate(nil)
+		create.Filter = optionalnullable.From(&map[string]any{
+			"body": map[string]any{"user_id": "usr_123"},
+		})
+		id := createDest(t, client, create)
+		defer deleteDest(t, client, id)
+
+		emptyFilter := map[string]any{}
+		updateDest(t, client, id, components.DestinationUpdateWebhook{
+			Filter: optionalnullable.From(&emptyFilter),
+		})
+
+		got := getDest(t, client, id)
+		f, _ := got.Filter.GetOrZero()
+		assert.True(t, got.Filter.IsNull() || len(f) == 0,
+			"filter should be cleared")
+	})
+}


### PR DESCRIPTION
## Summary

Replaces PR #844. Implements RFC 7396 JSON merge-patch semantics for destination PATCH endpoint, resolving the discussion about consistent update semantics.

### API Semantics

| Field | Semantics | Send `{"k":"v"}` | Send `{"k":null}` | Send `null` | Send `{}` | Omit |
|---|---|---|---|---|---|---|
| `config` | **Merge-patch** | Add/update key | Delete key | Clear all | No-op | No change |
| `credentials` | **Merge-patch** | Add/update key | Delete key | Clear all | No-op | No change |
| `metadata` | **Merge-patch** | Add/update key | Delete key | Clear all | No-op | No change |
| `delivery_metadata` | **Merge-patch** | Add/update key | Delete key | Clear all | No-op | No change |
| `filter` | **Replace** | Replace entirely | N/A | Clear | Clear | No change |

### Server Changes

- `UpdateDestinationRequest` fields changed from typed maps to `json.RawMessage` to distinguish omitted / null / object
- New `MergePatchStringMap` utility: null values delete keys per RFC 7396, type coercion matches existing `MapStringString` behavior
- `applyMergePatchStringMap` helper handles the three states (omitted → no-op, null → clear, object → merge-patch)
- Filter keeps full-replacement semantics (unchanged from before)

### OpenAPI Spec

- All 8 `DestinationUpdate*` schemas updated: `additionalProperties` now `oneOf: [string, "null"]` with RFC 7396 description
- Filter description clarified: full-replacement on update

### Go SDK

- `nullableOptionalWrapper: true` in Speakeasy gen.yaml (breaking change)
- All nullable optional fields wrapped in `OptionalNullable[T]` to distinguish omitted / null / value
- Update metadata/delivery_metadata typed as `OptionalNullable[map[string]*string]` — nil pointer values = delete key

### SDK Verification

All SDKs verified against running server:

| SDK | Tests | Null key deletion | Null field clear | Empty no-op | Omit no-op |
|---|---|---|---|---|---|
| **TypeScript** | 15/15 ✅ | `{region: null}` | `metadata: null` | `metadata: {}` | omit field |
| **Python** | 14/14 ✅ | `{"region": None}` | `metadata=None` | `metadata={}` | omit field |
| **Go** | 7/7 ✅ | `"region": nil` in map | `From[T](nil)` | N/A (omitempty) | zero value |

### Test Plan

- [x] Unit tests: `MergePatchStringMap` (12 tests) — add, update, delete, mixed, type coercion
- [x] Handler tests: 24 tests covering all fields × all merge-patch/replacement operations
- [x] SDK e2e: TS (15), Python (14), Go (7) — all passing against live server
- [x] Pre-existing tests: all pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)