### PR TITLE
fix: Go SDK metrics unmarshal error with OptionalNullable[time.Time]

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2175,11 +2175,9 @@ components:
       type: object
       properties:
         time_bucket:
-          type:
-            - string
-            - "null"
+          type: string
           format: date-time
-          description: Start of the time bucket. Null when no granularity is specified.
+          description: Start of the time bucket. Absent when no granularity is specified.
           example: "2026-03-02T14:00:00Z"
         dimensions:
           type: object
@@ -2201,10 +2199,8 @@ components:
       type: object
       properties:
         granularity:
-          type:
-            - string
-            - "null"
-          description: The granularity used for time bucketing, or null if none was specified.
+          type: string
+          description: The granularity used for time bucketing. Absent when none was specified.
           example: "1h"
         query_time_ms:
           type: integer

--- a/internal/apirouter/metrics_handlers.go
+++ b/internal/apirouter/metrics_handlers.go
@@ -63,7 +63,7 @@ var (
 // --- API response types ---
 
 type APIMetricsDataPoint struct {
-	TimeBucket *time.Time     `json:"time_bucket"`
+	TimeBucket *time.Time     `json:"time_bucket,omitempty"`
 	Dimensions map[string]any `json:"dimensions"`
 	Metrics    map[string]any `json:"metrics"`
 }
@@ -74,7 +74,7 @@ type APIMetricsResponse struct {
 }
 
 type APIMetricsMetadata struct {
-	Granularity *string `json:"granularity"`
+	Granularity *string `json:"granularity,omitempty"`
 	QueryTimeMs int64   `json:"query_time_ms"`
 	RowCount    int     `json:"row_count"`
 	RowLimit    int     `json:"row_limit"`

--- a/sdks/outpost-go/internal/utils/json_metrics_test.go
+++ b/sdks/outpost-go/internal/utils/json_metrics_test.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hookdeck/outpost/sdks/outpost-go/optionalnullable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal reproduction of MetricsDataPoint with OptionalNullable[time.Time]
+type testMetricsDataPoint struct {
+	TimeBucket optionalnullable.OptionalNullable[time.Time] `json:"time_bucket,omitempty"`
+	Dimensions map[string]string                            `json:"dimensions,omitempty"`
+	Metrics    map[string]any                               `json:"metrics,omitempty"`
+}
+
+func (m testMetricsDataPoint) MarshalJSON() ([]byte, error) {
+	return MarshalJSON(m, "", false)
+}
+
+func (m *testMetricsDataPoint) UnmarshalJSON(data []byte) error {
+	return UnmarshalJSON(data, &m, "", false, nil)
+}
+
+type testMetricsMetadata struct {
+	Granularity optionalnullable.OptionalNullable[string] `json:"granularity,omitempty"`
+	QueryTimeMs *int64                                    `json:"query_time_ms,omitempty"`
+	RowCount    *int64                                    `json:"row_count,omitempty"`
+	RowLimit    *int64                                    `json:"row_limit,omitempty"`
+	Truncated   *bool                                     `json:"truncated,omitempty"`
+}
+
+type testMetricsResponse struct {
+	Data     []testMetricsDataPoint `json:"data,omitempty"`
+	Metadata *testMetricsMetadata   `json:"metadata,omitempty"`
+}
+
+func TestUnmarshalMetricsResponse_WithTimeBucket(t *testing.T) {
+	// This is the exact JSON shape returned by the API when granularity is specified.
+	// The bug: OptionalNullable[time.Time] is map[bool]*time.Time, and unmarshalValue
+	// sees map + complex value type (time.Time) and tries to unmarshal the datetime
+	// string into map[string]json.RawMessage, which fails.
+	responseJSON := `{
+		"data": [
+			{
+				"time_bucket": "2026-03-02T14:00:00Z",
+				"dimensions": {"topic": "user.created"},
+				"metrics": {"count": 1423}
+			},
+			{
+				"time_bucket": "2026-03-02T15:00:00Z",
+				"dimensions": {"topic": "user.created"},
+				"metrics": {"count": 1891}
+			}
+		],
+		"metadata": {
+			"granularity": "1h",
+			"query_time_ms": 5,
+			"row_count": 2,
+			"row_limit": 1000,
+			"truncated": false
+		}
+	}`
+
+	var out testMetricsResponse
+	err := UnmarshalJSON([]byte(responseJSON), &out, "", true, nil)
+	require.NoError(t, err, "unmarshalling metrics response with time_bucket should succeed")
+
+	// Verify data points
+	require.Len(t, out.Data, 2)
+
+	// First data point
+	tb1, ok := out.Data[0].TimeBucket.GetOrZero()
+	assert.True(t, ok)
+	assert.Equal(t, time.Date(2026, 3, 2, 14, 0, 0, 0, time.UTC), tb1)
+	assert.Equal(t, "user.created", out.Data[0].Dimensions["topic"])
+
+	// Second data point
+	tb2, ok := out.Data[1].TimeBucket.GetOrZero()
+	assert.True(t, ok)
+	assert.Equal(t, time.Date(2026, 3, 2, 15, 0, 0, 0, time.UTC), tb2)
+}
+
+func TestUnmarshalMetricsResponse_WithNullTimeBucket(t *testing.T) {
+	// When no granularity is specified, time_bucket is null.
+	responseJSON := `{
+		"data": [
+			{
+				"time_bucket": null,
+				"dimensions": {},
+				"metrics": {"count": 5000}
+			}
+		],
+		"metadata": {
+			"granularity": null,
+			"query_time_ms": 3,
+			"row_count": 1,
+			"row_limit": 1000,
+			"truncated": false
+		}
+	}`
+
+	var out testMetricsResponse
+	err := UnmarshalJSON([]byte(responseJSON), &out, "", true, nil)
+	require.NoError(t, err, "unmarshalling metrics response with null time_bucket should succeed")
+
+	require.Len(t, out.Data, 1)
+	assert.True(t, out.Data[0].TimeBucket.IsNull())
+}

--- a/sdks/outpost-go/internal/utils/json_metrics_test.go
+++ b/sdks/outpost-go/internal/utils/json_metrics_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hookdeck/outpost/sdks/outpost-go/optionalnullable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Minimal reproduction of MetricsDataPoint with OptionalNullable[time.Time]
+// Minimal reproduction of MetricsDataPoint matching the generated SDK types.
+// time_bucket and granularity are now *time.Time / *string (non-nullable in spec).
 type testMetricsDataPoint struct {
-	TimeBucket optionalnullable.OptionalNullable[time.Time] `json:"time_bucket,omitempty"`
-	Dimensions map[string]string                            `json:"dimensions,omitempty"`
-	Metrics    map[string]any                               `json:"metrics,omitempty"`
+	TimeBucket *time.Time        `json:"time_bucket,omitempty"`
+	Dimensions map[string]string `json:"dimensions,omitempty"`
+	Metrics    map[string]any    `json:"metrics,omitempty"`
 }
 
 func (m testMetricsDataPoint) MarshalJSON() ([]byte, error) {
@@ -25,11 +25,11 @@ func (m *testMetricsDataPoint) UnmarshalJSON(data []byte) error {
 }
 
 type testMetricsMetadata struct {
-	Granularity optionalnullable.OptionalNullable[string] `json:"granularity,omitempty"`
-	QueryTimeMs *int64                                    `json:"query_time_ms,omitempty"`
-	RowCount    *int64                                    `json:"row_count,omitempty"`
-	RowLimit    *int64                                    `json:"row_limit,omitempty"`
-	Truncated   *bool                                     `json:"truncated,omitempty"`
+	Granularity *string `json:"granularity,omitempty"`
+	QueryTimeMs *int64  `json:"query_time_ms,omitempty"`
+	RowCount    *int64  `json:"row_count,omitempty"`
+	RowLimit    *int64  `json:"row_limit,omitempty"`
+	Truncated   *bool   `json:"truncated,omitempty"`
 }
 
 type testMetricsResponse struct {
@@ -39,9 +39,6 @@ type testMetricsResponse struct {
 
 func TestUnmarshalMetricsResponse_WithTimeBucket(t *testing.T) {
 	// This is the exact JSON shape returned by the API when granularity is specified.
-	// The bug: OptionalNullable[time.Time] is map[bool]*time.Time, and unmarshalValue
-	// sees map + complex value type (time.Time) and tries to unmarshal the datetime
-	// string into map[string]json.RawMessage, which fails.
 	responseJSON := `{
 		"data": [
 			{
@@ -72,19 +69,44 @@ func TestUnmarshalMetricsResponse_WithTimeBucket(t *testing.T) {
 	require.Len(t, out.Data, 2)
 
 	// First data point
-	tb1, ok := out.Data[0].TimeBucket.GetOrZero()
-	assert.True(t, ok)
-	assert.Equal(t, time.Date(2026, 3, 2, 14, 0, 0, 0, time.UTC), tb1)
+	require.NotNil(t, out.Data[0].TimeBucket)
+	assert.Equal(t, time.Date(2026, 3, 2, 14, 0, 0, 0, time.UTC), *out.Data[0].TimeBucket)
 	assert.Equal(t, "user.created", out.Data[0].Dimensions["topic"])
 
 	// Second data point
-	tb2, ok := out.Data[1].TimeBucket.GetOrZero()
-	assert.True(t, ok)
-	assert.Equal(t, time.Date(2026, 3, 2, 15, 0, 0, 0, time.UTC), tb2)
+	require.NotNil(t, out.Data[1].TimeBucket)
+	assert.Equal(t, time.Date(2026, 3, 2, 15, 0, 0, 0, time.UTC), *out.Data[1].TimeBucket)
+}
+
+func TestUnmarshalMetricsResponse_WithoutTimeBucket(t *testing.T) {
+	// When no granularity is specified, time_bucket is absent.
+	responseJSON := `{
+		"data": [
+			{
+				"dimensions": {},
+				"metrics": {"count": 5000}
+			}
+		],
+		"metadata": {
+			"query_time_ms": 3,
+			"row_count": 1,
+			"row_limit": 1000,
+			"truncated": false
+		}
+	}`
+
+	var out testMetricsResponse
+	err := UnmarshalJSON([]byte(responseJSON), &out, "", true, nil)
+	require.NoError(t, err, "unmarshalling metrics response without time_bucket should succeed")
+
+	require.Len(t, out.Data, 1)
+	assert.Nil(t, out.Data[0].TimeBucket)
+	assert.Nil(t, out.Metadata.Granularity)
 }
 
 func TestUnmarshalMetricsResponse_WithNullTimeBucket(t *testing.T) {
-	// When no granularity is specified, time_bucket is null.
+	// The API server currently returns "time_bucket": null (no omitempty on server side).
+	// The SDK should handle this gracefully — null deserializes to nil *time.Time.
 	responseJSON := `{
 		"data": [
 			{
@@ -107,5 +129,6 @@ func TestUnmarshalMetricsResponse_WithNullTimeBucket(t *testing.T) {
 	require.NoError(t, err, "unmarshalling metrics response with null time_bucket should succeed")
 
 	require.Len(t, out.Data, 1)
-	assert.True(t, out.Data[0].TimeBucket.IsNull())
+	assert.Nil(t, out.Data[0].TimeBucket)
+	assert.Nil(t, out.Metadata.Granularity)
 }


### PR DESCRIPTION
## Summary

Fixes Go SDK crash when calling `GetEventMetrics` or `GetAttemptMetrics` with granularity:
```
json: cannot unmarshal string into Go value of type map[string]json.RawMessage
```

### Root cause

Speakeasy's generated `unmarshalValue` in `json.go` has a bug with `OptionalNullable[time.Time]`. The type is `map[bool]*time.Time` under the hood. When unmarshalling a map field, the code checks if the map's value type is a "complex value type" (`time.Time`, `big.Int`, `types.Date`). If it is, it skips the standard `json.Unmarshal` path (which would correctly call `OptionalNullable.UnmarshalJSON()`) and falls through to custom map handling that tries to unmarshal a datetime string into `map[string]json.RawMessage` — which crashes.

This only affects `OptionalNullable[time.Time]`. Other `OptionalNullable` types like `OptionalNullable[string]` work fine because `string` is not a "complex value type". The marshal side already handles this correctly with a `json.Marshaler` check, but the unmarshal side is missing the equivalent `json.Unmarshaler` check. This is a Speakeasy codegen bug — we'll report it upstream.

### Fix

- **OpenAPI spec**: Changed `time_bucket` and `granularity` from nullable (`type: [string, "null"]`) to non-nullable (`type: string`). This makes Speakeasy generate `*time.Time` / `*string` instead of `OptionalNullable[T]`, avoiding the buggy code path.
- **Server**: Added `omitempty` to `APIMetricsDataPoint.TimeBucket` and `APIMetricsMetadata.Granularity` JSON tags so the server omits these fields when nil instead of returning `null`. This matches the updated spec.

### API behavior change

When no granularity is specified, the response changes from:
```json
{
  "data": [{"time_bucket": null, "dimensions": {}, "metrics": {"count": 100}}],
  "metadata": {"granularity": null, "query_time_ms": 5, ...}
}
```
to:
```json
{
  "data": [{"dimensions": {}, "metrics": {"count": 100}}],
  "metadata": {"query_time_ms": 5, ...}
}
```

The fields are omitted instead of sent as `null`. Functionally equivalent for consumers — both result in nil/undefined when accessed.

## Test plan

- [x] Regression test reproduces the original error before fix
- [x] SDK test passes after spec change (with value, absent, and null cases)
- [x] Server-side metrics tests pass with `omitempty` change
- [ ] Speakeasy codegen will regenerate the SDK on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)