### PR TITLE
docs: refresh migrate-to-outpost guide and nodejs SDK example

### DIFF
--- a/docs/content/guides/migrate-to-outpost.mdoc
+++ b/docs/content/guides/migrate-to-outpost.mdoc
@@ -7,7 +7,7 @@ This guide will help you migrate your existing webhook infrastructure to Outpost
 
 ## Why Migrate to Outpost?
 
-Outpost is self-hosted, open-source infrastructure that enables event producers to add Event Destinations to their platform with support for destination types such as Webhooks, Hookdeck Event Gateway, Amazon EventBridge, AWS SQS, AWS S3, GCP Pub/Sub, RabbitMQ, and Kafka.
+Outpost is available as both a managed Hookdeck service and a self-hosted open-source deployment. It enables event producers to add Event Destinations to their platform with support for destination types such as Webhooks, Hookdeck Event Gateway, AWS SQS, AWS S3, GCP Pub/Sub, RabbitMQ, and Kafka.
 
 The benefits of migrating to Outpost include:
 
@@ -86,6 +86,40 @@ You can customize the following webhook features and behaviors. The full path to
 
 Templates use the [Go template syntax](https://pkg.go.dev/text/template).
 
+{% tabs tabGroup="deployment" %}
+{% tab label="Managed" %}
+
+In managed Outpost, prefer the [Config API](/docs/outpost/api#configuration) for migration automation and anything you want to drive from scripts, pipelines, or infrastructure-as-code. The same values are editable in the [Hookdeck dashboard](https://dashboard.hookdeck.com) under your **Outpost** project when you want to review or change settings by hand.
+
+#### Topics and retry defaults
+
+Use the [Config API](/docs/outpost/api#configuration) with `TOPICS`, `MAX_RETRY_LIMIT`, `RETRY_INTERVAL_SECONDS`, and `RETRY_SCHEDULE` so topic and retry defaults stay alongside the rest of your automated migration. The same fields are available in [Hookdeck General settings](https://dashboard.hookdeck.com/settings/project/general).
+
+For more on how topics and delivery fit together, see [Concepts](/docs/outpost/concepts) and [Event Delivery & Retries](/docs/outpost/features/event-delivery).
+
+#### Webhook headers and signatures
+
+Use the [Config API](/docs/outpost/api#configuration) with the `DESTINATIONS_WEBHOOK_*` keys to automate webhook headers, signatures, and related destination behavior (the managed counterpart to self-hosted webhook environment variables). The same options can be changed in [Hookdeck Destinations settings](https://dashboard.hookdeck.com/settings/project/destinations).
+
+See [Webhook destination](/docs/outpost/destinations/webhook) for templates, defaults, and the full key list.
+
+#### Portal and tenant-facing options
+
+Use the [Config API](/docs/outpost/api#configuration) with `PORTAL_*` keys for the refresh URL, branding, and other tenant-facing portal options. The same settings are available in [Hookdeck User Portal settings](https://dashboard.hookdeck.com/settings/project/user-portal).
+
+See [Tenant Portal](/docs/outpost/features/tenant-user-portal) for how those options affect operators and end users.
+
+#### Tenants, destinations, and backfill
+
+Use the [Outpost API](/docs/outpost/api) or an [SDK](/docs/outpost/sdks) to create or upsert tenants, create destinations (including topics and secrets), and publish or backfill historical events in batches—this is the path that scales for migration automation. Config keys and dashboard settings above define platform defaults; this step is about moving organizations and subscriptions into Outpost.
+
+You can also perform many tenant and destination actions from the [Hookdeck dashboard](https://dashboard.hookdeck.com) when you want a manual or exploratory workflow alongside scripted migration.
+
+For walkthroughs, see the [curl](/docs/outpost/quickstarts/hookdeck-outpost-curl), [TypeScript](/docs/outpost/quickstarts/hookdeck-outpost-typescript), [Python](/docs/outpost/quickstarts/hookdeck-outpost-python), and [Go](/docs/outpost/quickstarts/hookdeck-outpost-go) quickstarts, the [API reference](/docs/outpost/api), and the [SDKs](/docs/outpost/sdks) overview.
+
+{% /tab %}
+{% tab label="Self-Hosted" %}
+
 | YAML                               | Environment Variable                                    | Default Value                    |
 | ---------------------------------- | ------------------------------------------------------- | -------------------------------- |
 | `header_prefix`                    | `DESTINATIONS_WEBHOOK_HEADER_PREFIX`                    | `x-outpost`                      |
@@ -97,6 +131,8 @@ Templates use the [Go template syntax](https://pkg.go.dev/text/template).
 | `signature_header_template`        | `DESTINATIONS_WEBHOOK_SIGNATURE_HEADER_TEMPLATE`        | `v0={{.Signatures \| join ","}}` |
 | `signature_encoding`               | `DESTINATIONS_WEBHOOK_SIGNATURE_ENCODING`               | `hex`                            |
 | `signature_algorithm`              | `DESTINATIONS_WEBHOOK_SIGNATURE_ALGORITHM`              | `hmac-sha256`                    |
+{% /tab %}
+{% /tabs %}
 
 ### Migration Process
 
@@ -119,33 +155,60 @@ For the full migration, you may need to:
 1. Notify your customers of scheduled maintenance ahead of time, and again notify them when the maintenance begins and ends.
 2. Prevent new webhook subscriptions from being created.
 3. Ensure all in-flight events are completed (either delivered or failed) before the migration begins.
-4. Queue any new events for publishing. This works well if you are using a publish message queue with Outpost. If you are using the Outpost API to publish events, you will need to store the events to be published once the migration has completed.
+4. Queue any new events for publishing. This works well if you are using a publish message queue with Outpost. If you are using the [Outpost API](/docs/outpost/api) to publish events, you will need to store the events to be published once the migration has completed.
 5. Follow the steps 1 - 4 in the test migration process.
 6. Resume delivering the queued events via Outpost.
 
-#### Migrating Historic Event Database
+#### Migrating Historical Event Data
 
-To migrate your historical data to Outpost, you need to map your existing data structure to the Outpost schema.
+{% tabs tabGroup="deployment" %}
+{% tab label="Managed" %}
 
-The Outpost schema contains two tables related to events:
+Managed Outpost does not provide direct database access. For historical event migration, backfill by publishing historical events through the [Outpost API](/docs/outpost/api) or an [SDK](/docs/outpost/sdks) in controlled batches, preserving any external identifiers in metadata so downstream systems can deduplicate or correlate.
 
-1. **events** - The events that Outpost has received to publish.
-2. **attempts** - The delivery attempts of events to destinations.
+Recommended managed approach:
 
-The following diagram shows the Outpost schema. You can connect to the database instance within your Outpost installation to inspect the schema further.
+1. Export historical events from your existing system.
+2. Re-publish them to Outpost by tenant/topic in batches.
+3. Verify deliveries and retries in Hookdeck logs and metrics.
+4. Gradually increase batch size and then switch live traffic.
 
-![Event Destination Request List](/outpost-images/outpost-schema.png)
+{% /tab %}
+{% tab label="Self-Hosted" %}
+
+To migrate your historical data to Outpost, you map your existing structure into Outpost’s **logical** model (tenants, destinations, published events). For **self-hosted** installs you can also inspect the **PostgreSQL** schema that stores the event log; the canonical definitions are the migration files under [`internal/migrator/migrations/postgres`](https://github.com/hookdeck/outpost/tree/main/internal/migrator/migrations/postgres) in the Outpost repository.
+
+Outpost persists published events and delivery history in two **time-partitioned** tables:
+
+**`events`** — one row per distinct published event (retries reuse the same row). Columns include `id`, `tenant_id`, `time`, `topic`, `eligible_for_retry`, `matched_destination_ids` (text array of destination IDs that matched the event), `data` (payload stored as **text** so JSON key order is preserved), and `metadata` (JSON). There is **no** `destination_id` column on `events`; routing to destinations is expressed through `matched_destination_ids` and the delivery pipeline.
+
+**`attempts`** — one row per delivery attempt to a destination. Columns include `id`, `event_id`, `tenant_id`, `destination_id`, `destination_type`, `topic`, `status`, `time`, `attempt_number`, `manual`, `code`, `response_data` (HTTP-style response body stored as **text**), plus denormalized event fields (`event_time`, `eligible_for_retry`, `event_data`, `event_metadata`) for efficient querying.
+
+Writing rows directly is possible for advanced operators, but easy to get wrong (partitions, denormalized attempt fields, and invariants enforced in application code). For historical replay, prefer publishing through the [Outpost API](/docs/outpost/api) or an [SDK](/docs/outpost/sdks) unless you are deliberately doing a low-level database migration.
 
 #### Example Migration Script
 
-A migration script may look something like this:
+The following uses the current [`@hookdeck/outpost-sdk`](https://www.npmjs.com/package/@hookdeck/outpost-sdk) (`Outpost` client, `serverURL` + `apiKey`) to mirror tenants and webhook destinations from a placeholder `db` module—same pattern as the runnable demo.
 
 ```ts
-// Outpost TypeScript SDK (see examples/demos/nodejs)
-import outpost from "./outpost";
+import process from "node:process";
+import dotenv from "dotenv";
+dotenv.config();
 
-// Database wrapper
+import { Outpost } from "@hookdeck/outpost-sdk";
+
+// Replace with your own source of organizations and subscriptions.
 import { default as db } from "./db";
+
+if (!process.env.OUTPOST_API_BASE_URL || !process.env.OUTPOST_API_KEY) {
+  console.error("OUTPOST_API_BASE_URL and OUTPOST_API_KEY are required");
+  process.exit(1);
+}
+
+const outpost = new Outpost({
+  serverURL: process.env.OUTPOST_API_BASE_URL,
+  apiKey: process.env.OUTPOST_API_KEY,
+});
 
 const listTopics = async () => {
   const subscriptions = db.getSubscriptions();
@@ -175,23 +238,24 @@ const migrateSubscriptions = async (organizationId: string) => {
   for (const subscription of subscriptions) {
     await outpost.destinations.create(organizationId, {
       type: "webhook",
-      config: { url: subscription.url },
+      config: {
+        url: subscription.url,
+      },
       topics: subscription.topics,
-      credentials: { secret: subscription.secret },
+      credentials: {
+        secret: subscription.secret,
+      },
     });
   }
 };
 
 const main = async () => {
-  // 1. List topics
   const topics = await listTopics();
   console.log("Subscription topics:", topics);
 
-  // 2. Get list of organizations and migrate them
   const migratedOrgIds = await migrateOrganizations();
 
   for (const organizationId of migratedOrgIds) {
-    // 3. Migrate subscriptions
     await migrateSubscriptions(organizationId);
   }
 };
@@ -199,15 +263,17 @@ const main = async () => {
 main()
   .then(() => {
     console.log("Migration complete");
-
     process.exit(0);
   })
   .catch((error) => {
     console.error(error);
+    process.exit(1);
   });
 ```
 
-You can find a runnable version of this example script in the [Outpost examples directory](https://github.com/hookdeck/outpost/tree/main/examples).
+A runnable variant lives at [`examples/demos/nodejs/src/migrate.ts`](https://github.com/hookdeck/outpost/blob/main/examples/demos/nodejs/src/migrate.ts). The [`examples/sdk-typescript`](https://github.com/hookdeck/outpost/tree/main/examples/sdk-typescript) package pins the SDK via `file:../../sdks/outpost-typescript` for working inside this repository; when you copy the script elsewhere, depend on `@hookdeck/outpost-sdk` from npm.
+{% /tab %}
+{% /tabs %}
 
 ### Troubleshooting
 

--- a/examples/demos/nodejs/package-lock.json
+++ b/examples/demos/nodejs/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.774.0",
         "@google-cloud/pubsub": "^4.11.0",
-        "@hookdeck/outpost-sdk": "0.9.2",
+        "@hookdeck/outpost-sdk": "^1.0.1",
         "amqplib": "^0.10.3",
         "dotenv": "^16.4.7"
       },
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@hookdeck/outpost-sdk": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@hookdeck/outpost-sdk/-/outpost-sdk-0.9.2.tgz",
-      "integrity": "sha512-S394MDF9nrzb6Hw/DN9wWaA/7K+48rXsJT8RE//ZhfDh6muoGj55pwMhNC8w5yma80sI6KHSY1GoO8SMlIvypA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hookdeck/outpost-sdk/-/outpost-sdk-1.0.1.tgz",
+      "integrity": "sha512-c9dg+gm+n3qqfOh8rApVgV+5VOvDmEd1lNqKGF2rzJc/ima9BlLMSjo1UHfFaCXoerDlLXw/jgUCAnuT4/8B2w==",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "zod": "^3.25.0 || ^4.0.0"

--- a/examples/demos/nodejs/package.json
+++ b/examples/demos/nodejs/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.774.0",
     "@google-cloud/pubsub": "^4.11.0",
-    "@hookdeck/outpost-sdk": "0.9.2",
+    "@hookdeck/outpost-sdk": "^1.0.1",
     "amqplib": "^0.10.3",
     "dotenv": "^16.4.7"
   }


### PR DESCRIPTION
## Summary

This updates the **Migrate to Outpost** guide for how customers run Outpost today (managed Hookdeck + self-hosted), fixes outdated self-hosted schema copy, and aligns the Node.js migration demo with the current TypeScript SDK.

## Changes

- **Webhook customization:** Managed vs self-hosted tabs; Config API first with matching Hookdeck dashboard settings (General, Destinations, User Portal); follow-on doc links; links for [Outpost API](/docs/outpost/api) and [SDKs](/docs/outpost/sdks) where relevant.
- **Why migrate / intro:** Clarify managed and self-hosted; align destination list with current product positioning.
- **Historical data:** Managed tab for API/SDK batch backfill; self-hosted section describes `events` and `attempts` (partitioning, `matched_destination_ids`, text payloads) and points at Postgres migrations in-repo; remove the old schema PNG reference (image was gitignored on the website; guide no longer depends on it).
- **Example script:** Use `Outpost` from `@hookdeck/outpost-sdk` with `serverURL` / `apiKey`, env checks, and npm doc links; **examples/demos/nodejs** depends on `@hookdeck/outpost-sdk@^1.0.1` with updated lockfile.

## Test plan

- [ ] Proofread rendered Outpost docs (tabs, links).
- [ ] `cd examples/demos/nodejs && npm ci && npm run typecheck` (optional CI follow-up).

Made with [Cursor](https://cursor.com)