### PR TITLE
fix: use LogMaxConcurrency for logmq consumer worker

### DIFF
--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -418,7 +418,7 @@ func (b *ServiceBuilder) BuildLogWorker(baseRouter *gin.Engine) error {
 		"logmq-consumer",
 		logMQ.Subscribe,
 		handler,
-		b.cfg.DeliveryMaxConcurrency,
+		b.cfg.LogMaxConcurrency,
 		b.logger,
 	)
 	b.supervisor.Register(logWorker)


### PR DESCRIPTION
## Summary
- Fix bug where logmq consumer worker used `DeliveryMaxConcurrency` instead of `LogMaxConcurrency` in `builder.go`
- This caused `LOG_MAX_CONCURRENCY` env var to be entirely ignored, capping Pub/Sub unacked messages at the delivery concurrency limit

## Test plan
- [ ] Verify `LOG_MAX_CONCURRENCY` is respected by the logmq consumer subscription
- [ ] Confirm delivery concurrency is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)