### PR TITLE
chore(sdk): hoist publish and retry to SDK root

### DIFF
--- a/cmd/tools/genprovider/main.go
+++ b/cmd/tools/genprovider/main.go
@@ -16,10 +16,10 @@ type CoreMetadata struct {
 }
 
 type UIMetadata struct {
-	Label          string `json:"label"`
-	Description    string `json:"description"`
-	Icon           string `json:"icon"`
-	SetupLink *struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Icon        string `json:"icon"`
+	SetupLink   *struct {
 		Href string `json:"href"`
 		Cta  string `json:"cta"`
 	} `json:"setup_link,omitempty"`

--- a/docs/agent-evaluation/scripts/smoke-test-execute-ci-artifacts.sh
+++ b/docs/agent-evaluation/scripts/smoke-test-execute-ci-artifacts.sh
@@ -109,7 +109,7 @@ await outpost.destinations.create(tenantId, {
   topics: ["*"],
   config: { url: webhookUrl },
 });
-const published = await outpost.publish.event({
+const published = await outpost.publish({
   tenantId,
   topic,
   eligibleForRetry: true,

--- a/docs/content/quickstarts/hookdeck-outpost-go.mdoc
+++ b/docs/content/quickstarts/hookdeck-outpost-go.mdoc
@@ -125,7 +125,7 @@ func main() {
 	// --- 5. Publish one event ---
 	//
 
-	pubRes, err := s.Publish.Event(ctx, components.PublishRequest{
+	pubRes, err := s.Publish(ctx, components.PublishRequest{
 		TenantID:         outpostgo.String(tenantID),
 		Topic:            outpostgo.String(topic),
 		EligibleForRetry: outpostgo.Bool(true),

--- a/docs/content/quickstarts/hookdeck-outpost-python.mdoc
+++ b/docs/content/quickstarts/hookdeck-outpost-python.mdoc
@@ -101,7 +101,7 @@ client.destinations.create(
 # --- 5. Publish one event ---
 #
 
-published = client.publish.event(
+published = client.publish(
     request={
         "tenant_id": tenant_id,
         "topic": topic,

--- a/docs/content/quickstarts/hookdeck-outpost-typescript.mdoc
+++ b/docs/content/quickstarts/hookdeck-outpost-typescript.mdoc
@@ -104,7 +104,7 @@ await outpost.destinations.create(tenantId, {
 // --- 5. Publish one event (delivered to destinations subscribed to `topic`) ---
 //
 
-const published = await outpost.publish.event({
+const published = await outpost.publish({
   tenantId,
   topic,
   eligibleForRetry: true,

--- a/docs/content/sdks.mdoc
+++ b/docs/content/sdks.mdoc
@@ -88,7 +88,7 @@ async function manageOutpostResources() {
     };
 
     console.log(`Publishing event to topic ${topic} for tenant ${tenantId}...`);
-    await outpostAdmin.publish.event({
+    await outpostAdmin.publish({
       data: eventPayload,
       tenantId,
       topic,

--- a/examples/demos/dashboard-integration/INTEGRATION_DETAILS.md
+++ b/examples/demos/dashboard-integration/INTEGRATION_DETAILS.md
@@ -943,7 +943,7 @@ export async function POST(request: NextRequest) {
       };
 
       // Publish event using Outpost SDK
-      const result = await outpostClient.publish.event({
+      const result = await outpostClient.publish({
         tenantId,
         topic,
         data: eventPayload,

--- a/examples/demos/dashboard-integration/src/app/api/playground/trigger/route.ts
+++ b/examples/demos/dashboard-integration/src/app/api/playground/trigger/route.ts
@@ -86,8 +86,7 @@ export async function POST(request: NextRequest) {
       };
 
       // Publish the event using the Outpost SDK
-      // Based on the SDK examples, use publish.event method
-      const result = await outpostClient.publish.event({
+      const result = await outpostClient.publish({
         tenantId,
         topic,
         data: eventPayload,

--- a/examples/demos/nodejs/src/publish-api.ts
+++ b/examples/demos/nodejs/src/publish-api.ts
@@ -31,7 +31,7 @@ const main = async () => {
       };
       console.log("Publishing event");
       console.log(event);
-      await outpost.publish.event(event);
+      await outpost.publish(event);
     }
   }
 };

--- a/examples/sdk-go/publish_event.go
+++ b/examples/sdk-go/publish_event.go
@@ -75,7 +75,7 @@ func runPublishEventExample() {
 		TenantID: &tenantID,
 	}
 
-	res, err := client.Publish.Event(context.Background(), request)
+	res, err := client.Publish(context.Background(), request)
 	if err != nil {
 		log.Fatalf("Error publishing event: %v", err)
 	}

--- a/examples/sdk-go/resources.go
+++ b/examples/sdk-go/resources.go
@@ -81,7 +81,7 @@ func manageOutpostResources(adminAPIKey string, apiServerURL string) {
 		Data:             eventPayload,
 		EligibleForRetry: outpostgo.Bool(true),
 	}
-	publishRes, err := outpostAdmin.Publish.Event(ctx, publishRequest)
+	publishRes, err := outpostAdmin.Publish(ctx, publishRequest)
 	if err != nil {
 		log.Fatalf("Failed to publish event: %v\n", err)
 	}

--- a/examples/sdk-python/example/publish_event.py
+++ b/examples/sdk-python/example/publish_event.py
@@ -46,7 +46,7 @@ def run():
         ],
     }
 
-    res = client.publish.event(
+    res = client.publish(
         topic=topic,
         data=payload,
         tenant_id=tenant_id,

--- a/examples/sdk-typescript/auth.ts
+++ b/examples/sdk-typescript/auth.ts
@@ -83,7 +83,7 @@ const withAdminApiKey = async () => {
   console.log(
     `Publishing event to topic ${topic} for tenant ${tenantId}...`
   );
-  await outpost.publish.event({
+  await outpost.publish({
     data: eventPayload,
     tenantId,
     topic: "user.created",

--- a/examples/sdk-typescript/index.ts
+++ b/examples/sdk-typescript/index.ts
@@ -51,7 +51,7 @@ async function manageOutpostResources() {
     };
 
     console.log(`Publishing event to topic ${topic} for tenant ${tenantId}...`);
-    await outpostAdmin.publish.event({
+    await outpostAdmin.publish({
       data: eventPayload,
       tenantId,
       topic,

--- a/examples/sdk-typescript/publish-event.ts
+++ b/examples/sdk-typescript/publish-event.ts
@@ -46,7 +46,7 @@ async function main() {
   };
 
   try {
-    const response = await client.publish.event({
+    const response = await client.publish({
       topic: topic,
       data: payload,
       tenantId: tenantId,

--- a/internal/logstore/chlogstore/chlogstore_test.go
+++ b/internal/logstore/chlogstore/chlogstore_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hookdeck/outpost/internal/clickhouse"
 	"github.com/hookdeck/outpost/internal/logstore/driver"
 	"github.com/hookdeck/outpost/internal/logstore/drivertest"
-	"github.com/hookdeck/outpost/internal/pagination"
 	"github.com/hookdeck/outpost/internal/migrator"
 	"github.com/hookdeck/outpost/internal/models"
+	"github.com/hookdeck/outpost/internal/pagination"
 	"github.com/hookdeck/outpost/internal/util/testinfra"
 	"github.com/hookdeck/outpost/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
@@ -124,25 +124,30 @@ func newHarnessWithDeploymentID(ctx context.Context, t *testing.T) (drivertest.H
 // ── Dataset ──────────────────────────────────────────────────────────────────
 //
 // Event A ("order.created"): Fanout to 3 destinations in one batch.
-//   Batch 1:  dest-a #1 success, dest-b #1 failed, dest-c #1 success
-//   Batch 2:  dest-b #2 success  (retry)
+//
+//	Batch 1:  dest-a #1 success, dest-b #1 failed, dest-c #1 success
+//	Batch 2:  dest-b #2 success  (retry)
 //
 // Event B ("user.signup"): Single destination, fails twice then succeeds.
-//   Batch 3:  dest-a #1 failed
-//   Batch 4:  dest-a #2 failed   (retry)
-//   Batch 5:  dest-a #3 success  (retry)
+//
+//	Batch 3:  dest-a #1 failed
+//	Batch 4:  dest-a #2 failed   (retry)
+//	Batch 5:  dest-a #3 success  (retry)
 //
 // Event C ("payment.received"): Single destination, succeeds first try.
-//   Batch 6:  dest-b #1 success
+//
+//	Batch 6:  dest-b #1 success
 //
 // ── Expected ─────────────────────────────────────────────────────────────────
-//   Event rows:   3 (one per unique event, retries skipped by write path)
-//   Attempt rows: 8 (A×4 + B×3 + C×1, all persisted)
-//   ListEvent:    3 unique events (client-side dedup hides any stragglers)
+//
+//	Event rows:   3 (one per unique event, retries skipped by write path)
+//	Attempt rows: 8 (A×4 + B×3 + C×1, all persisted)
+//	ListEvent:    3 unique events (client-side dedup hides any stragglers)
 //
 // After injecting legacy duplicates (raw batch inserts simulating pre-fix data):
-//   Event rows:   9 (3 original + 6 injected)
-//   ListEvent:    still 3 (read-path dedup)
+//
+//	Event rows:   9 (3 original + 6 injected)
+//	ListEvent:    still 3 (read-path dedup)
 func TestEventDedup(t *testing.T) {
 	testutil.CheckIntegrationTest(t)
 	t.Parallel()
@@ -159,19 +164,19 @@ func TestEventDedup(t *testing.T) {
 	eventA := &models.Event{
 		ID: "evt-a", TenantID: tenantID,
 		MatchedDestinationIDs: []string{"dest-a", "dest-b", "dest-c"},
-		Topic: "order.created", EligibleForRetry: true,
+		Topic:                 "order.created", EligibleForRetry: true,
 		Time: baseTime, Data: []byte(`{"order_id":"100"}`),
 	}
 	eventB := &models.Event{
 		ID: "evt-b", TenantID: tenantID,
 		MatchedDestinationIDs: []string{"dest-a"},
-		Topic: "user.signup", EligibleForRetry: true,
+		Topic:                 "user.signup", EligibleForRetry: true,
 		Time: baseTime.Add(-1 * time.Minute), Data: []byte(`{"user_id":"42"}`),
 	}
 	eventC := &models.Event{
 		ID: "evt-c", TenantID: tenantID,
 		MatchedDestinationIDs: []string{"dest-b"},
-		Topic: "payment.received", EligibleForRetry: false,
+		Topic:                 "payment.received", EligibleForRetry: false,
 		Time: baseTime.Add(-2 * time.Minute), Data: []byte(`{"amount":99}`),
 	}
 

--- a/sdks/schemas/speakeasy-modifications-overlay.yaml
+++ b/sdks/schemas/speakeasy-modifications-overlay.yaml
@@ -56,9 +56,10 @@ actions:
   - target: $["paths"]["/retry"]["post"]
     update:
       x-speakeasy-name-override: retry
+      x-speakeasy-group: ""
     x-speakeasy-metadata:
-      after: sdk.attempts.retry()
-      before: sdk.Attempts.retryEvent()
+      after: sdk.retry()
+      before: sdk.Retry.retryEvent()
       created_at: 1745611620645
       reviewed_at: 1745611624395
       type: method-name
@@ -181,9 +182,10 @@ actions:
       type: method-name
   - target: $["paths"]["/publish"]["post"]
     update:
-      x-speakeasy-name-override: event
+      x-speakeasy-name-override: publish
+      x-speakeasy-group: ""
     x-speakeasy-metadata:
-      after: sdk.publish.event()
+      after: sdk.publish()
       before: sdk.Publish.publishEvent()
       created_at: 1745611620645
       reviewed_at: 1745611624395

--- a/spec-sdk-tests/tests/events.test.ts
+++ b/spec-sdk-tests/tests/events.test.ts
@@ -176,7 +176,7 @@ describe('Events (PR #491)', () => {
 
       const sdk: Outpost = client.getSDK();
 
-      await sdk.publish.event({
+      await sdk.publish({
         tenantId: client.getTenantId(),
         topic: TEST_TOPICS[0],
         data: {
@@ -235,7 +235,7 @@ describe('Events (PR #491)', () => {
 
       const sdk: Outpost = client.getSDK();
 
-      const publishResponse = await sdk.publish.event({
+      const publishResponse = await sdk.publish({
         tenantId: client.getTenantId(),
         topic: TEST_TOPICS[0],
         data: {


### PR DESCRIPTION
## Summary

- Add `x-speakeasy-group: \"\"` to `/publish` and `/retry` POST overlays so single-operation namespaces collapse to root methods.
- Updated `x-speakeasy-name-override` for `/publish` from `event` to `publish` to match new shape.
- Caller migration: `sdk.Publish.Event(...)` / `sdk.Retry.Retry(...)` → `sdk.Publish(...)` / `sdk.Retry(...)`.

## Why

After #883 retagged `/retry` to its own `Retry` tag (1.1.0), Speakeasy generated stuttering `sdk.retry.retry()`. Both `/publish` and `/retry` are single-operation tags — hoisting to root is more idiomatic and removes the stutter.

## Verification

Tested locally with `speakeasy run -t outpost-go`:
- `publish.go` and `retry.go` namespace files removed
- `Publish` and `Retry` become methods on the root `Outpost` struct
- `docs/sdks/publish/` and `docs/sdks/retry/` removed; methods documented in new `docs/sdks/outpost/README.md`
- No collision with `WithRetryConfig` HTTP retry option
- Build, tests, and staticcheck all pass

## Test plan

- [ ] Merge spec change
- [ ] Trigger SDK regeneration as 1.2.0 (Go → Python → TS)
- [ ] Verify each SDK exposes root-level `publish` / `retry`
- [ ] Confirm no Speakeasy linting regressions