### PR TITLE
fix: correct misleading ID prefix field descriptions

### DIFF
--- a/internal/config/id_gen.go
+++ b/internal/config/id_gen.go
@@ -3,7 +3,7 @@ package config
 // IDGenConfig is the configuration for ID generation
 type IDGenConfig struct {
 	Type              string `yaml:"type" env:"IDGEN_TYPE" desc:"ID generation type for all entities: uuidv4, uuidv7, nanoid. Default: uuidv4" required:"N"`
-	AttemptPrefix     string `yaml:"attempt_prefix" env:"IDGEN_ATTEMPT_PREFIX" desc:"Prefix for attempt IDs, used as-is (e.g., 'atm_' produces 'atm_<id>'). Default: empty (no prefix)" required:"N"`
-	DestinationPrefix string `yaml:"destination_prefix" env:"IDGEN_DESTINATION_PREFIX" desc:"Prefix for destination IDs, used as-is (e.g., 'dst_' produces 'dst_<id>'). Default: empty (no prefix)" required:"N"`
-	EventPrefix       string `yaml:"event_prefix" env:"IDGEN_EVENT_PREFIX" desc:"Prefix for event IDs, used as-is (e.g., 'evt_' produces 'evt_<id>'). Default: empty (no prefix)" required:"N"`
+	AttemptPrefix     string `yaml:"attempt_prefix" env:"IDGEN_ATTEMPT_PREFIX" desc:"Prefix for attempt IDs, prepended without modification (e.g., 'atm_' produces 'atm_<id>'). Default: empty (no prefix)" required:"N"`
+	DestinationPrefix string `yaml:"destination_prefix" env:"IDGEN_DESTINATION_PREFIX" desc:"Prefix for destination IDs, prepended without modification (e.g., 'des_' produces 'des_<id>'). Default: empty (no prefix)" required:"N"`
+	EventPrefix       string `yaml:"event_prefix" env:"IDGEN_EVENT_PREFIX" desc:"Prefix for event IDs, prepended without modification (e.g., 'evt_' produces 'evt_<id>'). Default: empty (no prefix)" required:"N"`
 }

--- a/internal/config/id_gen.go
+++ b/internal/config/id_gen.go
@@ -3,7 +3,7 @@ package config
 // IDGenConfig is the configuration for ID generation
 type IDGenConfig struct {
 	Type              string `yaml:"type" env:"IDGEN_TYPE" desc:"ID generation type for all entities: uuidv4, uuidv7, nanoid. Default: uuidv4" required:"N"`
-	AttemptPrefix     string `yaml:"attempt_prefix" env:"IDGEN_ATTEMPT_PREFIX" desc:"Prefix for attempt IDs, prepended with underscore (e.g., 'atm_123'). Default: empty (no prefix)" required:"N"`
-	DestinationPrefix string `yaml:"destination_prefix" env:"IDGEN_DESTINATION_PREFIX" desc:"Prefix for destination IDs, prepended with underscore (e.g., 'dst_123'). Default: empty (no prefix)" required:"N"`
-	EventPrefix       string `yaml:"event_prefix" env:"IDGEN_EVENT_PREFIX" desc:"Prefix for event IDs, prepended with underscore (e.g., 'evt_123'). Default: empty (no prefix)" required:"N"`
+	AttemptPrefix     string `yaml:"attempt_prefix" env:"IDGEN_ATTEMPT_PREFIX" desc:"Prefix for attempt IDs, used as-is (e.g., 'atm_' produces 'atm_<id>'). Default: empty (no prefix)" required:"N"`
+	DestinationPrefix string `yaml:"destination_prefix" env:"IDGEN_DESTINATION_PREFIX" desc:"Prefix for destination IDs, used as-is (e.g., 'dst_' produces 'dst_<id>'). Default: empty (no prefix)" required:"N"`
+	EventPrefix       string `yaml:"event_prefix" env:"IDGEN_EVENT_PREFIX" desc:"Prefix for event IDs, used as-is (e.g., 'evt_' produces 'evt_<id>'). Default: empty (no prefix)" required:"N"`
 }


### PR DESCRIPTION
## Summary
- Fixed misleading `desc` tags on `AttemptPrefix`, `DestinationPrefix`, and `EventPrefix` in `IDGenConfig`
- Old text said "prepended with underscore" but the prefix is used verbatim (confirmed by `idgen/idgen_test.go:118-127`)
- Updated to "used as-is" with clearer examples like `'evt_' produces 'evt_<id>'`

## Test plan
- [ ] Verify existing `idgen` tests still pass (`go test ./internal/idgen/...`)
- [ ] Confirm generated config docs (if any) reflect the updated descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)