### PR TITLE
docs(agent-eval): README refresh and scenario 01 publish heuristic fix

### DIFF
--- a/docs/agent-evaluation/README.md
+++ b/docs/agent-evaluation/README.md
@@ -127,7 +127,7 @@ This folder contains **manual** scenario specs (markdown) and an **automated** r
 
 **Deliberate scope:** `npm run eval` **requires** **`--scenario`**, **`--scenarios`**, or **`--all`**. There is no silent "run everything" default — you choose the scenarios and accept the cost. After **each** run: **`transcript.json`**, **`heuristic-score.json`**, and **`llm-score.json`** (judge reads the same **Success criteria** as humans). Exit **1** if any enabled score fails.
 
-Opt out of scoring: **`--no-score`** (heuristic only), **`--no-score-llm`** (drops the Success-criteria judge), or **`.env`**: **`EVAL_NO_SCORE_HEURISTIC=1`**, **`EVAL_NO_SCORE_LLM=1`**. Transcript-only: **`npm run eval -- --no-score --no-score-llm`**.
+Opt out of scoring: **`--no-score`** (skips heuristic scoring), **`--no-score-llm`** (drops the Success-criteria judge), or **`.env`**: **`EVAL_NO_SCORE_HEURISTIC=1`**, **`EVAL_NO_SCORE_LLM=1`**. Transcript-only: **`npm run eval -- --no-score --no-score-llm`**.
 
 Each scenario run uses one directory:
 

--- a/docs/agent-evaluation/README.md
+++ b/docs/agent-evaluation/README.md
@@ -1,19 +1,131 @@
 # Agent evaluation — Hookdeck Outpost onboarding
 
-This folder contains **manual** scenario specs (markdown) and an **automated** runner that uses the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) (`src/run-agent-eval.ts`).
+An evaluation harness for testing whether AI agents can successfully onboard developers to [Hookdeck Outpost](https://hookdeck.com/outpost) (outbound webhooks and event destinations) — from first prompt through to a working integration.
+
+## What this is
+
+As AI agents become a primary way developers interact with platforms, the onboarding experience needs to work for agents, not just humans. This harness evaluates the complete agent onboarding journey: give an agent a task, point it at the docs, SDK, and API, and measure whether it produces a working result.
+
+The core artifact being tested is the **Turn 0 prompt** — a 22K-token onboarding prompt that's the single artifact with the most leverage over agent behavior. It's the equivalent of the "getting started" page, but for an agent. At 22K tokens, it occupies ~11% of Claude Sonnet's 200K context window, ~17% of GPT-4o's 128K, or ~2% of the 1M-token models (Claude Opus 4.7, Gemini 2.5 Pro, GPT-4.1).
+
+The goal of agent onboarding: give the developer a **working prototype** they can evaluate and build on — including integration into their existing application.
+
+## Why this exists
+
+Traditional developer experience had natural feedback loops: support tickets, user interviews, onboarding analytics. With agents, that signal disappears. The agent either succeeds or silently fails and moves on to a competitor. Evals are the feedback loop you get back.
+
+This harness answers: **when an agent follows our onboarding prompt, does it produce working code that actually integrates with Outpost?**
+
+## Architecture
+
+```
+Turn 0 prompt (22K tokens)
+        |
+        v
+   Agent runs against
+   docs / SDK / API
+        |
+        v
+  Generated artifacts
+  (code, config, scripts)
+        |
+        v
+  ┌─────────────────────┐
+  │   Scoring            │
+  │                      │
+  │  Deterministic:      │
+  │   - Heuristics       │
+  │     (transcript +    │
+  │      artifact checks)│
+  │   - Live execution   │
+  │     (run agent code  │
+  │      against real    │
+  │      Outpost)        │
+  │                      │
+  │  LLM judge:          │
+  │   - Scores against   │
+  │     same criteria    │
+  │     human reviewers  │
+  │     use              │
+  └─────────────────────┘
+```
+
+## Scenarios
+
+10 scenarios across 3 tiers of increasing complexity:
+
+### Tier 1 — "Try it out"
+
+Basic integration using a single language or tool. Does the agent produce working code that sends events to Outpost?
+
+| ID  | File                                                                              | Goal                                                                   |
+| --- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1   | [scenarios/01-basics-curl.md](scenarios/01-basics-curl.md)                        | Minimal **curl** only (managed API).                                   |
+| 2   | [scenarios/02-basics-typescript.md](scenarios/02-basics-typescript.md)             | Minimal **TypeScript** script (`@hookdeck/outpost-sdk`).               |
+| 3   | [scenarios/03-basics-python.md](scenarios/03-basics-python.md)                    | Minimal **Python** script (`outpost_sdk`).                             |
+| 4   | [scenarios/04-basics-go.md](scenarios/04-basics-go.md)                            | Minimal **Go** program (`outpost-go`).                                 |
+
+### Tier 2 — "Build a minimal app"
+
+Scaffold a small application with Outpost integration. Tests whether the agent can build something runnable end-to-end.
+
+| ID  | File                                                                              | Goal                                                                   |
+| --- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 5   | [scenarios/05-app-nextjs.md](scenarios/05-app-nextjs.md)                          | Small **Next.js** app: UI to register a webhook destination and trigger a test publish. |
+| 6   | [scenarios/06-app-fastapi.md](scenarios/06-app-fastapi.md)                        | Small **FastAPI** app with the same UX as scenario 5.                  |
+| 7   | [scenarios/07-app-go-http.md](scenarios/07-app-go-http.md)                        | Small **Go** `net/http` app + simple HTML UI (same UX as scenario 5).  |
+
+### Tier 3 — "Integrate with an existing app"
+
+Integrate Outpost into a pinned open-source codebase. The agent has to understand an existing application, figure out where to add the integration, and make it work. This is a fundamentally different challenge from scaffolding from scratch.
+
+| ID  | File                                                                                              | Goal                                                                   |
+| --- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 8   | [scenarios/08-integrate-nextjs-existing.md](scenarios/08-integrate-nextjs-existing.md)             | **Existing Next.js SaaS** baseline — add outbound webhooks via Outpost ([leerob/next-saas-starter](https://github.com/leerob/next-saas-starter)). |
+| 9   | [scenarios/09-integrate-fastapi-existing.md](scenarios/09-integrate-fastapi-existing.md)           | **Existing FastAPI full-stack** baseline — Outpost integration ([fastapi/full-stack-fastapi-template](https://github.com/fastapi/full-stack-fastapi-template)). |
+| 10  | [scenarios/10-integrate-go-existing.md](scenarios/10-integrate-go-existing.md)                     | **Existing Go SaaS API** baseline — Outpost integration ([devinterface/startersaas-go-api](https://github.com/devinterface/startersaas-go-api)). |
+
+Scenarios **1–4** align with **"Try it out"**; **5–7** with **"Build a minimal example"**; **8–10** with **"Integrate with an existing app"** using pinned OSS baselines (Java / .NET can be added later the same way).
+
+## The iteration loop (how to use this harness)
+
+This section is **operating guidance**, not something the repo automates. There is no paired A/B runner, no prompt-version registry, and no stored “pass rate” or delta — you **derive** comparisons from discrete runs yourself (diff transcripts, open `heuristic-score.json` / `llm-score.json`, spreadsheets, or your own notes).
+
+**What “iteration” means here:** you hold **scenario set** and harness settings as steady as you can, change **Turn 0** ([`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md) and/or eval env such as `EVAL_LOCAL_DOCS`), then **re-run the same commands** (for example `npm run eval -- --scenarios 01,02` or `npm run eval:ci`). Each run writes a **new** directory under [`results/runs/`](results/runs/) with a timestamp — keep the folders (or copies of the score JSON) so you can compare **before vs after** a prompt edit.
+
+**What a “pass delta” would be in practice:** after two batches of runs, you count how many scenarios passed heuristic, LLM judge, and (if you do it) **live execution** — then subtract or tabulate. That arithmetic lives outside this package; the harness only emits **per-run** pass/fail (exit code **1** if any enabled scorer fails for that run).
+
+**Suggested workflow:**
+
+1. Record **which commit / branch** Turn 0 and docs were on, and the exact **`npm run eval …`** flags and important env vars (`EVAL_LOCAL_DOCS`, model, and so on).
+2. Run your chosen slice; optionally track outcomes in **[`SCENARIO-RUN-TRACKER.md`](SCENARIO-RUN-TRACKER.md)** (heuristic / LLM / execution columns and **Notes**).
+3. Change the prompt or docs; repeat with the **same** scenario slice.
+4. Compare run dirs or tracker rows to see whether onboarding got **better, worse, or no change** — and open **`transcript.json`** when scores disagree or execution fails.
+
+CI’s **`eval:ci`** slice is one fixed scenario pair for regression signal; broader iteration (more scenarios, different models) stays a **local or ad hoc** process until you add your own automation on top.
+
+---
+
+## Operational reference
+
+Everything below is the detailed operational guide for running, scoring, and debugging evaluations.
+
+### Where success criteria live
+
+| What                                                                              | Where                                                                  |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Human checklist** (full eval, including execution)                               | Each file under [`scenarios/`](scenarios/) — section **Success criteria** (static + **Execution (full pass)** rows). |
+| **Manual run write-up**                                                            | [`results/RUN-RECORDING.template.md`](results/RUN-RECORDING.template.md) — copy to a local file under `results/` (gitignored). |
+| **Automated transcript rubric** (regex heuristics)                                 | [`src/score-transcript.ts`](src/score-transcript.ts) — `scoreScenario01`–`scoreScenario10` (assistant text + tool-written file corpus). Scenarios **08–10** include **`publish_beyond_test_only`** (domain publish signal vs test-only). |
+| **LLM judge** (Anthropic vs **`## Success criteria`** in each scenario)            | [`src/llm-judge.ts`](src/llm-judge.ts) — runs after each scenario unless **`--no-score-llm`**; also `npm run score -- --llm`. |
 
 **Authoring standards (user-turn wording, no eval leakage):** [`AGENTS.md`](AGENTS.md) — also enforced via [`.cursor/rules/agent-evaluation-authoring.mdc`](../../.cursor/rules/agent-evaluation-authoring.mdc) when editing here.
 
-## Where success criteria live
+### Scoring detail
 
-| What                                                                    | Where                                                                                                                                                                                                                                    |
-| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Human checklist** (full eval, including execution)                    | Each file under [`scenarios/`](scenarios/) — section **Success criteria** (static + **Execution (full pass)** rows).                                                                                                                     |
-| **Manual run write-up**                                                 | [`results/RUN-RECORDING.template.md`](results/RUN-RECORDING.template.md) — copy to a local file under `results/` (gitignored).                                                                                                           |
-| **Automated transcript rubric** (regex heuristics)                      | [`src/score-transcript.ts`](src/score-transcript.ts) — `scoreScenario01`–`scoreScenario10` (assistant text + tool-written file corpus). Scenarios **08–10** include **`publish_beyond_test_only`** (domain publish signal vs test-only). |
-| **LLM judge** (Anthropic vs **`## Success criteria`** in each scenario) | [`src/llm-judge.ts`](src/llm-judge.ts) — runs after each scenario unless **`--no-score-llm`**; also `npm run score -- --llm`.                                                                                                            |
+This folder contains **manual** scenario specs (markdown) and an **automated** runner that uses the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) (`src/run-agent-eval.ts`).
 
-**Deliberate scope:** `npm run eval` **requires** **`--scenario`**, **`--scenarios`**, or **`--all`**. There is no silent “run everything” default — you choose the scenarios and accept the cost. After **each** run: **`transcript.json`**, **`heuristic-score.json`**, and **`llm-score.json`** (judge reads the same **Success criteria** as humans). Exit **1** if any enabled score fails.
+**Deliberate scope:** `npm run eval` **requires** **`--scenario`**, **`--scenarios`**, or **`--all`**. There is no silent "run everything" default — you choose the scenarios and accept the cost. After **each** run: **`transcript.json`**, **`heuristic-score.json`**, and **`llm-score.json`** (judge reads the same **Success criteria** as humans). Exit **1** if any enabled score fails.
 
 Opt out of scoring: **`--no-score`** (heuristic only), **`--no-score-llm`** (drops the Success-criteria judge), or **`.env`**: **`EVAL_NO_SCORE_HEURISTIC=1`**, **`EVAL_NO_SCORE_LLM=1`**. Transcript-only: **`npm run eval -- --no-score --no-score-llm`**.
 
@@ -30,7 +142,7 @@ Each scenario run uses one directory:
 - **`heuristic-score.json`** / **`llm-score.json`** — by default (unless disabled above)
 - **Agent-written files** — the SDK **`cwd`** is this directory. Defaults include **`Write`**, **`Edit`**, and **`Bash`** for clones, installs, and generated code.
 
-Re-score a finished run without re-invoking the agent — uses **today’s** [`src/score-transcript.ts`](src/score-transcript.ts) and **scenario markdown on disk** (so LLM criteria update when you edit **`## Success criteria`**):
+Re-score a finished run without re-invoking the agent — uses **today's** [`src/score-transcript.ts`](src/score-transcript.ts) and **scenario markdown on disk** (so LLM criteria update when you edit **`## Success criteria`**):
 
 - **`npm run score -- --run results/runs/<dir> --write`** — refresh **`heuristic-score.json`**
 - Add **`--llm`** to also re-run the judge and write **`llm-score.json`** (needs **`ANTHROPIC_API_KEY`**)
@@ -39,7 +151,7 @@ Legacy flat files `*-scenario-NN.json` next to `runs/` are still accepted by **`
 
 **Execution** (live Outpost) is still not auto-verified; the LLM is instructed to set `execution_in_transcript.pass` to **null** unless the transcript itself reports HTTP results.
 
-## Automated runs (Claude Agent SDK)
+### Automated runs (Claude Agent SDK)
 
 From `docs/agent-evaluation/`:
 
@@ -50,18 +162,18 @@ npm run eval -- --scenario 01
 npm run eval -- --scenarios 01,02,08
 npm run eval -- --all   # explicit full suite (every scenario file)
 npm run eval:ci         # same as --scenarios 01,02 + heuristic + LLM judge (see § CI)
-npm run eval -- --dry-run
+npm run eval -- --scenario 01 --dry-run   # requires --scenario | --scenarios | --all (even for dry-run)
 ```
 
 The runner loads **`docs/agent-evaluation/.env`** automatically (via `dotenv`). Shell exports still override `.env` if both are set.
 
 ### Wall time (scenarios **08–10** and other heavy baselines)
 
-Scenarios that **`git clone`** a full SaaS template and run **`npm` / `pnpm` / `docker compose`** installs are **slow by design**. Expect **roughly 30–90+ minutes** of wall time for a single run of **08**, **09**, or **10** (clone + install + several agent turns). The harness prints little to the terminal until **`transcript.json`** is written at the end, which can look hung.
+Scenarios that **`git clone`** a full SaaS template and run **`npm`** / **`pnpm`** / **`docker compose`** installs are **slow by design**. Expect **roughly 30–90+ minutes** of wall time for a single run of **08**, **09**, or **10** (clone + install + several agent turns). The harness prints little to the terminal until **`transcript.json`** is written at the end, which can look hung.
 
 - **Progress on stderr:** set **`EVAL_PROGRESS=1`** so the runner prints **periodic lines** (default every **30s** per agent query, plus every **25** SDK messages). You still see activity when the agent is inside a **long Bash** call and the SDK emits **no** new messages for a while. Tune with **`EVAL_PROGRESS_INTERVAL_MS`** (minimum **5000**). Default is off so CI and short runs stay quiet.
 - **Stop early:** **Ctrl+C** (**SIGINT**) in the terminal running `npm run eval`. The runner writes **`*-scenario-NN.eval-aborted.json`** next to the run folder (see **Harness sidecars** at the top of this file).
-- **Skip re-clone:** If the baseline is already under the run directory, **`EVAL_SKIP_HARNESS_PRE_STEPS=1`** skips **`git_clone`** from the scenario harness (see each scenario’s **`## Eval harness`** block).
+- **Skip re-clone:** If the baseline is already under the run directory, **`EVAL_SKIP_HARNESS_PRE_STEPS=1`** skips **`git_clone`** from the scenario harness (see each scenario's **`## Eval harness`** block).
 - **Cap agent length (smoke only):** **`EVAL_MAX_TURNS`** (default **80**) limits SDK turns; lowering it may end the run sooner but often **fails** the integration before success criteria are met—use for debugging, not a real pass.
 - **Save judge time only:** **`--no-score-llm`** skips the Success-criteria LLM judge at the end (saves a few minutes; you lose that rubric).
 
@@ -71,10 +183,10 @@ For **fast** automated signal in CI, use **`eval:ci`** (**01** + **02** only)—
 
 For **pull-request or main-branch** automation, run **two** scenarios only:
 
-| Scenario            | Why                                                                                                                                                                                |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **01** (curl)       | Shortest path: managed API, tenant → destination → publish, no `npm install` / framework scaffold. Cheap signal that the prompt + heuristics still align with the curl quickstart. |
-| **02** (TypeScript) | Most common integration style: **`@hookdeck/outpost-sdk`**, env vars, same API flow in code. Still much faster than **05** (Next.js) or **08** (clone a full SaaS repo).           |
+| Scenario          | Why                                                                    |
+| ----------------- | ---------------------------------------------------------------------- |
+| **01** (curl)     | Shortest path: managed API, tenant → destination → publish, no `npm install` / framework scaffold. Cheap signal that the prompt + heuristics still align with the curl quickstart. |
+| **02** (TypeScript) | Most common integration style: **`@hookdeck/outpost-sdk`**, env vars, same API flow in code. Still much faster than **05** (Next.js) or **08** (clone a full SaaS repo). |
 
 **Commands:**
 
@@ -84,17 +196,17 @@ cd docs/agent-evaluation && npm ci && npm run eval:ci
 # after a successful eval:ci, live Outpost smoke: OUTPOST_API_KEY + OUTPOST_TEST_WEBHOOK_URL ./scripts/execute-ci-artifacts.sh
 ```
 
-`eval:ci` is **`npm run eval -- --scenarios 01,02`**: both **heuristic** checks and the **LLM judge** (grounded in each scenario’s **`## Success criteria`**). Skipping the judge would leave you with regex-only signal, which does not encode the product checklist.
+`eval:ci` is **`npm run eval -- --scenarios 01,02`**: both **heuristic** checks and the **LLM judge** (grounded in each scenario's **`## Success criteria`**). Skipping the judge would leave you with regex-only signal, which does not encode the product checklist.
 
-**GitHub Actions:** add repository secrets **`ANTHROPIC_API_KEY`**, **`EVAL_TEST_DESTINATION_URL`**, and **`OUTPOST_API_KEY`**. Workflow **`.github/workflows/docs-agent-eval-ci.yml`** runs **`./scripts/ci-eval.sh`** with **`EVAL_LOCAL_DOCS=1`** (agent **reads docs from the repo**), then **`./scripts/execute-ci-artifacts.sh`**: picks the **newest** **`*-scenario-01`** / **`*-scenario-02`** pair from **`results/runs/`**, runs the generated **`.sh`** then **`npx tsx`** on the TypeScript artifact (**`npm install`** in the **02** run dir when **`package.json`** exists). **`OUTPOST_TEST_WEBHOOK_URL`** in CI is set from the same secret as **`EVAL_TEST_DESTINATION_URL`**. Triggers on **`workflow_dispatch`** (manual: Actions → **Docs agent eval (CI slice)** → **Run workflow**, pick branch), pushes to **`main`**, and **pull requests** when **`docs/content/**`**, **`docs/apis/**`**, **`sdks/outpost-typescript/**`**, root **`docs/README.md`** / **`docs/AGENTS.md`**, or **`docs/agent-evaluation/**`** change (GitHub does not allow **`paths`** + **`paths-ignore`** together on the same event, so edits under e.g. **`docs/agent-evaluation/README.md`** also match **`docs/agent-evaluation/**`** and can trigger a run). Uses **`ubuntu-latest`** (Claude Agent SDK needs normal filesystem access — avoid tight sandboxes; see **Permissions / failures** above). **Fork PRs\*\* skip this job (secrets are not available).
+**GitHub Actions:** add repository secrets **`ANTHROPIC_API_KEY`**, **`EVAL_TEST_DESTINATION_URL`**, and **`OUTPOST_API_KEY`**. Workflow **`.github/workflows/docs-agent-eval-ci.yml`** runs **`./scripts/ci-eval.sh`** with **`EVAL_LOCAL_DOCS=1`** (agent **reads docs from the repo**), then **`./scripts/execute-ci-artifacts.sh`**: picks the **newest** **`*-scenario-01`** / **`*-scenario-02`** pair from **`results/runs/`**, runs the generated **`.sh`** then **`npx tsx`** on the TypeScript artifact (**`npm install`** in the **02** run dir when **`package.json`** exists). **`OUTPOST_TEST_WEBHOOK_URL`** in CI is set from the same secret as **`EVAL_TEST_DESTINATION_URL`**. Triggers on **`workflow_dispatch`** (manual: Actions → **Docs agent eval (CI slice)** → **Run workflow**, pick branch), pushes to **`main`**, and **pull requests** when **`docs/content/**`**, **`docs/apis/**`**, **`sdks/outpost-typescript/**`**, root **`docs/README.md`** / **`docs/AGENTS.md`**, or **`docs/agent-evaluation/**`** change (GitHub does not allow **`paths`** + **`paths-ignore`** together on the same event, so edits under e.g. **`docs/agent-evaluation/README.md`** also match **`docs/agent-evaluation/**`** and can trigger a run). Uses **`ubuntu-latest`** (Claude Agent SDK needs normal filesystem access — avoid tight sandboxes; see **Permissions / failures** above). **Fork PRs** skip this job (secrets are not available).
 
 The workflow uses **`concurrency: { group: outpost-docs-agent-eval-live-outpost, cancel-in-progress: false }`** so only one run at a time talks to the shared CI Outpost project for execution, and sets **`OUTPOST_CI_CLEANUP_TENANT=customer_acme_001`** so **`execute-ci-artifacts.sh`** **DELETE**s that tenant before the curl script and again on **EXIT** (clears destinations from prior runs and avoids parallel deletes). Override the tenant id only if your Turn 0 fixtures consistently use another id.
 
 - **`ANTHROPIC_API_KEY`** — required for the agent and for the **LLM judge** (Success criteria) after each scenario you run.
 - **`EVAL_TEST_DESTINATION_URL`** — required for Turn 0; same Source URL as `{{TEST_DESTINATION_URL}}` (and, in CI, reused as **`OUTPOST_TEST_WEBHOOK_URL`** for execution).
 - **`OUTPOST_API_KEY`** — required for **`execute-ci-artifacts.sh`** and for **GitHub Actions** execution after **`eval:ci`**. For **local** transcript-only runs you can omit it. Put the key in **`docs/agent-evaluation/.env`** (or export); never paste it into chat.
-- **`EVAL_LOCAL_DOCS=1`** — Turn 0 replaces public doc URLs with **absolute paths to MDX/OpenAPI files in this repo** (agent uses **Read** on **`docs/`** instead of **WebFetch** to production). Use locally when validating unpublished docs; **GitHub Actions** sets this for **`docs-agent-eval-ci.yml`**.
-- **`EVAL_SKIP_HARNESS_PRE_STEPS=1`** — skip **`git_clone`** (and any future **`preSteps`**) declared in a scenario’s **`## Eval harness`** JSON block; useful offline or when the baseline folder is already present.
+- **`EVAL_LOCAL_DOCS=1`** — Turn 0 replaces public doc URLs with **absolute paths to repo docs** (primarily **`.mdoc`** under **`docs/content/`**, plus OpenAPI under **`docs/apis/`**; the Turn 0 template itself is **[`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md)**). The agent uses **Read** on **`docs/`** instead of **WebFetch** to production. Use locally when validating unpublished docs; **GitHub Actions** sets this for **`docs-agent-eval-ci.yml`**.
+- **`EVAL_SKIP_HARNESS_PRE_STEPS=1`** — skip **`git_clone`** (and any future **`preSteps`**) declared in a scenario's **`## Eval harness`** JSON block; useful offline or when the baseline folder is already present.
 
 - **Turn 0** text is built from [`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md) (`## Template`) with placeholders filled from environment variables. **Scenario 01 (curl)** only: the runner **appends** the delimited block `<!-- eval:turn0-appendix-start -->` … `<!-- eval:turn0-appendix-end -->` from [`scenarios/01-basics-curl.md`](scenarios/01-basics-curl.md) after that template (POSIX / `curl` hygiene — not Outpost API teaching); see that file § Turn 0 for manual parity.
 - Transcripts are written to `results/runs/<stamp>-scenario-NN/transcript.json` (gitignored).
@@ -103,24 +215,24 @@ See `npm run eval -- --help` for env vars (`EVAL_TOOLS`, `EVAL_MODEL`, etc.).
 
 ### Permissions / failures (why a run might not work)
 
-Two different things get called “permissions”:
+Two different things get called "permissions":
 
-1. **Cursor (or CI) sandbox and `tsx`** — The `tsx` **CLI** opens an IPC pipe in `/tmp` (or similar), which some sandboxes block (`listen EPERM`). This repo’s `npm run eval` uses **`node --import tsx`** instead so Node loads the tsx **loader** only (no CLI IPC). If you still see EPERM, run the same command in a normal terminal outside the sandbox, or use `npm run eval:tsx-cli` only where IPC is allowed.
+1. **Cursor (or CI) sandbox and `tsx`** — The `tsx` **CLI** opens an IPC pipe in `/tmp` (or similar), which some sandboxes block (`listen EPERM`). This repo's `npm run eval` uses **`node --import tsx`** instead so Node loads the tsx **loader** only (no CLI IPC). If you still see EPERM, run the same command in a normal terminal outside the sandbox, or use `npm run eval:tsx-cli` only where IPC is allowed.
 
 2. **Claude Agent SDK `dontAsk` + `allowedTools`** — In `dontAsk` mode, tools **not** listed in `allowedTools` are denied (no prompt). Defaults include **`Write`**, **`Edit`**, and **`Bash`** so app scenarios can scaffold and install dependencies inside the per-run directory. With **`EVAL_LOCAL_DOCS=1`**: **`Read,Glob,Grep,Write,Edit,Bash`**. Otherwise **`Read,Glob,Grep,WebFetch,Write,Edit,Bash`**. Narrow **`EVAL_TOOLS`** only if you need a stricter harness (e.g. transcript-only, no shell).
 
 3. **Run-directory sandbox (`PreToolUse`)** — Under `permissionMode: dontAsk`, hooks enforce boundaries (not `canUseTool` alone):
    - **Write / Edit / NotebookEdit** — target path must resolve under `results/runs/<stamp>-scenario-NN/`. **`EVAL_DISABLE_WORKSPACE_WRITE_GUARD=1`** disables this only (debug).
-   - **Read / Glob / Grep** — must stay under that same run directory, and (when **`EVAL_LOCAL_DOCS=1`**) under **`docs/`** of the Outpost repo for local MDX/OpenAPI only. **`EVAL_DISABLE_WORKSPACE_READ_GUARD=1`** disables read/glob/grep/bash/agent checks (restores pre–workspace-sandbox behavior).
+   - **Read / Glob / Grep** — must stay under that same run directory, and (when **`EVAL_LOCAL_DOCS=1`**) under **`docs/`** of the Outpost repo for local **`.mdoc`** / OpenAPI sources only. **`EVAL_DISABLE_WORKSPACE_READ_GUARD=1`** disables read/glob/grep/bash/agent checks (restores pre–workspace-sandbox behavior).
    - **Bash** — commands must not reference the Outpost **`repositoryRoot`** on disk unless the reference stays inside the run dir or (with local docs) inside **`docs/`**.
-   - **Agent** (subagent) — **denied by default** so runs cannot spider the monorepo for “free” SDK context. **`EVAL_ALLOW_AGENT_TOOL=1`** to opt in.
+   - **Agent** (subagent) — **denied by default** so runs cannot spider the monorepo for "free" SDK context. **`EVAL_ALLOW_AGENT_TOOL=1`** to opt in.
    - Turn 0 also appends a short **workspace boundary** block (absolute run-dir paths) so the model treats only the clone as the product under integration.
 
 Changing **`EVAL_PERMISSION_MODE`** is usually unnecessary; widening **`EVAL_TOOLS`** (or using local docs) fixes most tool denials.
 
 ### Transcript vs execution (full pass)
 
-`npm run eval` only captures **what the model produced**; by itself it does **not** call Outpost (transcript review). **`./scripts/execute-ci-artifacts.sh`** (and the **GitHub Actions** workflow’s second step) runs the **01** shell + **02** TypeScript outputs against **live** Outpost when **`OUTPOST_API_KEY`** and **`OUTPOST_TEST_WEBHOOK_URL`** are set.
+`npm run eval` only captures **what the model produced**; by itself it does **not** call Outpost (transcript review). **`./scripts/execute-ci-artifacts.sh`** (and the **GitHub Actions** workflow's second step) runs the **01** shell + **02** TypeScript outputs against **live** Outpost when **`OUTPOST_API_KEY`** and **`OUTPOST_TEST_WEBHOOK_URL`** are set.
 
 **Local smoke (no agent):** to verify secrets and the managed API the same way CI does—without depending on a fresh eval transcript—run from **`docs/agent-evaluation/`** with **`OUTPOST_API_KEY`** and **`OUTPOST_TEST_WEBHOOK_URL`** set (e.g. **`source .env`**):
 
@@ -128,7 +240,7 @@ Changing **`EVAL_PERMISSION_MODE`** is usually unnecessary; widening **`EVAL_TOO
 npm run smoke:execute-ci
 ```
 
-That writes a temporary **`*-scenario-01` / `*-scenario-02`** pair under **`results/runs/`** with hand-maintained scripts: shell destination uses **`topics: ["*"]`** so you do not need every topic name pre-created; publish still uses **`OUTPOST_CI_PUBLISH_TOPIC`** (default **`user.created`**, overridable in the environment), which **must exist** in your Outpost project’s topic list. **`execute-ci-artifacts.sh`** was not exercised end-to-end in-repo before CI; use this command after changing execution logic.
+That writes a temporary **`*-scenario-01` / `*-scenario-02`** pair under **`results/runs/`** with hand-maintained scripts: shell destination uses **`topics: ["*"]`** so you do not need every topic name pre-created; publish still uses **`OUTPOST_CI_PUBLISH_TOPIC`** (default **`user.created`**, overridable in the environment), which **must exist** in your Outpost project's topic list. **`execute-ci-artifacts.sh`** was not exercised end-to-end in-repo before CI; use this command after changing execution logic.
 
 **CI `curl: (22) … 404`:** the agent-generated shell script is calling an Outpost URL that returned **404**. Common causes: wrong **`OUTPOST_API_BASE_URL`** in the script (CI now sets the managed URL explicitly), or a **publish/destination topic** that does not exist in the project tied to **`OUTPOST_API_KEY`**. Ensure **`user.created`** is configured in that project, or set **`OUTPOST_CI_PUBLISH_TOPIC`** to a topic you do have. Compare the failing **`curl`** line in the Actions log with the [curl quickstart](../content/quickstarts/hookdeck-outpost-curl.mdoc).
 
@@ -136,10 +248,10 @@ That writes a temporary **`*-scenario-01` / `*-scenario-02`** pair under **`resu
 
 **Managed `TOPICS` pre-check (`execute-ci-artifacts.sh`):** when **`GET /configs`** returns **200**, the script checks **`TOPICS`** (comma-separated, same as dashboard / Config API). **Empty** → OK (no restriction for this check). **Non-empty** → must include **`OUTPOST_CI_PUBLISH_TOPIC`** (default **`user.created`**) or **`*`**. Non-200 on **`/configs`** skips the check (e.g. self-hosted). Set **`OUTPOST_SKIP_MANAGED_TOPICS_VERIFY=1`** to skip.
 
-A **full pass** also answers: _did the generated curl / script / app succeed against a live Outpost project?_ Each scenario’s **Success criteria** ends with **Execution** checkboxes for that step. To run them:
+A **full pass** also answers: _did the generated curl / script / app succeed against a live Outpost project?_ Each scenario's **Success criteria** ends with **Execution** checkboxes for that step. To run them:
 
 1. Add **`OUTPOST_API_KEY`** (and **`OUTPOST_TEST_WEBHOOK_URL`** / **`OUTPOST_API_BASE_URL`** when the artifact expects them) to `docs/agent-evaluation/.env` so your shell has them after `dotenv` or when you `source` / copy into the directory where you run the code.
-2. Run the agent’s commands or start its app and complete the flows the scenario describes.
+2. Run the agent's commands or start its app and complete the flows the scenario describes.
 3. Record pass/fail in your run notes ([`results/RUN-RECORDING.template.md`](results/RUN-RECORDING.template.md)).
 
 #### Integration scenarios (08–10): depth to verify
@@ -147,28 +259,54 @@ A **full pass** also answers: _did the generated curl / script / app succeed aga
 These measure **existing-app integration**, not a greenfield demo. When you **execute** the artifact:
 
 - **Topic reconciliation:** Confirm README maps **`publish` topics** to **real domain events** and, when the **configured topic list from onboarding** is incomplete, tells the operator to **add topics in Hookdeck**—not to retarget the app to a stale list (unless the scenario was explicitly wiring-only).
-- **Domain publish:** Prefer a smoke step that performs a **real product action** (signup, create entity, etc.) and observe an accepted publish—not **only** a “send test event” button.
+- **Domain publish:** Prefer a smoke step that performs a **real product action** (signup, create entity, etc.) and observe an accepted publish—not **only** a "send test event" button.
 - **Heuristic `publish_beyond_test_only`:** [`score-transcript.ts`](src/score-transcript.ts) adds a weak automated check that the transcript corpus suggests publish beyond synthetic test-only paths; it is **not** a substitute for execution or the LLM judge reading **Success criteria**.
 
-## Single source of truth for the dashboard prompt
+### Measuring scenarios
+
+| Layer          | What it answers                                                | Where                                                                  |
+| -------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Definition** | What "good" means (product + transcript)                       | **`## Success criteria`** in each [`scenarios/*.md`](scenarios/)       |
+| **Heuristic**  | Fast, deterministic signal from transcript JSON                | [`src/score-transcript.ts`](src/score-transcript.ts) — combines assistant text with **Write/Edit tool inputs** and tool results so on-disk artifacts count |
+| **LLM judge**  | Structured pass/fail vs the same **Success criteria**          | After each scenario when **`--no-score-llm`** is not set; or `npm run score -- --run <dir> --llm` — [`src/llm-judge.ts`](src/llm-judge.ts) |
+| **Execution**  | Live API / app smoke test                                      | Human (or future script); not automated here                           |
+
+**Heuristic functions** (failed checks set **`npm run eval`** / **`npm run score`** exit **1** when that scorer ran):
+
+| Scenario | Function          | Topics covered (summary)                                               |
+| -------- | ----------------- | ---------------------------------------------------------------------- |
+| 01       | `scoreScenario01` | Managed URL, tenant PUT, webhook destination POST, publish `data`, no key leak, optional verify turn |
+| 02       | `scoreScenario02` | TS SDK, `Outpost`, env key, tenants/destinations/publish, webhook env, run command |
+| 03       | `scoreScenario03` | Python SDK import, client, same API calls, env, webhook URL            |
+| 04       | `scoreScenario04` | Go module, `New`/`WithSecurity`, Upsert/Create/Publish, env, webhook URL |
+| 05       | `scoreScenario05` | Next.js signals, TS SDK, API routes, two flows, server env key, no `NEXT_PUBLIC_` key, README, optional stress-turn Hookdeck hint |
+| 06       | `scoreScenario06` | FastAPI, `outpost_sdk`, uvicorn, server env, two flows, README, webhook docs |
+| 07       | `scoreScenario07` | `net/http`, Go SDK + `CreateDestinationCreateWebhook`, HTML UI, two flows, `go run`, README |
+| 08       | `scoreScenario08` | Clone **next-saas-starter** (or git baseline), TS SDK, publish/destinations/tenants, server env key, per-customer webhook story |
+| 09       | `scoreScenario09` | Clone **full-stack-fastapi-template** (or git baseline), `outpost_sdk`, integration + domain hook, env key, no client `NEXT_PUBLIC_`/`VITE_` key wiring, `publish_beyond_test_only`, README/env docs signal |
+| 10       | `scoreScenario10` | Clone **startersaas-go-api** (or git baseline), Go Outpost SDK, publish + handler hook, env key |
+
+Export **`SCENARIO_IDS_WITH_HEURISTIC_RUBRIC`** in `score-transcript.ts` lists IDs **01–10** for tooling.
+
+### Single source of truth for the dashboard prompt
 
 The **full prompt template** (the text operators paste as Turn 0) lives in **one** place:
 
-**[`docs/agent-evaluation/hookdeck-outpost-agent-prompt.md`](../agent-evaluation/hookdeck-outpost-agent-prompt.md)** — use the fenced block under **## Template**.
+**[`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md)** — use the fenced block under **## Template**.
 
 For eval runs, example placeholder substitutions (non-secret) are in [`fixtures/placeholder-values-for-turn0.md`](fixtures/placeholder-values-for-turn0.md) only. That file intentionally **does not** duplicate the template.
 
-The Hookdeck dashboard should eventually render the **same** template body from product-side source; until then, this MDX page is the documentation canonical copy.
+The Hookdeck dashboard should eventually render the **same** template body from product-side source; until then, **[`hookdeck-outpost-agent-prompt.md`](hookdeck-outpost-agent-prompt.md)** is the canonical copy for Turn 0, and guides live as **`.mdoc`** under **`docs/content/`** (not MDX).
 
-## How to run an evaluation (manual)
+### How to run an evaluation (manual)
 
-1. **Turn 0:** Open the [agent prompt template](../agent-evaluation/hookdeck-outpost-agent-prompt.md), copy **## Template**, replace `{{…}}` (see [placeholder examples](fixtures/placeholder-values-for-turn0.md)).
+1. **Turn 0:** Open the [agent prompt template](hookdeck-outpost-agent-prompt.md), copy **## Template**, replace `{{…}}` (see [placeholder examples](fixtures/placeholder-values-for-turn0.md)).
 2. **Pick a scenario:** e.g. [`scenarios/01-basics-curl.md`](scenarios/01-basics-curl.md).
 3. **New agent thread:** Paste Turn 0, then follow each **Turn N — User** line from the scenario verbatim (or as specified).
-4. **Judge output:** Use the scenario’s **Success criteria** checkboxes (human decision).
+4. **Judge output:** Use the scenario's **Success criteria** checkboxes (human decision).
 5. **Record:** Copy [`results/RUN-RECORDING.template.md`](results/RUN-RECORDING.template.md) to a local filename under `results/` (see [`results/README.md`](results/README.md)); those files are **gitignored** by default.
 
-### Helper script (optional)
+#### Helper script (optional)
 
 From the repo root:
 
@@ -178,73 +316,48 @@ From the repo root:
 
 This **only prints** paths and reminders. It does **not** start an agent or call OpenAI/Anthropic/etc.
 
-## Judging results
+### Judging results
 
 - **Automated runs:** use **Success criteria** in each `scenarios/*.md` (definition of pass). Each **`npm run eval -- --scenario|scenarios|all`** run applies **heuristic + LLM** scorers unless you pass **`--no-score`** / **`--no-score-llm`**; **Execution** rows stay manual unless you add a verifier.
 - **Manual runs** use the checklist in [`results/RUN-RECORDING.template.md`](results/RUN-RECORDING.template.md).
 
-There is still **no single portable “IDE agent” CLI** for all vendors; the SDK runner is the supported path for headless Anthropic-based CI.
-
-## Measuring scenarios
-
-| Layer          | What it answers                                       | Where                                                                                                                                                      |
-| -------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Definition** | What “good” means (product + transcript)              | **`## Success criteria`** in each [`scenarios/*.md`](scenarios/)                                                                                           |
-| **Heuristic**  | Fast, deterministic signal from transcript JSON       | [`src/score-transcript.ts`](src/score-transcript.ts) — combines assistant text with **Write/Edit tool inputs** and tool results so on-disk artifacts count |
-| **LLM judge**  | Structured pass/fail vs the same **Success criteria** | After each scenario when **`--no-score-llm`** is not set; or `npm run score -- --run <dir> --llm` — [`src/llm-judge.ts`](src/llm-judge.ts)                 |
-| **Execution**  | Live API / app smoke test                             | Human (or future script); not automated here                                                                                                               |
-
-**Heuristic functions** (failed checks set **`npm run eval`** / **`npm run score`** exit **1** when that scorer ran):
-
-| Scenario | Function          | Topics covered (summary)                                                                                                                                                                                    |
-| -------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 01       | `scoreScenario01` | Managed URL, tenant PUT, webhook destination POST, publish `data`, no key leak, optional verify turn                                                                                                        |
-| 02       | `scoreScenario02` | TS SDK, `Outpost`, env key, tenants/destinations/publish, webhook env, run command                                                                                                                          |
-| 03       | `scoreScenario03` | Python SDK import, client, same API calls, env, webhook URL                                                                                                                                                 |
-| 04       | `scoreScenario04` | Go module, `New`/`WithSecurity`, Upsert/Create/Publish, env, webhook URL                                                                                                                                    |
-| 05       | `scoreScenario05` | Next.js signals, TS SDK, API routes, two flows, server env key, no `NEXT_PUBLIC_` key, README, optional stress-turn Hookdeck hint                                                                           |
-| 06       | `scoreScenario06` | FastAPI, `outpost_sdk`, uvicorn, server env, two flows, README, webhook docs                                                                                                                                |
-| 07       | `scoreScenario07` | `net/http`, Go SDK + `CreateDestinationCreateWebhook`, HTML UI, two flows, `go run`, README                                                                                                                 |
-| 08       | `scoreScenario08` | Clone **next-saas-starter** (or git baseline), TS SDK, publish/destinations/tenants, server env key, per-customer webhook story                                                                             |
-| 09       | `scoreScenario09` | Clone **full-stack-fastapi-template** (or git baseline), `outpost_sdk`, integration + domain hook, env key, no client `NEXT_PUBLIC_`/`VITE_` key wiring, `publish_beyond_test_only`, README/env docs signal |
-| 10       | `scoreScenario10` | Clone **startersaas-go-api** (or git baseline), Go Outpost SDK, publish + handler hook, env key                                                                                                             |
-
-Export **`SCENARIO_IDS_WITH_HEURISTIC_RUBRIC`** in `score-transcript.ts` lists IDs **01–10** for tooling.
-
-## Scenarios
+There is still **no single portable "IDE agent" CLI** for all vendors; the SDK runner is the supported path for headless Anthropic-based CI.
 
 To record each **`npm run eval -- --scenario …`** run, automated scores, and **whether you ran the generated code** with `OUTPOST_API_KEY`, use **[`SCENARIO-RUN-TRACKER.md`](SCENARIO-RUN-TRACKER.md)** (committed; not under `results/`, which is gitignored).
 
-| ID  | File                                                                                     | Goal                                                                                                                                                            |
-| --- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | [scenarios/01-basics-curl.md](scenarios/01-basics-curl.md)                               | Minimal **curl** only (managed API).                                                                                                                            |
-| 2   | [scenarios/02-basics-typescript.md](scenarios/02-basics-typescript.md)                   | Minimal **TypeScript** script (`@hookdeck/outpost-sdk`).                                                                                                        |
-| 3   | [scenarios/03-basics-python.md](scenarios/03-basics-python.md)                           | Minimal **Python** script (`outpost_sdk`).                                                                                                                      |
-| 4   | [scenarios/04-basics-go.md](scenarios/04-basics-go.md)                                   | Minimal **Go** program (`outpost-go`).                                                                                                                          |
-| 5   | [scenarios/05-app-nextjs.md](scenarios/05-app-nextjs.md)                                 | Small **Next.js** app: UI to register a webhook destination and trigger a test publish.                                                                         |
-| 6   | [scenarios/06-app-fastapi.md](scenarios/06-app-fastapi.md)                               | Small **FastAPI** app with the same UX as scenario 5.                                                                                                           |
-| 7   | [scenarios/07-app-go-http.md](scenarios/07-app-go-http.md)                               | Small **Go** `net/http` app + simple HTML UI (same UX as scenario 5).                                                                                           |
-| 8   | [scenarios/08-integrate-nextjs-existing.md](scenarios/08-integrate-nextjs-existing.md)   | **Existing Next.js SaaS** baseline — add outbound webhooks via Outpost ([leerob/next-saas-starter](https://github.com/leerob/next-saas-starter)).               |
-| 9   | [scenarios/09-integrate-fastapi-existing.md](scenarios/09-integrate-fastapi-existing.md) | **Existing FastAPI full-stack** baseline — Outpost integration ([fastapi/full-stack-fastapi-template](https://github.com/fastapi/full-stack-fastapi-template)). |
-| 10  | [scenarios/10-integrate-go-existing.md](scenarios/10-integrate-go-existing.md)           | **Existing Go SaaS API** baseline — Outpost integration ([devinterface/startersaas-go-api](https://github.com/devinterface/startersaas-go-api)).                |
+### Agent skills recommendation
 
-Scenarios **1–4** align with **“Try it out”**; **5–7** with **“Build a minimal example”**; **8–10** with **“Integrate with an existing app”** using pinned OSS baselines (Java / .NET can be added later the same way).
+**Recommend yes** for teams standardizing on Hookdeck's skill pack: the [outpost skill](https://github.com/hookdeck/agent-skills/tree/main/skills/outpost) gives agents a consistent overview (tenants, destinations, topics, curl shape) and links into docs.
 
-## Agent skills recommendation
+**Caveats (update the skill in [`hookdeck/agent-skills`](https://github.com/hookdeck/agent-skills), not in this repo):**
 
-**Recommend yes** for teams standardizing on Hookdeck’s skill pack: the [outpost skill](https://github.com/hookdeck/agent-skills/tree/main/skills/outpost) gives agents a consistent overview (tenants, destinations, topics, curl shape) and links into docs.
+1. **Managed path vs Docker + self-hosted curl** — The skill opens with deployment options, then **reference SaaS apps** (full `examples/nextjs-saas` and `examples/fastapi-saas` trees with integration maps) before the long **Self-Hosted Quick Start (Docker)**. The **Publish Your First Event** curl block still defaults to **self-hosted** URLs and `API_KEY`/`BASE_URL` naming. For parity with Hookdeck managed onboarding, foreground [managed curl](../content/quickstarts/hookdeck-outpost-curl.mdoc) first: **`OUTPOST_API_BASE_URL`** (`https://api.outpost.hookdeck.com/2025-07-01`), **`OUTPOST_API_KEY`** from **Settings → Secrets**, then keep Docker/self-hosted as a clearly labeled alternate path.
+2. **REST paths** — Examples must use **`/tenants/{id}`** (e.g. `PUT "$BASE_URL/tenants/$TENANT_ID"`), not `PUT "$BASE_URL/$TENANT_ID"` (missing **`/tenants/`** segment for the real API).
+3. **Auth env naming** — The skill's **API Access** table documents **`HOOKDECK_API_KEY`** for managed; this repo's quickstarts and eval harness use **`OUTPOST_API_KEY`** / **`OUTPOST_API_BASE_URL`**. Align upstream with dashboard copy and the **`.mdoc`** quickstarts so Turn 0, CI, and the skill do not disagree.
+4. **Size vs minimal tasks** — Bundling concepts, Docker, curl, portal, architecture, **and** two full example products is strong for integration-style work (similar to scenarios **08–09**) but heavy for **01–02**-style minimal runs. Consider a short **"fastest path (managed)"** section up front, or split into child skills later (`outpost-managed-quickstart`, `outpost-self-hosted`, etc.) without forcing many installs for the common case.
+5. **Future skills** — The skill already notes destination-specific follow-ons (`outpost-webhooks`, …); keep that roadmap visible when content grows.
 
-**Caveats (update the skill in `hookdeck/agent-skills`, not in this repo):**
+Until the skill is updated, agents should still be pointed at the **quickstart `.mdoc` pages** under **`docs/content/quickstarts/`** in this repo (or production docs URLs); the skill is supplementary.
 
-1. **Managed-first** — The published skill is still **self-hosted heavy** (Docker block first; managed is a short table). For Hookdeck Outpost GA, the skill should foreground [managed quickstarts](../content/quickstarts/hookdeck-outpost-curl.mdoc), `https://api.outpost.hookdeck.com/2025-07-01`, **Settings → Secrets**, and `OUTPOST_API_KEY` / optional `OUTPOST_API_BASE_URL` to match product copy.
-2. **REST paths** — Examples must use **`/tenants/{id}`**, not `PUT $BASE_URL/$TENANT_ID` (that path is wrong for the real API).
-3. **Naming** — Align env var naming with docs (`OUTPOST_API_KEY` or documented dashboard name), not ad-hoc `HOOKDECK_API_KEY` unless the dashboard literally uses that string.
-4. **Router vs. deep skills** — Today `outpost` is one monolithic `SKILL.md`. The skill itself mentions **future** destination-specific skills (`outpost-webhooks`, etc.). For scale, consider either **sections** with clear headings or **child skills** (e.g. `outpost-managed-quickstart`, `outpost-self-hosted`) once content grows—without forcing users to install many tiles for the common case.
+### Sanity-checking this README (optional)
 
-Until the skill is updated, agents should still be pointed at the **quickstart MDX pages** in this repo (or production docs URLs); the skill is supplementary.
+A README this large will drift from the harness. You do **not** need a full **`eval:ci`** pass to catch most mistakes; a small smoke set is enough when you edit operational sections:
 
-## Related docs
+1. From **`docs/agent-evaluation/`**: **`npm ci`** then **`npm run eval -- --scenario 01 --dry-run`** (or another explicit scenario) — exercises CLI and config wiring without spending tokens on a real agent run. **`--dry-run` alone is rejected** — the harness always requires an explicit scenario set.
+2. If you change CI claims here, diff against **`.github/workflows/docs-agent-eval-ci.yml`** (triggers, env, scripts).
+3. If you change **`EVAL_LOCAL_DOCS`** behavior or doc paths, confirm the injected path list in **`src/run-agent-eval.ts`** still matches **`docs/content/**/*.mdoc`** (and related **`docs/apis/`** files).
 
-- [Agent prompt template (SSoT)](../agent-evaluation/hookdeck-outpost-agent-prompt.md)
-- [Upstream skill notes](SKILL-UPSTREAM-NOTES.md)
-- [TEMP tracking note](../TEMP-hookdeck-outpost-onboarding-status.md)
+## Context: Hookdeck's agentic DX journey
+
+This eval harness is part of Hookdeck's broader investment in developer experience for AI agents:
+
+- **Phase 1 — Agent-ready (done):** Made the platform accessible to agents with `.md` doc routes, `llms.txt`, OpenAPI specs, [agent skills](https://github.com/hookdeck/agent-skills), MCP server, and CLI.
+- **Phase 2 — Agent onboarding (current):** One prompt drives an agent through a complete use case. This harness evaluates that. Currently Outpost only.
+- **Phase 3 — Agent discovery (future):** Agents discover and evaluate platforms independently, comparing onboarding experiences and reporting recommendations back to the developer.
+
+## Related
+
+- [Agent prompt template (SSoT)](hookdeck-outpost-agent-prompt.md)
+- [Hookdeck agent skills](https://github.com/hookdeck/agent-skills) — Skills that guide agents through Hookdeck workflows, with their own [testing approach](https://github.com/hookdeck/agent-skills/blob/main/TESTING.md)
+- [Tracking AI agent traffic](https://hookdeck.com/webhooks/platforms/track-ai-agent-traffic-vercel-log-drains-hookdeck-posthog) — How Hookdeck measures whether agents are reaching its content
+- [Hookdeck docs: AI agent resources](https://hookdeck.com/docs/ai-agent-resources) — The agent-facing entry points to Hookdeck's platform

--- a/docs/agent-evaluation/src/score-transcript.ts
+++ b/docs/agent-evaluation/src/score-transcript.ts
@@ -222,22 +222,34 @@ function scoreScenario01(corpus: string, assistant: string, meta: RunJson["meta"
     detail: publish ? "POST …/publish present" : "Expected POST publish",
   });
 
-  const afterPublish = t.split(/\/publish/i).pop() ?? t;
-  // Tool corpus JSON-stringifies Write bodies, so bash-escaped keys look like \"data\": not "data":
-  const wrongPayload =
-    /"payload"\s*:/.test(afterPublish) || /\\"payload\\"\s*:/.test(afterPublish);
+  // Do not inspect only text after the *final* /publish: late-turn assistant summaries
+  // often repeat "POST /publish" in markdown tables without the JSON body, while the real
+  // curl/jq payload appears earlier (e.g. in Write(run.sh)). Scan a bounded window after any
+  // /publish. Accept JSON "data":, tool-escaped \"data\":, or jq object literals: data: {
+  const publishBodyWindow = 12_000;
+  const wrongPayload = new RegExp(
+    `/publish[\\s\\S]{0,${publishBodyWindow}}?(?:"payload"|\\\\"payload\\\\")\\s*:`,
+    "i",
+  ).test(t);
   const hasData =
-    /"data"\s*:/.test(afterPublish) || /\\"data\\"\s*:/.test(afterPublish);
+    new RegExp(
+      `/publish[\\s\\S]{0,${publishBodyWindow}}?(?:"data"|\\\\"data\\\\")\\s*:`,
+      "i",
+    ).test(t) ||
+    new RegExp(
+      `/publish[\\s\\S]{0,${publishBodyWindow}}?\\bdata\\s*:\\s*\\{`,
+      "i",
+    ).test(t);
   checks.push({
     id: "publish_body_data_not_payload",
     pass: publish && !wrongPayload && hasData,
     detail: !publish
       ? "N/A (no publish block)"
       : wrongPayload
-        ? 'Found "payload" after /publish — Outpost expects "data"'
+        ? 'Found "payload" near /publish — Outpost expects "data"'
         : hasData
-          ? 'Publish section uses "data"'
-          : 'Missing "data" in publish JSON (check manually)',
+          ? "Publish body uses top-level data (JSON, escaped JSON, or jq data: { … })"
+          : 'Missing "data" near /publish in transcript (check manually)',
   });
 
   checks.push({


### PR DESCRIPTION
## Summary

- **README (`docs/agent-evaluation/README.md`):** Restructure into narrative (what/why/architecture), tiered scenarios, operational reference (scoring, CI, permissions, execution), skills caveats aligned with published agent-skills Outpost skill, and optional sanity-check steps. Use **`.mdoc`** terminology for repo docs; Turn 0 template remains **`.md`**. Document that **`--dry-run`** still requires **`--scenario` / `--scenarios` / `--all`**. Expand **iteration loop** as **manual workflow** (no automated pass deltas or A/B harness). Remove broken Related link to missing TEMP doc.

- **Heuristic (`src/score-transcript.ts`):** Fix **`publish_body_data_not_payload`** false negatives when the assistant ends with a markdown **`POST /publish`** summary (so text after the *last* `/publish` omits the real body) and when publish JSON is built with **jq** unquoted keys (`data: { ... }`).

## Testing

- `cd docs/agent-evaluation && npm ci && npm run typecheck`
- `npm run eval -- --scenario 01 --dry-run`
- `npm run score -- --run results/runs/<stamp>-scenario-01 --write` on an affected run (7/7 heuristic after fix)

Made with [Cursor](https://cursor.com)