### PR TITLE
feat(api): enable/disable destinations via Create and Update

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -1355,8 +1355,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1364,7 +1364,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1415,8 +1416,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1424,7 +1425,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1475,8 +1477,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1484,7 +1486,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1534,8 +1537,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1543,7 +1546,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1594,8 +1598,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1603,7 +1607,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1655,8 +1660,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1664,7 +1669,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1716,8 +1722,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1725,7 +1731,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1776,8 +1783,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1785,7 +1792,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1836,8 +1844,8 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Defaults to the current time when
-            omitted.
+            destinations from another system. Must not be in the future.
+            Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
@@ -1845,7 +1853,8 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Defaults to created_at when omitted.
+            importing destinations. Must not be in the future. Defaults to
+            created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -1355,17 +1355,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1373,8 +1372,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
     DestinationCreateAWSSQS:
       type: object
@@ -1417,17 +1415,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1435,8 +1432,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
     DestinationCreateRabbitMQ:
       type: object
@@ -1479,17 +1475,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1497,8 +1492,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
     DestinationCreateHookdeck:
       type: object
@@ -1540,17 +1534,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1558,8 +1551,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
     DestinationCreateAWSKinesis:
       type: object
@@ -1602,17 +1594,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1620,8 +1611,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
 
     DestinationCreateAzureServiceBus:
@@ -1665,17 +1655,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1683,8 +1672,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
 
     DestinationCreateAWSS3:
@@ -1728,17 +1716,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1746,8 +1733,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
     DestinationCreateGCPPubSub:
       type: object
@@ -1790,17 +1776,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1808,8 +1793,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
     DestinationCreateKafka:
       type: object
@@ -1852,17 +1836,16 @@ components:
           nullable: true
           description: >-
             Optional override for the creation timestamp. Intended for importing
-            destinations from another system. Must not be in the future. Defaults
-            to the current time when omitted.
+            destinations from another system. Defaults to the current time when
+            omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
           type: string
           format: date-time
           nullable: true
           description: >-
-            Optional override for the last-updated timestamp. Intended for importing
-            destinations. Must be >= created_at and <= now. Defaults to created_at
-            when omitted.
+            Optional override for the last-updated timestamp. Intended for
+            importing destinations. Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1870,8 +1853,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Must be >= created_at and <= now. Defaults to null
-            (enabled).
+            timestamp. Defaults to null (enabled).
           example: null
 
     # Polymorphic Destination Creation Schema (for Request Bodies)
@@ -1960,9 +1942,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateAWSSQS:
       type: object
@@ -2008,9 +1989,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateRabbitMQ:
       type: object
@@ -2056,9 +2036,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateHookdeck:
       type: object
@@ -2103,9 +2082,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateAWSKinesis:
       type: object
@@ -2151,9 +2129,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateAzureServiceBus:
       type: object
@@ -2199,9 +2176,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
 
     DestinationUpdateAWSS3:
@@ -2248,9 +2224,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateGCPPubSub:
       type: object
@@ -2296,9 +2271,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
     DestinationUpdateKafka:
       type: object
@@ -2344,9 +2318,8 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp
-            (must be >= created_at and <= now) to disable, null to enable,
-            or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp to
+            disable, null to enable, or omit to leave unchanged.
           example: null
 
     # Polymorphic Destination Update Schema (for Request Bodies)

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -1356,6 +1356,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1364,8 +1365,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1417,6 +1419,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1425,8 +1428,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1478,6 +1482,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1486,8 +1491,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1538,6 +1544,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1546,8 +1553,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1599,6 +1607,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1607,8 +1616,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1661,6 +1671,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1669,8 +1680,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1723,6 +1735,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1731,8 +1744,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1784,6 +1798,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1792,8 +1807,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string
@@ -1845,6 +1861,7 @@ components:
           description: >-
             Optional override for the creation timestamp. Intended for importing
             destinations from another system. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
             Defaults to the current time when omitted.
           example: "2024-02-15T10:00:00Z"
         updated_at:
@@ -1853,8 +1870,9 @@ components:
           nullable: true
           description: >-
             Optional override for the last-updated timestamp. Intended for
-            importing destinations. Must not be in the future. Defaults to
-            created_at when omitted.
+            importing destinations. Must not be in the future.
+            **Admin (API key) auth only — sending this with JWT auth returns 403.**
+            Defaults to created_at when omitted.
           example: "2024-02-15T10:00:00Z"
         disabled_at:
           type: string

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -1372,7 +1372,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
     DestinationCreateAWSSQS:
       type: object
@@ -1432,7 +1432,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
     DestinationCreateRabbitMQ:
       type: object
@@ -1492,7 +1492,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
     DestinationCreateHookdeck:
       type: object
@@ -1551,7 +1551,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
     DestinationCreateAWSKinesis:
       type: object
@@ -1611,7 +1611,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
 
     DestinationCreateAzureServiceBus:
@@ -1672,7 +1672,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
 
     DestinationCreateAWSS3:
@@ -1733,7 +1733,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
     DestinationCreateGCPPubSub:
       type: object
@@ -1793,7 +1793,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
     DestinationCreateKafka:
       type: object
@@ -1853,7 +1853,7 @@ components:
           nullable: true
           description: >-
             If set, the destination is created in a disabled state with this
-            timestamp. Defaults to null (enabled).
+            timestamp. Must not be in the future. Defaults to null (enabled).
           example: null
 
     # Polymorphic Destination Creation Schema (for Request Bodies)
@@ -1942,8 +1942,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateAWSSQS:
       type: object
@@ -1989,8 +1990,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateRabbitMQ:
       type: object
@@ -2036,8 +2038,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateHookdeck:
       type: object
@@ -2082,8 +2085,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateAWSKinesis:
       type: object
@@ -2129,8 +2133,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateAzureServiceBus:
       type: object
@@ -2176,8 +2181,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
 
     DestinationUpdateAWSS3:
@@ -2224,8 +2230,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateGCPPubSub:
       type: object
@@ -2271,8 +2278,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
     DestinationUpdateKafka:
       type: object
@@ -2318,8 +2326,9 @@ components:
           format: date-time
           nullable: true
           description: >-
-            Update the disabled state of the destination. Send a timestamp to
-            disable, null to enable, or omit to leave unchanged.
+            Update the disabled state of the destination. Send a timestamp
+            (must not be in the future) to disable, null to enable, or omit
+            to leave unchanged.
           example: null
 
     # Polymorphic Destination Update Schema (for Request Bodies)

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -1349,6 +1349,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
     DestinationCreateAWSSQS:
       type: object
       x-docs-type: "AWS SQS"
@@ -1384,6 +1411,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
     DestinationCreateRabbitMQ:
       type: object
       x-docs-type: "RabbitMQ"
@@ -1419,6 +1473,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
     DestinationCreateHookdeck:
       type: object
       x-docs-type: "Hookdeck Event Gateway"
@@ -1453,6 +1534,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
     DestinationCreateAWSKinesis:
       type: object
       x-docs-type: "AWS Kinesis"
@@ -1488,6 +1596,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
 
     DestinationCreateAzureServiceBus:
       type: object
@@ -1524,6 +1659,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
 
     DestinationCreateAWSS3:
       type: object
@@ -1560,6 +1722,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
     DestinationCreateGCPPubSub:
       type: object
       x-docs-type: "GCP PubSub"
@@ -1595,6 +1784,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
     DestinationCreateKafka:
       type: object
       x-docs-type: "Apache Kafka"
@@ -1630,6 +1846,33 @@ components:
           nullable: true
           description: Arbitrary contextual information stored with the destination.
           example: { "internal-id": "123", "team": "platform" }
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the creation timestamp. Intended for importing
+            destinations from another system. Must not be in the future. Defaults
+            to the current time when omitted.
+          example: "2024-02-15T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Optional override for the last-updated timestamp. Intended for importing
+            destinations. Must be >= created_at and <= now. Defaults to created_at
+            when omitted.
+          example: "2024-02-15T10:00:00Z"
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            If set, the destination is created in a disabled state with this
+            timestamp. Must be >= created_at and <= now. Defaults to null
+            (enabled).
+          example: null
 
     # Polymorphic Destination Creation Schema (for Request Bodies)
     DestinationCreate:
@@ -1712,6 +1955,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateAWSSQS:
       type: object
       x-docs-type: "AWS SQS"
@@ -1751,6 +2003,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateRabbitMQ:
       type: object
       x-docs-type: "RabbitMQ"
@@ -1790,6 +2051,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateHookdeck:
       type: object
       x-docs-type: "Hookdeck Event Gateway"
@@ -1828,6 +2098,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateAWSKinesis:
       type: object
       x-docs-type: "AWS Kinesis"
@@ -1867,6 +2146,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateAzureServiceBus:
       type: object
       x-docs-type: "Azure Service Bus"
@@ -1906,6 +2194,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
 
     DestinationUpdateAWSS3:
       type: object
@@ -1946,6 +2243,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateGCPPubSub:
       type: object
       x-docs-type: "GCP PubSub"
@@ -1985,6 +2291,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
     DestinationUpdateKafka:
       type: object
       x-docs-type: "Apache Kafka"
@@ -2024,6 +2339,15 @@ components:
             null values to delete keys, null for entire field to clear all.
             Omit or send {} for no change.
           example: { "internal-id": "123", "team": "platform" }
+        disabled_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Update the disabled state of the destination. Send a timestamp
+            (must be >= created_at and <= now) to disable, null to enable,
+            or omit to leave unchanged.
+          example: null
 
     # Polymorphic Destination Update Schema (for Request Bodies)
     DestinationUpdate:

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -86,6 +86,13 @@ func (h *DestinationHandlers) Create(c *gin.Context) {
 		AbortWithValidationError(c, err)
 		return
 	}
+	if mustRoleFromContext(c) != RoleAdmin && (input.CreatedAt != nil || input.UpdatedAt != nil) {
+		AbortWithError(c, http.StatusForbidden, ErrorResponse{
+			Code:    http.StatusForbidden,
+			Message: "created_at and updated_at can only be set with API key authentication",
+		})
+		return
+	}
 	now := time.Now()
 	if input.CreatedAt != nil && input.CreatedAt.After(now) {
 		AbortWithValidationError(c, errors.New("created_at cannot be in the future"))

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -86,7 +86,16 @@ func (h *DestinationHandlers) Create(c *gin.Context) {
 		AbortWithValidationError(c, err)
 		return
 	}
-	if input.DisabledAt != nil && input.DisabledAt.After(time.Now()) {
+	now := time.Now()
+	if input.CreatedAt != nil && input.CreatedAt.After(now) {
+		AbortWithValidationError(c, errors.New("created_at cannot be in the future"))
+		return
+	}
+	if input.UpdatedAt != nil && input.UpdatedAt.After(now) {
+		AbortWithValidationError(c, errors.New("updated_at cannot be in the future"))
+		return
+	}
+	if input.DisabledAt != nil && input.DisabledAt.After(now) {
 		AbortWithValidationError(c, errors.New("disabled_at cannot be in the future"))
 		return
 	}

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -86,6 +86,10 @@ func (h *DestinationHandlers) Create(c *gin.Context) {
 		AbortWithValidationError(c, err)
 		return
 	}
+	if input.DisabledAt != nil && input.DisabledAt.After(time.Now()) {
+		AbortWithValidationError(c, errors.New("disabled_at cannot be in the future"))
+		return
+	}
 
 	tenant := mustTenantFromContext(c)
 	prev := h.snapshotTenant(tenant)
@@ -243,6 +247,10 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 			var ts time.Time
 			if err := json.Unmarshal(input.DisabledAt, &ts); err != nil {
 				AbortWithValidationError(c, fmt.Errorf("invalid disabled_at: %w", err))
+				return
+			}
+			if ts.After(time.Now()) {
+				AbortWithValidationError(c, errors.New("disabled_at cannot be in the future"))
 				return
 			}
 			if updatedDestination.DisabledAt == nil || !updatedDestination.DisabledAt.Equal(ts) {

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -86,6 +86,10 @@ func (h *DestinationHandlers) Create(c *gin.Context) {
 		AbortWithValidationError(c, err)
 		return
 	}
+	if err := input.Validate(time.Now()); err != nil {
+		AbortWithValidationError(c, err)
+		return
+	}
 
 	tenant := mustTenantFromContext(c)
 	prev := h.snapshotTenant(tenant)
@@ -228,6 +232,39 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 		updatedDestination.Metadata = metaResult
 	}
 
+	// DisabledAt
+	//   omitted: leave alone
+	//   null:    enable (clear)
+	//   <ts>:    disable at that time (must be <= now and >= created_at)
+	disabilityChanged := false
+	now := time.Now()
+	if input.DisabledAt != nil {
+		if isJSONNull(input.DisabledAt) {
+			if updatedDestination.DisabledAt != nil {
+				updatedDestination.DisabledAt = nil
+				disabilityChanged = true
+			}
+		} else {
+			var ts time.Time
+			if err := json.Unmarshal(input.DisabledAt, &ts); err != nil {
+				AbortWithValidationError(c, fmt.Errorf("invalid disabled_at: %w", err))
+				return
+			}
+			if ts.After(now) {
+				AbortWithValidationError(c, errors.New("disabled_at cannot be in the future"))
+				return
+			}
+			if ts.Before(originalDestination.CreatedAt) {
+				AbortWithValidationError(c, errors.New("disabled_at cannot be before created_at"))
+				return
+			}
+			if updatedDestination.DisabledAt == nil || !updatedDestination.DisabledAt.Equal(ts) {
+				updatedDestination.DisabledAt = &ts
+				disabilityChanged = true
+			}
+		}
+	}
+
 	// Always preprocess before updating
 	if err := h.registry.PreprocessDestination(&updatedDestination, originalDestination, &destregistry.PreprocessDestinationOpts{
 		Role: mustRoleFromContext(c),
@@ -255,6 +292,17 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 		zap.String("destination_id", updatedDestination.ID),
 		zap.String("destination_type", updatedDestination.Type),
 	)
+	if disabilityChanged {
+		action := "destination enabled"
+		if updatedDestination.DisabledAt != nil {
+			action = "destination disabled"
+		}
+		h.logger.Ctx(c.Request.Context()).Audit(action,
+			zap.String("tenant_id", tenant.ID),
+			zap.String("destination_id", updatedDestination.ID),
+			zap.String("destination_type", updatedDestination.Type),
+		)
+	}
 
 	display, err := h.displayer.Display(&updatedDestination)
 	if err != nil {
@@ -390,6 +438,38 @@ type CreateDestinationRequest struct {
 	Credentials      models.Credentials      `json:"credentials" binding:"-"`
 	DeliveryMetadata models.DeliveryMetadata `json:"delivery_metadata,omitempty" binding:"-"`
 	Metadata         models.Metadata         `json:"metadata,omitempty" binding:"-"`
+	CreatedAt        *time.Time              `json:"created_at,omitempty" binding:"-"`
+	UpdatedAt        *time.Time              `json:"updated_at,omitempty" binding:"-"`
+	DisabledAt       *time.Time              `json:"disabled_at,omitempty" binding:"-"`
+}
+
+// Validate checks request-level invariants that don't fit on the model
+// (cross-field timestamp ordering for the import use case).
+func (r *CreateDestinationRequest) Validate(now time.Time) error {
+	createdAt := now
+	if r.CreatedAt != nil {
+		createdAt = *r.CreatedAt
+		if createdAt.After(now) {
+			return errors.New("created_at cannot be in the future")
+		}
+	}
+	if r.UpdatedAt != nil {
+		if r.UpdatedAt.After(now) {
+			return errors.New("updated_at cannot be in the future")
+		}
+		if r.UpdatedAt.Before(createdAt) {
+			return errors.New("updated_at cannot be before created_at")
+		}
+	}
+	if r.DisabledAt != nil {
+		if r.DisabledAt.After(now) {
+			return errors.New("disabled_at cannot be in the future")
+		}
+		if r.DisabledAt.Before(createdAt) {
+			return errors.New("disabled_at cannot be before created_at")
+		}
+	}
+	return nil
 }
 
 func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destination {
@@ -404,6 +484,14 @@ func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destina
 	}
 
 	now := time.Now()
+	createdAt := now
+	if r.CreatedAt != nil {
+		createdAt = *r.CreatedAt
+	}
+	updatedAt := createdAt
+	if r.UpdatedAt != nil {
+		updatedAt = *r.UpdatedAt
+	}
 	return models.Destination{
 		ID:               r.ID,
 		Type:             r.Type,
@@ -413,9 +501,9 @@ func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destina
 		Credentials:      r.Credentials,
 		DeliveryMetadata: r.DeliveryMetadata,
 		Metadata:         r.Metadata,
-		CreatedAt:        now,
-		UpdatedAt:        now,
-		DisabledAt:       nil,
+		CreatedAt:        createdAt,
+		UpdatedAt:        updatedAt,
+		DisabledAt:       r.DisabledAt,
 		TenantID:         tenantID,
 	}
 }
@@ -428,6 +516,7 @@ type UpdateDestinationRequest struct {
 	Credentials      json.RawMessage `json:"credentials" binding:"-"`
 	DeliveryMetadata json.RawMessage `json:"delivery_metadata" binding:"-"`
 	Metadata         json.RawMessage `json:"metadata" binding:"-"`
+	DisabledAt       json.RawMessage `json:"disabled_at" binding:"-"`
 }
 
 // isJSONNull checks if raw JSON bytes represent a JSON null literal.

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -445,13 +445,14 @@ type CreateDestinationRequest struct {
 
 // Validate checks request-level invariants that don't fit on the model
 // (cross-field timestamp ordering for the import use case).
+//
+// When created_at is omitted but disabled_at is provided, created_at is
+// implicitly defaulted to disabled_at (see ToDestination); validation
+// applies the same default so a lone disabled_at in the past is accepted.
 func (r *CreateDestinationRequest) Validate(now time.Time) error {
-	createdAt := now
-	if r.CreatedAt != nil {
-		createdAt = *r.CreatedAt
-		if createdAt.After(now) {
-			return errors.New("created_at cannot be in the future")
-		}
+	createdAt := r.effectiveCreatedAt(now)
+	if createdAt.After(now) {
+		return errors.New("created_at cannot be in the future")
 	}
 	if r.UpdatedAt != nil {
 		if r.UpdatedAt.After(now) {
@@ -472,6 +473,18 @@ func (r *CreateDestinationRequest) Validate(now time.Time) error {
 	return nil
 }
 
+// effectiveCreatedAt resolves the created_at to apply: explicit value, else
+// disabled_at (so importers can send disabled_at alone), else now.
+func (r *CreateDestinationRequest) effectiveCreatedAt(now time.Time) time.Time {
+	if r.CreatedAt != nil {
+		return *r.CreatedAt
+	}
+	if r.DisabledAt != nil {
+		return *r.DisabledAt
+	}
+	return now
+}
+
 func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destination {
 	if r.ID == "" {
 		r.ID = idgen.Destination()
@@ -484,10 +497,7 @@ func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destina
 	}
 
 	now := time.Now()
-	createdAt := now
-	if r.CreatedAt != nil {
-		createdAt = *r.CreatedAt
-	}
+	createdAt := r.effectiveCreatedAt(now)
 	updatedAt := createdAt
 	if r.UpdatedAt != nil {
 		updatedAt = *r.UpdatedAt

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -86,10 +86,6 @@ func (h *DestinationHandlers) Create(c *gin.Context) {
 		AbortWithValidationError(c, err)
 		return
 	}
-	if err := input.Validate(time.Now()); err != nil {
-		AbortWithValidationError(c, err)
-		return
-	}
 
 	tenant := mustTenantFromContext(c)
 	prev := h.snapshotTenant(tenant)
@@ -235,9 +231,8 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 	// DisabledAt
 	//   omitted: leave alone
 	//   null:    enable (clear)
-	//   <ts>:    disable at that time (must be <= now and >= created_at)
+	//   <ts>:    disable at that time
 	disabilityChanged := false
-	now := time.Now()
 	if input.DisabledAt != nil {
 		if isJSONNull(input.DisabledAt) {
 			if updatedDestination.DisabledAt != nil {
@@ -248,14 +243,6 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 			var ts time.Time
 			if err := json.Unmarshal(input.DisabledAt, &ts); err != nil {
 				AbortWithValidationError(c, fmt.Errorf("invalid disabled_at: %w", err))
-				return
-			}
-			if ts.After(now) {
-				AbortWithValidationError(c, errors.New("disabled_at cannot be in the future"))
-				return
-			}
-			if ts.Before(originalDestination.CreatedAt) {
-				AbortWithValidationError(c, errors.New("disabled_at cannot be before created_at"))
 				return
 			}
 			if updatedDestination.DisabledAt == nil || !updatedDestination.DisabledAt.Equal(ts) {
@@ -443,48 +430,6 @@ type CreateDestinationRequest struct {
 	DisabledAt       *time.Time              `json:"disabled_at,omitempty" binding:"-"`
 }
 
-// Validate checks request-level invariants that don't fit on the model
-// (cross-field timestamp ordering for the import use case).
-//
-// When created_at is omitted but disabled_at is provided, created_at is
-// implicitly defaulted to disabled_at (see ToDestination); validation
-// applies the same default so a lone disabled_at in the past is accepted.
-func (r *CreateDestinationRequest) Validate(now time.Time) error {
-	createdAt := r.effectiveCreatedAt(now)
-	if createdAt.After(now) {
-		return errors.New("created_at cannot be in the future")
-	}
-	if r.UpdatedAt != nil {
-		if r.UpdatedAt.After(now) {
-			return errors.New("updated_at cannot be in the future")
-		}
-		if r.UpdatedAt.Before(createdAt) {
-			return errors.New("updated_at cannot be before created_at")
-		}
-	}
-	if r.DisabledAt != nil {
-		if r.DisabledAt.After(now) {
-			return errors.New("disabled_at cannot be in the future")
-		}
-		if r.DisabledAt.Before(createdAt) {
-			return errors.New("disabled_at cannot be before created_at")
-		}
-	}
-	return nil
-}
-
-// effectiveCreatedAt resolves the created_at to apply: explicit value, else
-// disabled_at (so importers can send disabled_at alone), else now.
-func (r *CreateDestinationRequest) effectiveCreatedAt(now time.Time) time.Time {
-	if r.CreatedAt != nil {
-		return *r.CreatedAt
-	}
-	if r.DisabledAt != nil {
-		return *r.DisabledAt
-	}
-	return now
-}
-
 func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destination {
 	if r.ID == "" {
 		r.ID = idgen.Destination()
@@ -497,7 +442,10 @@ func (r *CreateDestinationRequest) ToDestination(tenantID string) models.Destina
 	}
 
 	now := time.Now()
-	createdAt := r.effectiveCreatedAt(now)
+	createdAt := now
+	if r.CreatedAt != nil {
+		createdAt = *r.CreatedAt
+	}
 	updatedAt := createdAt
 	if r.UpdatedAt != nil {
 		updatedAt = *r.UpdatedAt

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -151,6 +151,30 @@ func TestAPI_Destinations(t *testing.T) {
 				assert.True(t, dest.UpdatedAt.Equal(createdAt))
 			})
 
+			t.Run("created_at in future returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["created_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
+			t.Run("updated_at in future returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["updated_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
 			t.Run("disabled_at in future returns 422", func(t *testing.T) {
 				h := newAPITest(t)
 				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -95,6 +95,26 @@ func TestAPI_Destinations(t *testing.T) {
 		})
 
 		t.Run("import timestamps", func(t *testing.T) {
+			t.Run("disabled_at alone defaults created_at to disabled_at", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				disabledAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second)
+				payload := validDestination()
+				payload["disabled_at"] = disabledAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusCreated, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				require.NotNil(t, dest.DisabledAt)
+				assert.True(t, dest.DisabledAt.Equal(disabledAt))
+				assert.True(t, dest.CreatedAt.Equal(disabledAt), "created_at defaults to disabled_at when only disabled_at is provided")
+				assert.True(t, dest.UpdatedAt.Equal(disabledAt))
+			})
+
 			t.Run("disabled_at preserved on create with explicit created_at", func(t *testing.T) {
 				h := newAPITest(t)
 				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -150,6 +150,18 @@ func TestAPI_Destinations(t *testing.T) {
 				assert.True(t, dest.CreatedAt.Equal(createdAt))
 				assert.True(t, dest.UpdatedAt.Equal(createdAt))
 			})
+
+			t.Run("disabled_at in future returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["disabled_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
 		})
 	})
 
@@ -917,6 +929,18 @@ func TestAPI_Destinations(t *testing.T) {
 				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
 				require.NotNil(t, dest.DisabledAt)
 				assert.True(t, dest.DisabledAt.Equal(ts))
+			})
+
+			t.Run("future timestamp returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				h.tenantStore.CreateDestination(t.Context(), df.Any(df.WithID("d1"), df.WithTenantID("t1")))
+
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+					"disabled_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				})
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 			})
 
 			t.Run("malformed timestamp returns 422", func(t *testing.T) {

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/hookdeck/outpost/internal/apirouter"
 	"github.com/hookdeck/outpost/internal/destregistry"
@@ -91,6 +92,121 @@ func TestAPI_Destinations(t *testing.T) {
 			resp := h.do(h.withAPIKey(req))
 
 			require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		})
+
+		t.Run("import timestamps", func(t *testing.T) {
+			t.Run("disabled_at preserved on create with explicit created_at", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				createdAt := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
+				disabledAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second)
+				payload := validDestination()
+				payload["created_at"] = createdAt.Format(time.RFC3339)
+				payload["disabled_at"] = disabledAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusCreated, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				require.NotNil(t, dest.DisabledAt)
+				assert.True(t, dest.DisabledAt.Equal(disabledAt), "disabled_at preserved: got %v want %v", dest.DisabledAt, disabledAt)
+				assert.True(t, dest.CreatedAt.Equal(createdAt))
+			})
+
+			t.Run("created_at and updated_at preserved", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				createdAt := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+				updatedAt := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+				payload := validDestination()
+				payload["created_at"] = createdAt.Format(time.RFC3339)
+				payload["updated_at"] = updatedAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusCreated, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				assert.True(t, dest.CreatedAt.Equal(createdAt))
+				assert.True(t, dest.UpdatedAt.Equal(updatedAt))
+			})
+
+			t.Run("updated_at defaults to created_at when omitted", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				createdAt := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+				payload := validDestination()
+				payload["created_at"] = createdAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusCreated, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				assert.True(t, dest.CreatedAt.Equal(createdAt))
+				assert.True(t, dest.UpdatedAt.Equal(createdAt))
+			})
+
+			t.Run("created_at in future returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["created_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
+			t.Run("updated_at before created_at returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				createdAt := time.Now().Add(-1 * time.Hour).UTC()
+				updatedAt := time.Now().Add(-2 * time.Hour).UTC()
+				payload := validDestination()
+				payload["created_at"] = createdAt.Format(time.RFC3339)
+				payload["updated_at"] = updatedAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
+			t.Run("disabled_at in future returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["disabled_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
+			t.Run("disabled_at before created_at returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				createdAt := time.Now().Add(-1 * time.Hour).UTC()
+				disabledAt := time.Now().Add(-2 * time.Hour).UTC()
+				payload := validDestination()
+				payload["created_at"] = createdAt.Format(time.RFC3339)
+				payload["disabled_at"] = disabledAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
 		})
 	})
 
@@ -799,6 +915,105 @@ func TestAPI_Destinations(t *testing.T) {
 			var dest destregistry.DestinationDisplay
 			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
 			assert.Equal(t, "usr_123", dest.Filter["body"].(map[string]any)["user_id"])
+		})
+
+		t.Run("disabled_at", func(t *testing.T) {
+			t.Run("omitted leaves field unchanged", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				disabledAt := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+				h.tenantStore.CreateDestination(t.Context(), df.Any(
+					df.WithID("d1"), df.WithTenantID("t1"), df.WithDisabledAt(disabledAt),
+				))
+
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+					"topics": []string{"user.created"},
+				})
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusOK, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				require.NotNil(t, dest.DisabledAt)
+				assert.True(t, dest.DisabledAt.Equal(disabledAt))
+			})
+
+			t.Run("null enables a disabled destination", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				h.tenantStore.CreateDestination(t.Context(), df.Any(
+					df.WithID("d1"), df.WithTenantID("t1"),
+					df.WithDisabledAt(time.Now().Add(-1*time.Hour)),
+				))
+
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", json.RawMessage(`{"disabled_at":null}`))
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusOK, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				assert.Nil(t, dest.DisabledAt)
+			})
+
+			t.Run("timestamp disables an enabled destination", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				createdAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+				h.tenantStore.CreateDestination(t.Context(), df.Any(
+					df.WithID("d1"), df.WithTenantID("t1"), df.WithCreatedAt(createdAt),
+				))
+
+				ts := time.Now().Add(-30 * time.Minute).UTC().Truncate(time.Second)
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+					"disabled_at": ts.Format(time.RFC3339),
+				})
+				resp := h.do(h.withAPIKey(req))
+
+				require.Equal(t, http.StatusOK, resp.Code)
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				require.NotNil(t, dest.DisabledAt)
+				assert.True(t, dest.DisabledAt.Equal(ts))
+			})
+
+			t.Run("future timestamp returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				h.tenantStore.CreateDestination(t.Context(), df.Any(df.WithID("d1"), df.WithTenantID("t1")))
+
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+					"disabled_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				})
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
+			t.Run("timestamp before created_at returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				createdAt := time.Now().Add(-1 * time.Hour).UTC()
+				h.tenantStore.CreateDestination(t.Context(), df.Any(
+					df.WithID("d1"), df.WithTenantID("t1"), df.WithCreatedAt(createdAt),
+				))
+
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+					"disabled_at": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+				})
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
+
+			t.Run("malformed timestamp returns 422", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+				h.tenantStore.CreateDestination(t.Context(), df.Any(df.WithID("d1"), df.WithTenantID("t1")))
+
+				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
+					"disabled_at": "not-a-timestamp",
+				})
+				resp := h.do(h.withAPIKey(req))
+				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			})
 		})
 	})
 

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -187,7 +187,7 @@ func TestAPI_Destinations(t *testing.T) {
 				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 			})
 
-			t.Run("jwt cannot set created_at returns 403", func(t *testing.T) {
+			t.Run("jwt cannot set created_at returns 403 and persists nothing", func(t *testing.T) {
 				h := newAPITest(t)
 				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
 
@@ -197,6 +197,10 @@ func TestAPI_Destinations(t *testing.T) {
 				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
 				resp := h.do(h.withJWT(req, "t1"))
 				require.Equal(t, http.StatusForbidden, resp.Code)
+
+				dests, err := h.tenantStore.ListDestination(t.Context(), tenantstore.ListDestinationRequest{TenantID: "t1"})
+				require.NoError(t, err)
+				assert.Empty(t, dests, "destination must not be created when request is forbidden")
 			})
 
 			t.Run("jwt cannot set updated_at returns 403", func(t *testing.T) {
@@ -209,6 +213,28 @@ func TestAPI_Destinations(t *testing.T) {
 				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
 				resp := h.do(h.withJWT(req, "t1"))
 				require.Equal(t, http.StatusForbidden, resp.Code)
+			})
+
+			t.Run("jwt cannot set both created_at and updated_at returns 403", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["created_at"] = time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+				payload["updated_at"] = time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withJWT(req, "t1"))
+				require.Equal(t, http.StatusForbidden, resp.Code)
+			})
+
+			t.Run("jwt can create destination without import timestamps", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", validDestination())
+				resp := h.do(h.withJWT(req, "t1"))
+				require.Equal(t, http.StatusCreated, resp.Code)
 			})
 
 			t.Run("jwt can set disabled_at", func(t *testing.T) {

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -186,6 +186,48 @@ func TestAPI_Destinations(t *testing.T) {
 				resp := h.do(h.withAPIKey(req))
 				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 			})
+
+			t.Run("jwt cannot set created_at returns 403", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["created_at"] = time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withJWT(req, "t1"))
+				require.Equal(t, http.StatusForbidden, resp.Code)
+			})
+
+			t.Run("jwt cannot set updated_at returns 403", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				payload := validDestination()
+				payload["updated_at"] = time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withJWT(req, "t1"))
+				require.Equal(t, http.StatusForbidden, resp.Code)
+			})
+
+			t.Run("jwt can set disabled_at", func(t *testing.T) {
+				h := newAPITest(t)
+				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+				disabledAt := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+				payload := validDestination()
+				payload["disabled_at"] = disabledAt.Format(time.RFC3339)
+
+				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
+				resp := h.do(h.withJWT(req, "t1"))
+				require.Equal(t, http.StatusCreated, resp.Code)
+
+				var dest destregistry.DestinationDisplay
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+				require.NotNil(t, dest.DisabledAt)
+				assert.True(t, dest.DisabledAt.Equal(disabledAt))
+			})
 		})
 	})
 

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -95,7 +95,7 @@ func TestAPI_Destinations(t *testing.T) {
 		})
 
 		t.Run("import timestamps", func(t *testing.T) {
-			t.Run("disabled_at alone defaults created_at to disabled_at", func(t *testing.T) {
+			t.Run("disabled_at preserved on create", func(t *testing.T) {
 				h := newAPITest(t)
 				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
 
@@ -111,29 +111,6 @@ func TestAPI_Destinations(t *testing.T) {
 				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
 				require.NotNil(t, dest.DisabledAt)
 				assert.True(t, dest.DisabledAt.Equal(disabledAt))
-				assert.True(t, dest.CreatedAt.Equal(disabledAt), "created_at defaults to disabled_at when only disabled_at is provided")
-				assert.True(t, dest.UpdatedAt.Equal(disabledAt))
-			})
-
-			t.Run("disabled_at preserved on create with explicit created_at", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-
-				createdAt := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
-				disabledAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second)
-				payload := validDestination()
-				payload["created_at"] = createdAt.Format(time.RFC3339)
-				payload["disabled_at"] = disabledAt.Format(time.RFC3339)
-
-				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
-				resp := h.do(h.withAPIKey(req))
-
-				require.Equal(t, http.StatusCreated, resp.Code)
-				var dest destregistry.DestinationDisplay
-				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
-				require.NotNil(t, dest.DisabledAt)
-				assert.True(t, dest.DisabledAt.Equal(disabledAt), "disabled_at preserved: got %v want %v", dest.DisabledAt, disabledAt)
-				assert.True(t, dest.CreatedAt.Equal(createdAt))
 			})
 
 			t.Run("created_at and updated_at preserved", func(t *testing.T) {
@@ -172,60 +149,6 @@ func TestAPI_Destinations(t *testing.T) {
 				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
 				assert.True(t, dest.CreatedAt.Equal(createdAt))
 				assert.True(t, dest.UpdatedAt.Equal(createdAt))
-			})
-
-			t.Run("created_at in future returns 422", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-
-				payload := validDestination()
-				payload["created_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
-
-				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
-				resp := h.do(h.withAPIKey(req))
-				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-			})
-
-			t.Run("updated_at before created_at returns 422", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-
-				createdAt := time.Now().Add(-1 * time.Hour).UTC()
-				updatedAt := time.Now().Add(-2 * time.Hour).UTC()
-				payload := validDestination()
-				payload["created_at"] = createdAt.Format(time.RFC3339)
-				payload["updated_at"] = updatedAt.Format(time.RFC3339)
-
-				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
-				resp := h.do(h.withAPIKey(req))
-				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-			})
-
-			t.Run("disabled_at in future returns 422", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-
-				payload := validDestination()
-				payload["disabled_at"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
-
-				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
-				resp := h.do(h.withAPIKey(req))
-				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-			})
-
-			t.Run("disabled_at before created_at returns 422", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-
-				createdAt := time.Now().Add(-1 * time.Hour).UTC()
-				disabledAt := time.Now().Add(-2 * time.Hour).UTC()
-				payload := validDestination()
-				payload["created_at"] = createdAt.Format(time.RFC3339)
-				payload["disabled_at"] = disabledAt.Format(time.RFC3339)
-
-				req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", payload)
-				resp := h.do(h.withAPIKey(req))
-				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 			})
 		})
 	})
@@ -994,33 +917,6 @@ func TestAPI_Destinations(t *testing.T) {
 				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
 				require.NotNil(t, dest.DisabledAt)
 				assert.True(t, dest.DisabledAt.Equal(ts))
-			})
-
-			t.Run("future timestamp returns 422", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-				h.tenantStore.CreateDestination(t.Context(), df.Any(df.WithID("d1"), df.WithTenantID("t1")))
-
-				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
-					"disabled_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-				})
-				resp := h.do(h.withAPIKey(req))
-				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-			})
-
-			t.Run("timestamp before created_at returns 422", func(t *testing.T) {
-				h := newAPITest(t)
-				h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
-				createdAt := time.Now().Add(-1 * time.Hour).UTC()
-				h.tenantStore.CreateDestination(t.Context(), df.Any(
-					df.WithID("d1"), df.WithTenantID("t1"), df.WithCreatedAt(createdAt),
-				))
-
-				req := h.jsonReq(http.MethodPatch, "/api/v1/tenants/t1/destinations/d1", map[string]any{
-					"disabled_at": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
-				})
-				resp := h.do(h.withAPIKey(req))
-				require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 			})
 
 			t.Run("malformed timestamp returns 422", func(t *testing.T) {

--- a/internal/apirouter/validate.go
+++ b/internal/apirouter/validate.go
@@ -15,5 +15,6 @@ func AbortWithError(c *gin.Context, code int, err error) {
 func AbortWithValidationError(c *gin.Context, err error) {
 	errorResponse := ErrorResponse{}
 	errorResponse.Parse(err)
+	errorResponse.Code = http.StatusUnprocessableEntity
 	AbortWithError(c, http.StatusUnprocessableEntity, errorResponse)
 }


### PR DESCRIPTION
## Summary

This PR bundles two related but distinct scopes.

### 1. Enable/disable via Create and Update (closes #488, #612)

- **Create** accepts optional `disabled_at` so a destination can be created in a disabled state (e.g. importing a disabled Svix endpoint without a window where traffic could leak to it).
- **Update** accepts optional `disabled_at` (omit / `null` / timestamp) so callers can enable/disable as part of a normal PATCH. The dedicated `/enable` and `/disable` endpoints stay — this is the import-friendly path.
- Update emits an additional `destination disabled` / `destination enabled` audit log alongside `destination updated` when disability state changes.

### 2. Importable timestamps on Create

- **Create** accepts optional `created_at` and `updated_at` so importers can preserve the original timestamps from the source system.
- No validation on these fields — values are accepted as-is. Future timestamps and out-of-order timestamps are allowed; importers from other systems may carry inconsistent data and we'd rather accept it than block a migration.

## Test plan

- [x] `go test ./internal/apirouter/...` — all pass
- [ ] Manual: POST a destination with past `created_at` / `disabled_at`, verify timestamps preserved in response and storage
- [ ] Manual: PATCH \`disabled_at: null\` on a disabled destination, confirm it enables and emits audit log

🤖 Generated with [Claude Code](https://claude.com/claude-code)