### PR TITLE
fix: remove go:generate directive for configdocsgen

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,3 @@
-//go:generate go run ../../cmd/configdocsgen/main.go -input-dir . -output-file ../../docs/pages/references/configuration.mdx
 package config
 
 import (


### PR DESCRIPTION
Docs moved from `docs/pages/` to `docs/content/`, so the `go:generate` directive in `config.go` points at a nonexistent path and breaks goreleaser's `go generate ./...` hook. Removes the directive; `make docs/generate/config` still works for manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)