### PR TITLE
fix: add automated db migrations to docker-compose using an outpost-migrate service

### DIFF
--- a/examples/docker-compose/compose-awssqs.yml
+++ b/examples/docker-compose/compose-awssqs.yml
@@ -12,6 +12,15 @@ services:
       timeout: 1s
       retries: 30
 
+  migrate:
+    depends_on:
+      aws:
+        condition: service_healthy
+    environment:
+      - AWS_SQS_ENDPOINT=http://aws:4566
+      - AWS_SQS_REGION=us-east-1
+      - AWS_SQS_ACCESS_KEY_ID=test
+      - AWS_SQS_SECRET_ACCESS_KEY=test
   api:
     depends_on:
       aws:

--- a/examples/docker-compose/compose-postgres.yml
+++ b/examples/docker-compose/compose-postgres.yml
@@ -15,7 +15,7 @@ services:
       timeout: 1s
       retries: 30
 
-  outpost-migrate:
+  migrate:
     depends_on:
       postgres:
         condition: service_healthy

--- a/examples/docker-compose/compose-postgres.yml
+++ b/examples/docker-compose/compose-postgres.yml
@@ -15,6 +15,12 @@ services:
       timeout: 1s
       retries: 30
 
+  outpost-migrate:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRES_URL=postgres://outpost:outpost@postgres:5432/outpost?sslmode=disable
   api:
     depends_on:
       postgres:

--- a/examples/docker-compose/compose-rabbitmq.yml
+++ b/examples/docker-compose/compose-rabbitmq.yml
@@ -12,6 +12,12 @@ services:
       timeout: 1s
       retries: 30
 
+  outpost-migrate:
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - "RABBITMQ_SERVER_URL=amqp://guest:guest@rabbitmq:5672"
   api:
     depends_on:
       rabbitmq:

--- a/examples/docker-compose/compose-rabbitmq.yml
+++ b/examples/docker-compose/compose-rabbitmq.yml
@@ -12,7 +12,7 @@ services:
       timeout: 1s
       retries: 30
 
-  outpost-migrate:
+  migrate:
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/examples/docker-compose/compose.yml
+++ b/examples/docker-compose/compose.yml
@@ -1,6 +1,6 @@
 name: outpost-example
 services:
-  outpost-migrate:
+  migrate:
     image: hookdeck/outpost:v1.0.2
     command: migrate apply --yes
     env_file: .env
@@ -8,12 +8,12 @@ services:
       redis:
         condition: service_started
     restart: "no"
-    
+
   api:
     image: hookdeck/outpost:v1.0.2
     env_file: .env
     depends_on:
-      outpost-migrate:
+      migrate:
         condition: service_completed_successfully
       redis:
         condition: service_started
@@ -28,7 +28,7 @@ services:
     image: hookdeck/outpost:v1.0.2
     env_file: .env
     depends_on:
-      outpost-migrate:
+      migrate:
         condition: service_completed_successfully
       redis:
         condition: service_started
@@ -41,7 +41,7 @@ services:
     image: hookdeck/outpost:v1.0.2
     env_file: .env
     depends_on:
-      outpost-migrate:
+      migrate:
         condition: service_completed_successfully
       redis:
         condition: service_started

--- a/examples/docker-compose/compose.yml
+++ b/examples/docker-compose/compose.yml
@@ -1,9 +1,20 @@
 name: outpost-example
 services:
+  outpost-migrate:
+    image: hookdeck/outpost:v1.0.2
+    command: migrate apply --yes
+    env_file: .env
+    depends_on:
+      redis:
+        condition: service_started
+    restart: "no"
+    
   api:
     image: hookdeck/outpost:v1.0.2
     env_file: .env
     depends_on:
+      outpost-migrate:
+        condition: service_completed_successfully
       redis:
         condition: service_started
     volumes:
@@ -17,6 +28,8 @@ services:
     image: hookdeck/outpost:v1.0.2
     env_file: .env
     depends_on:
+      outpost-migrate:
+        condition: service_completed_successfully
       redis:
         condition: service_started
     volumes:
@@ -28,6 +41,8 @@ services:
     image: hookdeck/outpost:v1.0.2
     env_file: .env
     depends_on:
+      outpost-migrate:
+        condition: service_completed_successfully
       redis:
         condition: service_started
     volumes:


### PR DESCRIPTION
## What does this PR do?
This PR introduces an automated migration step to the `docker-compose` example environment. By adding an `outpost-migrate` service, the environment now ensures that all database and Redis migrations are fully applied before starting up the core application services (`api`, `log`, and `delivery`).

## Why is this needed?
Previously, developers starting up the project locally via `docker-compose` had to manually manage database migrations. If services started before migrations were applied, it lead to startup crashes due to the prerun check

## Changes Made
- **`compose.yml`**: Added the `outpost-migrate` service running `migrate apply --yes`. Updated the `api`, `log`, and `delivery` services with a `depends_on` condition requiring `outpost-migrate` to complete successfully (`service_completed_successfully`).
- **`compose-postgres.yml` & `compose-rabbitmq.yml`**: Added configuration blocks for `outpost-migrate` to inject the appropriate environment variables (`POSTGRES_URL`, `RABBITMQ_SERVER_URL`) and wait for the respective datastore health checks.

## How to test
1. Run `docker-compose -f compose.yml -f compose-rabbitmq.yml -f compose-postgres.yml up -d`
2. Verify that the `outpost-migrate` container spins up, applies the pending migrations, and exits successfully (Exit code 0).
3. Confirm that the `api`, `log`, and `delivery` services wait for the migration to finish before booting their HTTP servers and consumers.

## Screenshots
<img width="1308" height="162" alt="image" src="https://github.com/user-attachments/assets/b60c5524-d58b-4062-a9f6-15c37286a17d" />

This screenshot from the log service indicates that after running migrations the services are starting successfully
