### PR TITLE
ci: trigger website deploy via Hookdeck on Outpost docs changes

### DIFF
--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -1,8 +1,9 @@
 # Triggers a Hookdeck source that forwards to the Vercel website deploy hook
 # when Outpost docs consumed by hookdeck/website change on main.
 #
-# Required repository secret (Settings → Secrets and variables → Actions):
-#   VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY — value for the Hookdeck source x-api-key header
+# Required repository configuration (Settings → Secrets and variables → Actions):
+#   Variable: HOOKDECK_WEBSITE_DEPLOY_SOURCE_URL — Hookdeck inbound source URL (not a secret)
+#   Secret:   VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY — Hookdeck source x-api-key header
 #
 # Assumes branch protection on main requires PR checks before merge; this job
 # does not wait for post-merge workflows. To gate on a specific workflow finishing,
@@ -25,9 +26,13 @@ jobs:
     steps:
       - name: POST Hookdeck source
         env:
-          HOOKDECK_SOURCE_URL: https://hkdk.events/a1bst55qm05dyx
+          HOOKDECK_SOURCE_URL: ${{ vars.HOOKDECK_WEBSITE_DEPLOY_SOURCE_URL }}
           HOOKDECK_SOURCE_API_KEY: ${{ secrets.VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY }}
         run: |
+          if [ -z "${HOOKDECK_SOURCE_URL}" ]; then
+            echo "::error::Missing repository variable HOOKDECK_WEBSITE_DEPLOY_SOURCE_URL"
+            exit 1
+          fi
           if [ -z "${HOOKDECK_SOURCE_API_KEY}" ]; then
             echo "::error::Missing secret VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY"
             exit 1

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -37,7 +37,13 @@ jobs:
             echo "::error::Missing secret VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY"
             exit 1
           fi
-          curl -sS -f -X POST "${HOOKDECK_SOURCE_URL}" \
+          curl -sS -f \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            -X POST "${HOOKDECK_SOURCE_URL}" \
             -H "x-api-key: ${HOOKDECK_SOURCE_API_KEY}" \
             -H "Content-Type: application/json" \
             -d '{}'

--- a/.github/workflows/trigger-website-deploy.yml
+++ b/.github/workflows/trigger-website-deploy.yml
@@ -1,0 +1,38 @@
+# Triggers a Hookdeck source that forwards to the Vercel website deploy hook
+# when Outpost docs consumed by hookdeck/website change on main.
+#
+# Required repository secret (Settings → Secrets and variables → Actions):
+#   VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY — value for the Hookdeck source x-api-key header
+#
+# Assumes branch protection on main requires PR checks before merge; this job
+# does not wait for post-merge workflows. To gate on a specific workflow finishing,
+# add a separate workflow_run-triggered workflow.
+
+name: Trigger website deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/content/**"
+      - "docs/public/images/**"
+
+jobs:
+  hookdeck:
+    name: Notify Hookdeck (Vercel deploy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST Hookdeck source
+        env:
+          HOOKDECK_SOURCE_URL: https://hkdk.events/a1bst55qm05dyx
+          HOOKDECK_SOURCE_API_KEY: ${{ secrets.VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY }}
+        run: |
+          if [ -z "${HOOKDECK_SOURCE_API_KEY}" ]; then
+            echo "::error::Missing secret VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY"
+            exit 1
+          fi
+          curl -sS -f -X POST "${HOOKDECK_SOURCE_URL}" \
+            -H "x-api-key: ${HOOKDECK_SOURCE_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d '{}'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs on `push` to `main` when files under `docs/content/**` or `docs/public/images/**` change. It POSTs to the Hookdeck source URL (Vercel deploy hook chain) with the `x-api-key` header from the repository secret `VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY`.

## Setup before merge

- Add secret `VERCEL_WEBSITE_DEPLOY_HOOK_SOURCE_API_KEY` on this repo (Hookdeck source API key).

## Notes

- Assumes branch protection ensures PR checks pass before merges to `main`; this workflow does not wait for post-merge CI runs.

Made with [Cursor](https://cursor.com)