### PR TITLE
chore(docs): align Outpost tenant terminology with dashboard onboarding

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs-agent-eval-ci.yml
+++ b/.github/workflows/docs-agent-eval-ci.yml
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: docs/agent-evaluation/package-lock.json
 
@@ -79,7 +79,7 @@ jobs:
       # Transcripts, heuristic + LLM scores, generated scripts — present after eval; execute step may add logs in-place.
       - name: Upload agent eval outputs (debug)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-agent-eval-runs-${{ github.run_id }}-${{ github.run_attempt }}
           path: docs/agent-evaluation/results/runs

--- a/.github/workflows/docs-agent-eval-ci.yml
+++ b/.github/workflows/docs-agent-eval-ci.yml
@@ -75,3 +75,13 @@ jobs:
           # Agent eval 01/02 fixtures use this tenant; delete before+after so destination caps do not break CI.
           OUTPOST_CI_CLEANUP_TENANT: customer_acme_001
         run: ./scripts/execute-ci-artifacts.sh
+
+      # Transcripts, heuristic + LLM scores, generated scripts — present after eval; execute step may add logs in-place.
+      - name: Upload agent eval outputs (debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-agent-eval-runs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: docs/agent-evaluation/results/runs
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Code checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install JS dependencies
         run: npm install

--- a/.github/workflows/sdk_publish_outpost_go.yaml
+++ b/.github/workflows/sdk_publish_outpost_go.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Ensure all tags are fetched

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/update-compose-version.yml
+++ b/.github/workflows/update-compose-version.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # We need to fetch all history for gh release list and to push
           fetch-depth: 0

--- a/docs/agent-evaluation/AGENTS.md
+++ b/docs/agent-evaluation/AGENTS.md
@@ -6,7 +6,7 @@ This file applies to **everything under `docs/agent-evaluation/`** (scenarios, R
 
 | Audience                 | Content                                                                                                                                                                                   |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **The model under test** | Turn 0 = pasted [`hookdeck-outpost-agent-prompt.mdoc`](../agent-evaluation/hookdeck-outpost-agent-prompt.md) template only, plus **Turn N — User** blockquotes (verbatim user role-play). |
+| **The model under test** | Turn 0 = pasted [`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md) **## Template** (placeholders filled), **plus** for **scenario 01 only** the harness appends the `<!-- eval:turn0-appendix-start -->` … `<!-- eval:turn0-appendix-end -->` block from [`scenarios/01-basics-curl.md`](scenarios/01-basics-curl.md) after the template (shell/`curl` hygiene — not Outpost API semantics); then **Turn N — User** blockquotes (verbatim user role-play). |
 | **Humans / harness**     | Intent, preconditions, eval harness JSON, Success criteria, Failure modes, `score-transcript.ts`, README.                                                                                 |
 
 **Never** put harness vocabulary into **user** lines. The user is a product engineer, not an eval runner.

--- a/docs/agent-evaluation/README.md
+++ b/docs/agent-evaluation/README.md
@@ -96,7 +96,7 @@ The workflow uses **`concurrency: { group: outpost-docs-agent-eval-live-outpost,
 - **`EVAL_LOCAL_DOCS=1`** — Turn 0 replaces public doc URLs with **absolute paths to MDX/OpenAPI files in this repo** (agent uses **Read** on **`docs/`** instead of **WebFetch** to production). Use locally when validating unpublished docs; **GitHub Actions** sets this for **`docs-agent-eval-ci.yml`**.
 - **`EVAL_SKIP_HARNESS_PRE_STEPS=1`** — skip **`git_clone`** (and any future **`preSteps`**) declared in a scenario’s **`## Eval harness`** JSON block; useful offline or when the baseline folder is already present.
 
-- **Turn 0** text is built from [`hookdeck-outpost-agent-prompt.mdoc`](../agent-evaluation/hookdeck-outpost-agent-prompt.md) (`## Template`) with placeholders filled from environment variables.
+- **Turn 0** text is built from [`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md) (`## Template`) with placeholders filled from environment variables. **Scenario 01 (curl)** only: the runner **appends** the delimited block `<!-- eval:turn0-appendix-start -->` … `<!-- eval:turn0-appendix-end -->` from [`scenarios/01-basics-curl.md`](scenarios/01-basics-curl.md) after that template (POSIX / `curl` hygiene — not Outpost API teaching); see that file § Turn 0 for manual parity.
 - Transcripts are written to `results/runs/<stamp>-scenario-NN/transcript.json` (gitignored).
 
 See `npm run eval -- --help` for env vars (`EVAL_TOOLS`, `EVAL_MODEL`, etc.).

--- a/docs/agent-evaluation/scenarios/01-basics-curl.md
+++ b/docs/agent-evaluation/scenarios/01-basics-curl.md
@@ -17,7 +17,16 @@ The harness sets the agent **cwd** to an empty directory under `docs/agent-evalu
 
 ### Turn 0
 
-Paste the **## Template** block from `[hookdeck-outpost-agent-prompt.mdoc](../../agent-evaluation/hookdeck-outpost-agent-prompt.md)`, with `{{…}}` filled using your project or `[fixtures/placeholder-values-for-turn0.md](../fixtures/placeholder-values-for-turn0.md)`.
+1. Paste the **## Template** block from [`hookdeck-outpost-agent-prompt.md`](../hookdeck-outpost-agent-prompt.md), with `{{…}}` filled using your project or [`fixtures/placeholder-values-for-turn0.md`](../fixtures/placeholder-values-for-turn0.md) (same shared Turn 0 as other scenarios).
+2. **Immediately after**, paste everything between `<!-- eval:turn0-appendix-start -->` and `<!-- eval:turn0-appendix-end -->` below (POSIX / `curl` only — no API or product semantics). **Automated** runs: the harness extracts that block and appends it after the template.
+
+<!-- eval:turn0-appendix-start -->
+When you emit **shell** that invokes **`curl`** (including small wrapper functions), **quoting is your responsibility** — it is orthogonal to HTTP paths and JSON bodies (those follow the documentation already in your context).
+
+- After parsing fixed leading arguments (e.g. method and URL), pass the remainder into `curl` with **`"$@"`** or another form that keeps **one shell word per `--data` payload**. **Never** expand a variable that holds multiple curl arguments **unquoted** on the `curl` line: the shell **word-splits** JSON and `curl` can treat fragments as extra URLs (symptoms such as “bad hostname”, “port number”, or “bad range in URL” with no meaningful HTTP status from the server).
+- For **multi-line JSON** bodies, prefer a **quoted heredoc** into `curl --data-binary @-`, **`jq -n`**, or a **single-quoted** `-d` string when it stays readable — pick the smallest pattern that is obviously safe when rerun non-interactively.
+- When values come from the **environment** (URLs, secrets, tokens), keep those expansions **inside** quoted JSON strings or otherwise **shell-quoted** so characters such as `&`, `?`, or spaces cannot break the command line.
+<!-- eval:turn0-appendix-end -->
 
 ### Turn 1 — User
 

--- a/docs/agent-evaluation/src/run-agent-eval.ts
+++ b/docs/agent-evaluation/src/run-agent-eval.ts
@@ -40,6 +40,28 @@ const PROMPT_MDX = join(
 const SCENARIOS_DIR = join(EVAL_ROOT, "scenarios");
 const RUNS_DIR = join(EVAL_ROOT, "results", "runs");
 
+/** Extract scenario-01 Turn 0 shell appendix from `01-basics-curl.md` (delimited block). */
+const TURN0_APPENDIX_IN_SCENARIO = /<!--\s*eval:turn0-appendix-start\s*-->\s*([\s\S]*?)\s*<!--\s*eval:turn0-appendix-end\s*-->/;
+
+function turn0AppendixFromScenarioMarkdown(
+  scenarioFile: string,
+  scenarioMarkdown: string,
+): string {
+  if (idFromFilename(scenarioFile) !== "01") return "";
+  const m = scenarioMarkdown.match(TURN0_APPENDIX_IN_SCENARIO);
+  if (!m) {
+    throw new Error(
+      `Scenario ${scenarioFile} must include <!-- eval:turn0-appendix-start --> ... <!-- eval:turn0-appendix-end --> (shell/curl Turn 0 supplement).`,
+    );
+  }
+  const body = m[1]!.trim();
+  return (
+    "\n\n## Scenario 01 appendix (shell / curl — code quality only)\n\n" +
+    body +
+    "\n"
+  );
+}
+
 /**
  * Harness-only status files next to the run folder (not inside `runDir`) so the agent sandbox cannot Read them.
  * Example: `…/runs/2026-…-scenario-08/transcript.json` vs `…/runs/2026-…-scenario-08.eval-started.json`.
@@ -841,12 +863,23 @@ Agent cwd is usually the run directory. Scenarios may define ## Eval harness (JS
       REPO_ROOT,
       localDocs,
     );
+    let scenario01AppendixChars = 0;
+    const file01 = selected.find((f) => idFromFilename(f) === "01");
+    if (file01) {
+      const md01 = await readFile(join(SCENARIOS_DIR, file01), "utf8");
+      scenario01AppendixChars = turn0AppendixFromScenarioMarkdown(
+        file01,
+        md01,
+      ).length;
+    }
     console.log("Dry run: would execute", selected.join(", "));
     console.log(
       "Turn 0 base template (chars):",
       filledTemplate.length,
       "| + workspace boundary (~chars):",
       boundarySample.length,
+      "| + scenario 01 shell appendix (~chars):",
+      scenario01AppendixChars,
     );
     process.exit(0);
   }
@@ -889,6 +922,7 @@ Agent cwd is usually the run directory. Scenarios may define ## Eval harness (JS
     });
     const turn0Prompt =
       filledTemplate +
+      turn0AppendixFromScenarioMarkdown(file, scenarioMd) +
       buildWorkspaceBoundaryAppendix(runDir, agentCwd, REPO_ROOT, localDocs);
     console.error(
       `\n>>> Scenario ${file} (run dir ${runDir}, agent cwd ${agentCwd}) ...`,

--- a/docs/content/concepts.mdoc
+++ b/docs/content/concepts.mdoc
@@ -11,7 +11,7 @@ At a high level, the same mental model as a single-tenant webhook product still 
 
 **Typical flow:**
 
-1. **Map your customer to a tenant** — Each organization, team, or account in your app should have a stable **tenant id** in Outpost (often the same id you already use internally). Create or upsert that tenant when the customer is ready to use outbound events (onboarding, first visit to integrations, and so on).
+1. **Map your customer to a tenant** — In B2B SaaS this is usually an **organization** (or workspace / team): one Outpost **tenant** per account you sell to, with that org’s users managing destinations on its behalf. In B2C or simple apps it may be a single end user. Use a stable **tenant id** (often the same ID you already store—org ID, account ID, and so on). Create or upsert that tenant when the customer is ready to use outbound events (onboarding, first visit to integrations, and so on).
 2. **Each tenant has zero or more destinations** — A **destination** is a concrete subscription: it combines a **destination type** (webhook, SQS, Hookdeck, …), one or more **topics** the customer wants to receive, and **type-specific configuration** (for a webhook, the HTTPS **endpoint URL** and signing secret; for a queue, the queue identifier; and so on). One tenant may have several destinations (for example production vs staging endpoints, or different systems).
 3. **Your backend publishes events** — When something happens, your **server** calls the publish API (or SDK) with **`tenant_id`**, **`topic`**, and payload metadata. Outpost does **not** infer the tenant from the browser; publishing uses your **platform** credentials and explicit tenant scope.
 4. **Outpost delivers to matching destinations** — For that tenant, every destination whose **topic subscription** includes the event’s topic gets a delivery attempt. A single publish can fan out to **many** destinations or to **none** if no destination subscribes to that topic.
@@ -22,7 +22,7 @@ For topic subscription behavior (wildcard `*`, multiple topics, fan-out), see [T
 
 ## Models
 
-- **Tenants** — A tenant represents a user, team, or organization in your product. All destinations and events are scoped to a tenant.
+- **Tenants** — A tenant is always an entity **in your product** that owns destinations and events. Most often it is an **organization** (or workspace / team): one tenant per customer company, with that org’s users managing its destinations. It can also be a single user in smaller products. It is **not** a Hookdeck login or an arbitrary end user unrelated to your account model—pick ids that match how you already identify the customer in your system.
 - **Destination Types** — The category of destination where events are delivered. Examples: webhook, Hookdeck Event Gateway, AWS SQS.
 - **Destinations** — A configured instance of a destination type. For example, a webhook destination with a specific URL and signing secret.
 - **Topics** — A topic categorizes events, following the common Pub/Sub concept. For example, `user.created` or `payment.succeeded`. Tenants subscribe their destinations to specific topics.
@@ -33,7 +33,7 @@ For topic subscription behavior (wildcard `*`, multiple topics, fan-out), see [T
 
 Outpost is designed as a multi-tenant system from the ground up. Each tenant has isolated destinations, topics, and event delivery. A single Outpost deployment serves all your customers.
 
-Tenants are created and managed via the API. Each tenant is identified by a string ID that maps to an identifier in your own system — for example, your customer's organization ID or database primary key. Outpost does not generate tenant IDs.
+Tenants are created and managed via the API. Each tenant is identified by a string ID that maps to an identifier in your own system—for example your customer’s **organization id**, workspace id, or account primary key. Outpost does not generate tenant IDs.
 
 If your application is single-tenant, use a hardcoded value such as `default`, `production`, or `staging` to support multiple environments on the same Outpost deployment.
 

--- a/docs/content/concepts.mdoc
+++ b/docs/content/concepts.mdoc
@@ -11,7 +11,7 @@ At a high level, the same mental model as a single-tenant webhook product still 
 
 **Typical flow:**
 
-1. **Map your customer to a tenant** — In B2B SaaS this is usually an **organization** (or workspace / team): one Outpost **tenant** per account you sell to, with that org’s users managing destinations on its behalf. In B2C or simple apps it may be a single end user. Use a stable **tenant id** (often the same ID you already store—org ID, account ID, and so on). Create or upsert that tenant when the customer is ready to use outbound events (onboarding, first visit to integrations, and so on).
+1. **Map your customer to a tenant** — Pick the entity **in your product** that should own destinations for a slice of customers—often an **organization**, **project**, **workspace**, **team**, or **user**, depending on how you structure accounts. One Outpost **tenant** per such entity (for example one tenant per company, per project, or per end user in B2C). Use a stable **tenant id** that matches an identifier you already store. Create or upsert that tenant when that scope is ready to use outbound events (onboarding, first visit to integrations, and so on).
 2. **Each tenant has zero or more destinations** — A **destination** is a concrete subscription: it combines a **destination type** (webhook, SQS, Hookdeck, …), one or more **topics** the customer wants to receive, and **type-specific configuration** (for a webhook, the HTTPS **endpoint URL** and signing secret; for a queue, the queue identifier; and so on). One tenant may have several destinations (for example production vs staging endpoints, or different systems).
 3. **Your backend publishes events** — When something happens, your **server** calls the publish API (or SDK) with **`tenant_id`**, **`topic`**, and payload metadata. Outpost does **not** infer the tenant from the browser; publishing uses your **platform** credentials and explicit tenant scope.
 4. **Outpost delivers to matching destinations** — For that tenant, every destination whose **topic subscription** includes the event’s topic gets a delivery attempt. A single publish can fan out to **many** destinations or to **none** if no destination subscribes to that topic.
@@ -22,7 +22,7 @@ For topic subscription behavior (wildcard `*`, multiple topics, fan-out), see [T
 
 ## Models
 
-- **Tenants** — A tenant is always an entity **in your product** that owns destinations and events. Most often it is an **organization** (or workspace / team): one tenant per customer company, with that org’s users managing its destinations. It can also be a single user in smaller products. It is **not** a Hookdeck login or an arbitrary end user unrelated to your account model—pick ids that match how you already identify the customer in your system.
+- **Tenants** — A tenant is always an entity **in your product** that owns destinations and events. It usually maps to an **organization**, **project**, **workspace**, **team**, or **user** (some products surface the same idea as a customer **account**)—the same unit you scope settings, billing, or integrations to in your own model. It is **not** a Hookdeck login or an unrelated visitor—pick ids that match how you already identify that entity in your system.
 - **Destination Types** — The category of destination where events are delivered. Examples: webhook, Hookdeck Event Gateway, AWS SQS.
 - **Destinations** — A configured instance of a destination type. For example, a webhook destination with a specific URL and signing secret.
 - **Topics** — A topic categorizes events, following the common Pub/Sub concept. For example, `user.created` or `payment.succeeded`. Tenants subscribe their destinations to specific topics.
@@ -33,7 +33,7 @@ For topic subscription behavior (wildcard `*`, multiple topics, fan-out), see [T
 
 Outpost is designed as a multi-tenant system from the ground up. Each tenant has isolated destinations, topics, and event delivery. A single Outpost deployment serves all your customers.
 
-Tenants are created and managed via the API. Each tenant is identified by a string ID that maps to an identifier in your own system—for example your customer’s **organization id**, workspace id, or account primary key. Outpost does not generate tenant IDs.
+Tenants are created and managed via the API. Each tenant is identified by a string ID that maps to an identifier in your own system—for example an **organization**, **project**, **workspace**, **team**, or **user** id, or your account primary key. Outpost does not generate tenant IDs.
 
 If your application is single-tenant, use a hardcoded value such as `default`, `production`, or `staging` to support multiple environments on the same Outpost deployment.
 

--- a/docs/content/concepts.mdoc
+++ b/docs/content/concepts.mdoc
@@ -11,7 +11,7 @@ At a high level, the same mental model as a single-tenant webhook product still 
 
 **Typical flow:**
 
-1. **Map your customer to a tenant** — Pick the entity **in your product** that should own destinations for a slice of customers—often an **organization**, **project**, **workspace**, **team**, or **user**, depending on how you structure accounts. One Outpost **tenant** per such entity (for example one tenant per company, per project, or per end user in B2C). Use a stable **tenant id** that matches an identifier you already store. Create or upsert that tenant when that scope is ready to use outbound events (onboarding, first visit to integrations, and so on).
+1. **Map your customer to a tenant** — Pick the entity **in your product** that should own destinations for a slice of customers—often an **organization**, **project**, **workspace**, **team**, or **user**, depending on how you structure accounts. One Outpost **tenant** per such entity (for example one tenant per company, per project, or per end user in B2C). Use a stable **tenant ID** that matches an identifier you already store. Create or upsert that tenant when that scope is ready to use outbound events (onboarding, first visit to integrations, and so on).
 2. **Each tenant has zero or more destinations** — A **destination** is a concrete subscription: it combines a **destination type** (webhook, SQS, Hookdeck, …), one or more **topics** the customer wants to receive, and **type-specific configuration** (for a webhook, the HTTPS **endpoint URL** and signing secret; for a queue, the queue identifier; and so on). One tenant may have several destinations (for example production vs staging endpoints, or different systems).
 3. **Your backend publishes events** — When something happens, your **server** calls the publish API (or SDK) with **`tenant_id`**, **`topic`**, and payload metadata. Outpost does **not** infer the tenant from the browser; publishing uses your **platform** credentials and explicit tenant scope.
 4. **Outpost delivers to matching destinations** — For that tenant, every destination whose **topic subscription** includes the event’s topic gets a delivery attempt. A single publish can fan out to **many** destinations or to **none** if no destination subscribes to that topic.
@@ -22,7 +22,7 @@ For topic subscription behavior (wildcard `*`, multiple topics, fan-out), see [T
 
 ## Models
 
-- **Tenants** — A tenant is always an entity **in your product** that owns destinations and events. It usually maps to an **organization**, **project**, **workspace**, **team**, or **user** (some products surface the same idea as a customer **account**)—the same unit you scope settings, billing, or integrations to in your own model. It is **not** a Hookdeck login or an unrelated visitor—pick ids that match how you already identify that entity in your system.
+- **Tenants** — A tenant is always an entity **in your product** that owns destinations and events. It usually maps to an **organization**, **project**, **workspace**, **team**, or **user** (some products surface the same idea as a customer **account**)—the same unit you scope settings, billing, or integrations to in your own model. It is **not** a Hookdeck login or an unrelated visitor—pick IDs that match how you already identify that entity in your system.
 - **Destination Types** — The category of destination where events are delivered. Examples: webhook, Hookdeck Event Gateway, AWS SQS.
 - **Destinations** — A configured instance of a destination type. For example, a webhook destination with a specific URL and signing secret.
 - **Topics** — A topic categorizes events, following the common Pub/Sub concept. For example, `user.created` or `payment.succeeded`. Tenants subscribe their destinations to specific topics.
@@ -33,7 +33,7 @@ For topic subscription behavior (wildcard `*`, multiple topics, fan-out), see [T
 
 Outpost is designed as a multi-tenant system from the ground up. Each tenant has isolated destinations, topics, and event delivery. A single Outpost deployment serves all your customers.
 
-Tenants are created and managed via the API. Each tenant is identified by a string ID that maps to an identifier in your own system—for example an **organization**, **project**, **workspace**, **team**, or **user** id, or your account primary key. Outpost does not generate tenant IDs.
+Tenants are created and managed via the API. Each tenant is identified by a string ID that maps to an identifier in your own system—for example, an **organization**, **project**, **workspace**, **team**, or **user** ID, or your account primary key. Outpost does not generate tenant IDs.
 
 If your application is single-tenant, use a hardcoded value such as `default`, `production`, or `staging` to support multiple environments on the same Outpost deployment.
 

--- a/docs/content/features/multi-tenancy.mdoc
+++ b/docs/content/features/multi-tenancy.mdoc
@@ -7,7 +7,7 @@ Outpost is designed as a multi-tenant system from the ground up. Every resource 
 
 ## Tenant Identifiers
 
-Each tenant is identified by a string ID that you define. Outpost does not generate tenant IDs, enabling you to use your existing customer identifiers (for example organization, project, workspace, team, or user IDs, a database primary key, or a slug).
+Each tenant is identified by a string ID that you define. Outpost does not generate tenant IDs, enabling you to use your existing customer identifiers (for example, organization IDs, project IDs, workspace IDs, team IDs, or user IDs, a database primary key, or a slug).
 
 If your application is single-tenant, use a hardcoded value such as `default`, `production`, or `staging` to support multiple environments on the same deployment.
 

--- a/docs/content/features/multi-tenancy.mdoc
+++ b/docs/content/features/multi-tenancy.mdoc
@@ -7,7 +7,7 @@ Outpost is designed as a multi-tenant system from the ground up. Every resource 
 
 ## Tenant Identifiers
 
-Each tenant is identified by a string ID that you define. Outpost does not generate tenant IDs, enabling you to use your existing customer identifiers (e.g., organization ID, database primary key, or slug).
+Each tenant is identified by a string ID that you define. Outpost does not generate tenant IDs, enabling you to use your existing customer identifiers (for example organization, project, workspace, team, or user IDs, a database primary key, or a slug).
 
 If your application is single-tenant, use a hardcoded value such as `default`, `production`, or `staging` to support multiple environments on the same deployment.
 

--- a/docs/content/guides/building-your-own-ui.mdoc
+++ b/docs/content/guides/building-your-own-ui.mdoc
@@ -29,8 +29,8 @@ The tenant portal illustrates how screens map to tenant → destinations → top
 
 **Tenant context**
 
-- Everything below applies to one tenant at a time: the signed-in account in your SaaS (your customer). Use that account’s `tenant_id` when listing or creating destinations and when publishing from your backend.
-- With a tenant JWT, the token is scoped to that tenant. If you proxy through your API, resolve the signed-in account to `tenant_id` and forward it on list, create, and publish calls.
+- Everything below applies to one **Outpost tenant** at a time: the **customer account in your SaaS** your UI is scoped to (often an **organization** or workspace—use the same stable ID you use for that customer in your database). Use that account's `tenant_id` when listing or creating destinations and when publishing from your backend.
+- With a tenant JWT, the token is scoped to that tenant. If you proxy through your API, resolve the signed-in customer (for example the current org) to `tenant_id` and forward it on list, create, and publish calls.
 
 **Recommended areas / screens**
 

--- a/docs/content/guides/building-your-own-ui.mdoc
+++ b/docs/content/guides/building-your-own-ui.mdoc
@@ -29,8 +29,8 @@ The tenant portal illustrates how screens map to tenant → destinations → top
 
 **Tenant context**
 
-- Everything below applies to one **Outpost tenant** at a time: the **customer account in your SaaS** your UI is scoped to (often an **organization** or workspace—use the same stable ID you use for that customer in your database). Use that account's `tenant_id` when listing or creating destinations and when publishing from your backend.
-- With a tenant JWT, the token is scoped to that tenant. If you proxy through your API, resolve the signed-in customer (for example the current org) to `tenant_id` and forward it on list, create, and publish calls.
+- Everything below applies to one **Outpost tenant** at a time: the **scope your SaaS UI is built around**—often a customer **account** in the broad sense (an organization, project, workspace, team, or user—use the same stable `tenant_id` you store for that scope in your database). Use that tenant's `tenant_id` when listing or creating destinations and when publishing from your backend.
+- With a tenant JWT, the token is scoped to that tenant. If you proxy through your API, resolve the signed-in scope (for example the current org, project, workspace, team, or user) to `tenant_id` and forward it on list, create, and publish calls.
 
 **Recommended areas / screens**
 


### PR DESCRIPTION
## Summary

Doc-only updates so public Outpost docs describe **tenants** the same way as the refreshed Hookdeck dashboard onboarding copy: entities **in the host product** (organization, project, workspace, team, or user), with **customer account** called out lightly where it helps SaaS readers without repeating it everywhere.

## Changes

- **`docs/content/concepts.mdoc`** — Typical flow + **Tenants** model + tenant ID examples; optional parenthetical tying “account” to the same layer when products use that word.
- **`docs/content/guides/building-your-own-ui.mdoc`** — Tenant context bullet: UI scope as customer **account** in the broad sense, then concrete examples.
- **`docs/content/features/multi-tenancy.mdoc`** — Tenant identifier examples expanded to match (org / project / workspace / team / user IDs, etc.).

No API or runtime changes.

Made with [Cursor](https://cursor.com)