### PR TITLE
feat(api): support wildcard topic subscriptions

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -194,7 +194,7 @@ components:
         - type: array
           items:
             type: string
-      description: '"*" or an array of enabled topics.'
+      description: '"*" or an array of enabled topics. Topic strings can include "*" as a wildcard matching any run of characters. When available topics are configured, wildcard patterns must match at least one available topic.'
       example: "*"
 
     Filter:

--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2949,6 +2949,8 @@ components:
           type: string
         TOPICS:
           type: string
+        TOPICS_ALLOW_WILDCARDS:
+          type: string
       additionalProperties: false
       example:
         TOPICS: "user.created,user.updated"
@@ -3114,6 +3116,7 @@ paths:
                 $ref: "#/components/schemas/ManagedConfig"
               example:
                 TOPICS: "user.created,user.updated"
+                TOPICS_ALLOW_WILDCARDS: "false"
                 DESTINATIONS_WEBHOOK_MODE: "default"
         "401":
           $ref: "#/components/responses/Unauthorized"
@@ -3138,6 +3141,7 @@ paths:
               $ref: "#/components/schemas/ManagedConfig"
             example:
               TOPICS: "user.created,user.updated"
+              TOPICS_ALLOW_WILDCARDS: "false"
               DESTINATIONS_WEBHOOK_MODE: "default"
       responses:
         "200":
@@ -3148,6 +3152,7 @@ paths:
                 $ref: "#/components/schemas/ManagedConfig"
               example:
                 TOPICS: "user.created,user.updated"
+                TOPICS_ALLOW_WILDCARDS: "false"
                 DESTINATIONS_WEBHOOK_MODE: "default"
         "400":
           $ref: "#/components/responses/BadRequest"

--- a/docs/content/features/topics.mdoc
+++ b/docs/content/features/topics.mdoc
@@ -19,6 +19,8 @@ Topics determine:
 
 Available topics are configured through the Hookdeck dashboard [project settings](https://dashboard.hookdeck.com/settings/project/general) or Config API. Topics determine which values are valid for the `topic` field when publishing events and which topics appear in the tenant portal.
 
+Wildcard topic subscriptions are disabled by default. Enable them in [project settings](https://dashboard.hookdeck.com/settings/project/general) or through the Config API with `TOPICS_ALLOW_WILDCARDS=true`.
+
 {% /tab %}
 {% tab label="Self-Hosted" %}
 Set the list of available topics using the `TOPICS` environment variable:
@@ -28,6 +30,8 @@ TOPICS=user.created,user.updated,user.deleted,order.placed,order.shipped
 ```
 
 If `TOPICS` is not set, Outpost defaults to `*`, allowing any topic value.
+
+Wildcard topic subscriptions are disabled by default. Set `TOPICS_ALLOW_WILDCARDS=TRUE` to allow `*` inside destination topic strings.
 {% /tab %}
 {% /tabs %}
 
@@ -64,7 +68,7 @@ curl '{% $OUTPOST_API_BASE_URL %}/tenants/<TENANT_ID>/destinations' \
 }'
 ```
 
-Destination topics can also use `*` inside a topic string as a wildcard that matches any run of characters. For example, `user.*` matches `user.created` and `user.profile.updated`, `*.created` matches `user.created` and `order.created`, and `order.*.completed` matches `order.payment.completed`.
+When wildcard topic subscriptions are enabled, destination topics can also use `*` inside a topic string as a wildcard that matches any run of characters. For example, `user.*` matches `user.created` and `user.profile.updated`, `*.created` matches `user.created` and `order.created`, and `order.*.completed` matches `order.payment.completed`.
 
 When available topics are configured, wildcard patterns must match at least one available topic.
 
@@ -91,5 +95,4 @@ curl '{% $OUTPOST_API_BASE_URL %}/tenants/<TENANT_ID>' \
 ```
 
 You can also subscribe to the `tenant.subscriptions.updated` [Operator Events](/docs/outpost/features/operator-events) topic to receive an event when the tenant's subscribed topics change.
-
 

--- a/docs/content/features/topics.mdoc
+++ b/docs/content/features/topics.mdoc
@@ -64,6 +64,10 @@ curl '{% $OUTPOST_API_BASE_URL %}/tenants/<TENANT_ID>/destinations' \
 }'
 ```
 
+Destination topics can also use `*` inside a topic string as a wildcard that matches any run of characters. For example, `user.*` matches `user.created` and `user.profile.updated`, `*.created` matches `user.created` and `order.created`, and `order.*.completed` matches `order.payment.completed`.
+
+When available topics are configured, wildcard patterns must match at least one available topic.
+
 ## Event Fanout
 
 A single published event is independently delivered to every destination that matches its topic. Each delivery attempt is tracked separately.

--- a/docs/content/self-hosting/configuration.mdoc
+++ b/docs/content/self-hosting/configuration.mdoc
@@ -74,9 +74,10 @@ Choose one for event log persistence:
 
 ## Topics
 
-| Variable | Description |
-|----------|-------------|
-| `TOPICS` | Comma-separated list of topics your instance supports |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TOPICS` | — | Comma-separated list of topics your instance supports |
+| `TOPICS_ALLOW_WILDCARDS` | `false` | Allow `*` inside destination topic subscriptions, such as `user.*` |
 
 ## Portal
 

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -37,24 +37,26 @@ type TenantSubscriptionUpdatedData struct {
 }
 
 type DestinationHandlers struct {
-	logger      *logging.Logger
-	telemetry   telemetry.Telemetry
-	tenantStore tenantstore.TenantStore
-	emitter     SubscriptionEmitter
-	topics      []string
-	registry    destregistry.Registry
-	displayer   *destinationDisplayer
+	logger               *logging.Logger
+	telemetry            telemetry.Telemetry
+	tenantStore          tenantstore.TenantStore
+	emitter              SubscriptionEmitter
+	topics               []string
+	topicsAllowWildcards bool
+	registry             destregistry.Registry
+	displayer            *destinationDisplayer
 }
 
-func NewDestinationHandlers(logger *logging.Logger, telemetry telemetry.Telemetry, tenantStore tenantstore.TenantStore, emitter SubscriptionEmitter, topics []string, registry destregistry.Registry, displayer *destinationDisplayer) *DestinationHandlers {
+func NewDestinationHandlers(logger *logging.Logger, telemetry telemetry.Telemetry, tenantStore tenantstore.TenantStore, emitter SubscriptionEmitter, topics []string, topicsAllowWildcards bool, registry destregistry.Registry, displayer *destinationDisplayer) *DestinationHandlers {
 	return &DestinationHandlers{
-		logger:      logger,
-		telemetry:   telemetry,
-		tenantStore: tenantStore,
-		emitter:     emitter,
-		topics:      topics,
-		registry:    registry,
-		displayer:   displayer,
+		logger:               logger,
+		telemetry:            telemetry,
+		tenantStore:          tenantStore,
+		emitter:              emitter,
+		topics:               topics,
+		topicsAllowWildcards: topicsAllowWildcards,
+		registry:             registry,
+		displayer:            displayer,
 	}
 }
 
@@ -111,7 +113,7 @@ func (h *DestinationHandlers) Create(c *gin.Context) {
 	prev := h.snapshotTenant(tenant)
 
 	destination := input.ToDestination(tenant.ID)
-	if err := destination.Validate(h.topics); err != nil {
+	if err := destination.Validate(h.topics, h.topicsAllowWildcards); err != nil {
 		AbortWithValidationError(c, err)
 		return
 	}
@@ -181,7 +183,7 @@ func (h *DestinationHandlers) Update(c *gin.Context) {
 	// Validate.
 	if input.Topics != nil {
 		updatedDestination.Topics = input.Topics
-		if err := updatedDestination.Validate(h.topics); err != nil {
+		if err := updatedDestination.Validate(h.topics, h.topicsAllowWildcards); err != nil {
 			AbortWithValidationError(c, err)
 			return
 		}

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -94,6 +94,37 @@ func TestAPI_Destinations(t *testing.T) {
 			require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 		})
 
+		t.Run("wildcard topic pattern matching configured topic is accepted", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+			req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", map[string]any{
+				"type":   "webhook",
+				"topics": []string{"user.*"},
+				"config": map[string]string{"url": "https://example.com/hook"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusCreated, resp.Code)
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Topics{"user.*"}, dest.Topics)
+		})
+
+		t.Run("wildcard topic pattern not matching configured topic returns 422", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+			req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", map[string]any{
+				"type":   "webhook",
+				"topics": []string{"order.*"},
+				"config": map[string]string{"url": "https://example.com/hook"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		})
+
 		t.Run("import timestamps", func(t *testing.T) {
 			t.Run("disabled_at preserved on create", func(t *testing.T) {
 				h := newAPITest(t)

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -67,6 +67,9 @@ func TestAPI_Destinations(t *testing.T) {
 			resp := h.do(h.withAPIKey(req))
 
 			require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+			assert.Equal(t, "validation error", body["message"])
 		})
 
 		t.Run("missing topics returns 422", func(t *testing.T) {
@@ -94,8 +97,22 @@ func TestAPI_Destinations(t *testing.T) {
 			require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 		})
 
-		t.Run("wildcard topic pattern matching configured topic is accepted", func(t *testing.T) {
+		t.Run("wildcard topic pattern matching configured topic requires opt-in", func(t *testing.T) {
 			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+			req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", map[string]any{
+				"type":   "webhook",
+				"topics": []string{"user.*"},
+				"config": map[string]string{"url": "https://example.com/hook"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		})
+
+		t.Run("wildcard topic pattern matching configured topic is accepted when enabled", func(t *testing.T) {
+			h := newAPITest(t, withTopicsAllowWildcards(true))
 			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
 
 			req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", map[string]any{
@@ -112,7 +129,7 @@ func TestAPI_Destinations(t *testing.T) {
 		})
 
 		t.Run("wildcard topic pattern not matching configured topic returns 422", func(t *testing.T) {
-			h := newAPITest(t)
+			h := newAPITest(t, withTopicsAllowWildcards(true))
 			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
 
 			req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", map[string]any{

--- a/internal/apirouter/router.go
+++ b/internal/apirouter/router.go
@@ -30,14 +30,15 @@ type RouteDefinition struct {
 }
 
 type RouterConfig struct {
-	ServiceName  string
-	APIKey       string
-	JWTSecret    string
-	DeploymentID string
-	Topics       []string
-	Registry     destregistry.Registry
-	PortalConfig portal.PortalConfig
-	GinMode      string
+	ServiceName          string
+	APIKey               string
+	JWTSecret            string
+	DeploymentID         string
+	Topics               []string
+	TopicsAllowWildcards bool
+	Registry             destregistry.Registry
+	PortalConfig         portal.PortalConfig
+	GinMode              string
 }
 
 type RouterDeps struct {
@@ -140,7 +141,7 @@ func NewRouter(cfg RouterConfig, deps RouterDeps) http.Handler {
 	displayer := newDestinationDisplayer(cfg.Registry)
 
 	tenantHandlers := NewTenantHandlers(deps.Logger, deps.Telemetry, cfg.JWTSecret, cfg.DeploymentID, deps.TenantStore)
-	destinationHandlers := NewDestinationHandlers(deps.Logger, deps.Telemetry, deps.TenantStore, deps.SubscriptionEmitter, cfg.Topics, cfg.Registry, displayer)
+	destinationHandlers := NewDestinationHandlers(deps.Logger, deps.Telemetry, deps.TenantStore, deps.SubscriptionEmitter, cfg.Topics, cfg.TopicsAllowWildcards, cfg.Registry, displayer)
 	publishHandlers := NewPublishHandlers(deps.Logger, deps.EventHandler)
 	logHandlers := NewLogHandlers(deps.Logger, deps.LogStore, deps.TenantStore, displayer)
 	retryHandlers := NewRetryHandlers(deps.Logger, deps.TenantStore, deps.LogStore, deps.DeliveryPublisher)

--- a/internal/apirouter/router_test.go
+++ b/internal/apirouter/router_test.go
@@ -58,10 +58,11 @@ type apiTest struct {
 type apiTestOption func(*apiTestConfig)
 
 type apiTestConfig struct {
-	tenantStore         tenantstore.TenantStore
-	destRegistry        destregistry.Registry
-	subscriptionEmitter apirouter.SubscriptionEmitter
-	logger              *logging.Logger
+	tenantStore          tenantstore.TenantStore
+	destRegistry         destregistry.Registry
+	subscriptionEmitter  apirouter.SubscriptionEmitter
+	logger               *logging.Logger
+	topicsAllowWildcards bool
 }
 
 func withTenantStore(ts tenantstore.TenantStore) apiTestOption {
@@ -85,6 +86,12 @@ func withSubscriptionEmitter(e apirouter.SubscriptionEmitter) apiTestOption {
 func withLogger(l *logging.Logger) apiTestOption {
 	return func(cfg *apiTestConfig) {
 		cfg.logger = l
+	}
+}
+
+func withTopicsAllowWildcards(allow bool) apiTestOption {
+	return func(cfg *apiTestConfig) {
+		cfg.topicsAllowWildcards = allow
 	}
 }
 
@@ -122,12 +129,13 @@ func newAPITest(t *testing.T, opts ...apiTestOption) *apiTest {
 
 	router := apirouter.NewRouter(
 		apirouter.RouterConfig{
-			ServiceName:  "test",
-			APIKey:       testAPIKey,
-			JWTSecret:    testJWTSecret,
-			Topics:       testutil.TestTopics,
-			Registry:     registry,
-			PortalConfig: portal.PortalConfig{},
+			ServiceName:          "test",
+			APIKey:               testAPIKey,
+			JWTSecret:            testJWTSecret,
+			Topics:               testutil.TestTopics,
+			TopicsAllowWildcards: cfg.topicsAllowWildcards,
+			Registry:             registry,
+			PortalConfig:         portal.PortalConfig{},
 		},
 		apirouter.RouterDeps{
 			TenantStore:         ts,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,10 +55,11 @@ type Config struct {
 	GinMode      string `yaml:"gin_mode" env:"GIN_MODE" desc:"Sets the Gin framework mode (e.g., 'debug', 'release', 'test'). See Gin documentation for details." required:"N"`
 
 	// Application
-	DeploymentID        string   `yaml:"deployment_id" env:"DEPLOYMENT_ID" desc:"Optional deployment identifier for multi-tenancy. Enables multiple deployments to share the same infrastructure while maintaining data isolation." required:"N"`
-	AESEncryptionSecret string   `yaml:"aes_encryption_secret" env:"AES_ENCRYPTION_SECRET" desc:"A 16, 24, or 32 byte secret key used for AES encryption of sensitive data at rest." required:"Y"`
-	Topics              []string `yaml:"topics" env:"TOPICS" envSeparator:"," desc:"Comma-separated list of topics that this Outpost instance should subscribe to for event processing." required:"N"`
-	HTTPUserAgent       string   `yaml:"http_user_agent" env:"HTTP_USER_AGENT" desc:"Custom HTTP User-Agent string for outgoing webhook deliveries. If unset, defaults to 'Outpost/{version}'." required:"N"`
+	DeploymentID         string   `yaml:"deployment_id" env:"DEPLOYMENT_ID" desc:"Optional deployment identifier for multi-tenancy. Enables multiple deployments to share the same infrastructure while maintaining data isolation." required:"N"`
+	AESEncryptionSecret  string   `yaml:"aes_encryption_secret" env:"AES_ENCRYPTION_SECRET" desc:"A 16, 24, or 32 byte secret key used for AES encryption of sensitive data at rest." required:"Y"`
+	Topics               []string `yaml:"topics" env:"TOPICS" envSeparator:"," desc:"Comma-separated list of topics that this Outpost instance should subscribe to for event processing." required:"N"`
+	TopicsAllowWildcards bool     `yaml:"topics_allow_wildcards" env:"TOPICS_ALLOW_WILDCARDS" desc:"If true, destination topic subscriptions can use '*' inside topic strings as a wildcard pattern." required:"N" default:"false"`
+	HTTPUserAgent        string   `yaml:"http_user_agent" env:"HTTP_USER_AGENT" desc:"Custom HTTP User-Agent string for outgoing webhook deliveries. If unset, defaults to 'Outpost/{version}'." required:"N"`
 
 	// Infrastructure
 	Redis       RedisConfig      `yaml:"redis"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -545,3 +545,15 @@ func TestTopicsNormalization(t *testing.T) {
 		})
 	}
 }
+
+func TestTopicsAllowWildcardsConfig(t *testing.T) {
+	mockOS := &mockOS{
+		envVars: map[string]string{
+			"TOPICS_ALLOW_WILDCARDS": "TRUE",
+		},
+	}
+
+	cfg, err := config.ParseWithoutValidation(config.Flags{}, mockOS)
+	assert.NoError(t, err)
+	assert.True(t, cfg.TopicsAllowWildcards)
+}

--- a/internal/config/portal.go
+++ b/internal/config/portal.go
@@ -37,6 +37,7 @@ func (c *Config) GetPortalConfig() portal.PortalConfig {
 			"ORGANIZATION_NAME":             c.Portal.OrgName,
 			"FORCE_THEME":                   c.Portal.ForceTheme,
 			"TOPICS":                        strings.Join(c.Topics, ","),
+			"TOPICS_ALLOW_WILDCARDS":        strconv.FormatBool(c.TopicsAllowWildcards),
 			"DISABLE_OUTPOST_BRANDING":      strconv.FormatBool(c.Portal.DisableOutpostBranding),
 			"DISABLE_TELEMETRY":             strconv.FormatBool(c.DisableTelemetry),
 			"ENABLE_DESTINATION_FILTER":     strconv.FormatBool(c.Portal.EnableDestinationFilter),

--- a/internal/models/entities.go
+++ b/internal/models/entities.go
@@ -148,7 +148,15 @@ func (t *Topics) MatchesAll() bool {
 }
 
 func (t *Topics) MatchTopic(eventTopic string) bool {
-	return eventTopic == "" || eventTopic == "*" || t.MatchesAll() || slices.Contains(*t, eventTopic)
+	if eventTopic == "" || eventTopic == "*" || t.MatchesAll() {
+		return true
+	}
+	for _, topic := range *t {
+		if matchTopicPattern(topic, eventTopic) {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *Topics) Validate(availableTopics []string) error {
@@ -166,11 +174,62 @@ func (t *Topics) Validate(availableTopics []string) error {
 		if topic == "*" {
 			return ErrInvalidTopics
 		}
+		if strings.Contains(topic, "*") {
+			if !topicPatternMatchesAny(topic, availableTopics) {
+				return ErrInvalidTopics
+			}
+			continue
+		}
 		if !slices.Contains(availableTopics, topic) {
 			return ErrInvalidTopics
 		}
 	}
 	return nil
+}
+
+func topicPatternMatchesAny(pattern string, topics []string) bool {
+	for _, topic := range topics {
+		if matchTopicPattern(pattern, topic) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchTopicPattern(pattern, topic string) bool {
+	if pattern == topic {
+		return true
+	}
+	if !strings.Contains(pattern, "*") {
+		return false
+	}
+
+	patternIndex, topicIndex := 0, 0
+	starIndex, starTopicIndex := -1, 0
+	for topicIndex < len(topic) {
+		if patternIndex < len(pattern) && pattern[patternIndex] == topic[topicIndex] {
+			patternIndex++
+			topicIndex++
+			continue
+		}
+		if patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+			starIndex = patternIndex
+			starTopicIndex = topicIndex
+			patternIndex++
+			continue
+		}
+		if starIndex != -1 {
+			patternIndex = starIndex + 1
+			starTopicIndex++
+			topicIndex = starTopicIndex
+			continue
+		}
+		return false
+	}
+	for patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+		patternIndex++
+	}
+	return patternIndex == len(pattern)
 }
 
 func TopicsFromString(s string) Topics {

--- a/internal/models/entities.go
+++ b/internal/models/entities.go
@@ -39,8 +39,8 @@ type Destination struct {
 	DisabledAt       *time.Time       `json:"disabled_at" redis:"disabled_at"`
 }
 
-func (d *Destination) Validate(topics []string, allowWildcards ...bool) error {
-	if err := d.Topics.Validate(topics, allowWildcards...); err != nil {
+func (d *Destination) Validate(topics []string, allowWildcards bool) error {
+	if err := d.Topics.Validate(topics, allowWildcards); err != nil {
 		return err
 	}
 	return nil
@@ -159,7 +159,7 @@ func (t *Topics) MatchTopic(eventTopic string) bool {
 	return false
 }
 
-func (t *Topics) Validate(availableTopics []string, allowWildcards ...bool) error {
+func (t *Topics) Validate(availableTopics []string, allowWildcards bool) error {
 	if len(*t) == 0 {
 		return ErrInvalidTopics
 	}
@@ -168,7 +168,7 @@ func (t *Topics) Validate(availableTopics []string, allowWildcards ...bool) erro
 	}
 	// If no available topics are configured, allow any exact topic.
 	if len(availableTopics) == 0 {
-		if !topicsAllowWildcards(allowWildcards...) {
+		if !allowWildcards {
 			for _, topic := range *t {
 				if strings.Contains(topic, "*") {
 					return ErrInvalidTopics
@@ -182,7 +182,7 @@ func (t *Topics) Validate(availableTopics []string, allowWildcards ...bool) erro
 			return ErrInvalidTopics
 		}
 		if strings.Contains(topic, "*") {
-			if !topicsAllowWildcards(allowWildcards...) {
+			if !allowWildcards {
 				return ErrInvalidTopics
 			}
 			if !topicPatternMatchesAny(topic, availableTopics) {
@@ -195,10 +195,6 @@ func (t *Topics) Validate(availableTopics []string, allowWildcards ...bool) erro
 		}
 	}
 	return nil
-}
-
-func topicsAllowWildcards(allowWildcards ...bool) bool {
-	return len(allowWildcards) > 0 && allowWildcards[0]
 }
 
 func topicPatternMatchesAny(pattern string, topics []string) bool {

--- a/internal/models/entities.go
+++ b/internal/models/entities.go
@@ -39,8 +39,8 @@ type Destination struct {
 	DisabledAt       *time.Time       `json:"disabled_at" redis:"disabled_at"`
 }
 
-func (d *Destination) Validate(topics []string) error {
-	if err := d.Topics.Validate(topics); err != nil {
+func (d *Destination) Validate(topics []string, allowWildcards ...bool) error {
+	if err := d.Topics.Validate(topics, allowWildcards...); err != nil {
 		return err
 	}
 	return nil
@@ -159,15 +159,22 @@ func (t *Topics) MatchTopic(eventTopic string) bool {
 	return false
 }
 
-func (t *Topics) Validate(availableTopics []string) error {
+func (t *Topics) Validate(availableTopics []string, allowWildcards ...bool) error {
 	if len(*t) == 0 {
 		return ErrInvalidTopics
 	}
 	if t.MatchesAll() {
 		return nil
 	}
-	// If no available topics are configured, allow any topics
+	// If no available topics are configured, allow any exact topic.
 	if len(availableTopics) == 0 {
+		if !topicsAllowWildcards(allowWildcards...) {
+			for _, topic := range *t {
+				if strings.Contains(topic, "*") {
+					return ErrInvalidTopics
+				}
+			}
+		}
 		return nil
 	}
 	for _, topic := range *t {
@@ -175,6 +182,9 @@ func (t *Topics) Validate(availableTopics []string) error {
 			return ErrInvalidTopics
 		}
 		if strings.Contains(topic, "*") {
+			if !topicsAllowWildcards(allowWildcards...) {
+				return ErrInvalidTopics
+			}
 			if !topicPatternMatchesAny(topic, availableTopics) {
 				return ErrInvalidTopics
 			}
@@ -185,6 +195,10 @@ func (t *Topics) Validate(availableTopics []string) error {
 		}
 	}
 	return nil
+}
+
+func topicsAllowWildcards(allowWildcards ...bool) bool {
+	return len(allowWildcards) > 0 && allowWildcards[0]
 }
 
 func topicPatternMatchesAny(pattern string, topics []string) bool {

--- a/internal/models/entities_test.go
+++ b/internal/models/entities_test.go
@@ -31,6 +31,26 @@ func TestDestinationTopics_Validate(t *testing.T) {
 			validated:       true,
 		},
 		{
+			topics:          []string{"user.*"},
+			availableTopics: testutil.TestTopics,
+			validated:       true,
+		},
+		{
+			topics:          []string{"order.*"},
+			availableTopics: testutil.TestTopics,
+			validated:       false,
+		},
+		{
+			topics:          []string{"user.created", "order.*"},
+			availableTopics: testutil.TestTopics,
+			validated:       false,
+		},
+		{
+			topics:          []string{"order.*"},
+			availableTopics: []string{"order.created", "user.created"},
+			validated:       true,
+		},
+		{
 			topics:          []string{"*"},
 			availableTopics: testutil.TestTopics,
 			validated:       true,
@@ -218,6 +238,54 @@ func TestTopics_MatchTopic(t *testing.T) {
 			eventTopic: "user.created",
 			expected:   true,
 		},
+		{
+			name:       "prefix wildcard matches topic family",
+			topics:     []string{"user.*"},
+			eventTopic: "user.created",
+			expected:   true,
+		},
+		{
+			name:       "prefix wildcard matches nested topic family",
+			topics:     []string{"user.*"},
+			eventTopic: "user.profile.updated",
+			expected:   true,
+		},
+		{
+			name:       "suffix wildcard matches topic family",
+			topics:     []string{"*.created"},
+			eventTopic: "order.created",
+			expected:   true,
+		},
+		{
+			name:       "middle wildcard matches topic family",
+			topics:     []string{"order.*.completed"},
+			eventTopic: "order.payment.completed",
+			expected:   true,
+		},
+		{
+			name:       "wildcard can match empty run of characters",
+			topics:     []string{"user.*.created"},
+			eventTopic: "user..created",
+			expected:   true,
+		},
+		{
+			name:       "prefix wildcard does not match different prefix",
+			topics:     []string{"user.*"},
+			eventTopic: "order.created",
+			expected:   false,
+		},
+		{
+			name:       "suffix wildcard does not match different suffix",
+			topics:     []string{"*.created"},
+			eventTopic: "user.deleted",
+			expected:   false,
+		},
+		{
+			name:       "middle wildcard requires suffix",
+			topics:     []string{"order.*.completed"},
+			eventTopic: "order.payment.failed",
+			expected:   false,
+		},
 		// No match
 		{
 			name:       "no topic match",
@@ -254,6 +322,49 @@ func TestTopics_MatchTopic(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.topics.MatchTopic(tc.eventTopic))
 		})
 	}
+}
+
+func BenchmarkTopics_MatchTopic(b *testing.B) {
+	topicsExact := models.Topics{
+		"user.created",
+		"user.deleted",
+		"user.updated",
+		"order.created",
+		"order.deleted",
+		"order.updated",
+	}
+	topicsPattern := models.Topics{
+		"user.*",
+		"*.deleted",
+		"order.*.completed",
+		"invoice.created",
+		"invoice.deleted",
+		"invoice.updated",
+	}
+
+	b.Run("exact match", func(b *testing.B) {
+		for range b.N {
+			_ = topicsExact.MatchTopic("order.updated")
+		}
+	})
+
+	b.Run("exact miss", func(b *testing.B) {
+		for range b.N {
+			_ = topicsExact.MatchTopic("payment.created")
+		}
+	})
+
+	b.Run("pattern match", func(b *testing.B) {
+		for range b.N {
+			_ = topicsPattern.MatchTopic("order.payment.completed")
+		}
+	})
+
+	b.Run("pattern miss", func(b *testing.B) {
+		for range b.N {
+			_ = topicsPattern.MatchTopic("order.payment.failed")
+		}
+	})
 }
 
 func TestFilter_MarshalBinary(t *testing.T) {

--- a/internal/models/entities_test.go
+++ b/internal/models/entities_test.go
@@ -16,6 +16,7 @@ func TestDestinationTopics_Validate(t *testing.T) {
 	type testCase struct {
 		topics          models.Topics
 		availableTopics []string
+		allowWildcards  bool
 		validated       bool
 	}
 
@@ -33,21 +34,30 @@ func TestDestinationTopics_Validate(t *testing.T) {
 		{
 			topics:          []string{"user.*"},
 			availableTopics: testutil.TestTopics,
+			validated:       false,
+		},
+		{
+			topics:          []string{"user.*"},
+			availableTopics: testutil.TestTopics,
+			allowWildcards:  true,
 			validated:       true,
 		},
 		{
 			topics:          []string{"order.*"},
 			availableTopics: testutil.TestTopics,
+			allowWildcards:  true,
 			validated:       false,
 		},
 		{
 			topics:          []string{"user.created", "order.*"},
 			availableTopics: testutil.TestTopics,
+			allowWildcards:  true,
 			validated:       false,
 		},
 		{
 			topics:          []string{"order.*"},
 			availableTopics: []string{"order.created", "user.created"},
+			allowWildcards:  true,
 			validated:       true,
 		},
 		{
@@ -92,6 +102,17 @@ func TestDestinationTopics_Validate(t *testing.T) {
 			validated:       true,
 		},
 		{
+			topics:          []string{"user.*"},
+			availableTopics: []string{},
+			validated:       false,
+		},
+		{
+			topics:          []string{"user.*"},
+			availableTopics: []string{},
+			allowWildcards:  true,
+			validated:       true,
+		},
+		{
 			topics:          []string{},
 			availableTopics: []string{},
 			validated:       false, // still require at least one topic
@@ -101,7 +122,7 @@ func TestDestinationTopics_Validate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("validate topics %v with available topics %v", tc.topics, tc.availableTopics), func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.validated, tc.topics.Validate(tc.availableTopics) == nil)
+			assert.Equal(t, tc.validated, tc.topics.Validate(tc.availableTopics, tc.allowWildcards) == nil)
 		})
 	}
 }

--- a/internal/portal/src/common/TopicPicker/TopicPicker.scss
+++ b/internal/portal/src/common/TopicPicker/TopicPicker.scss
@@ -3,7 +3,7 @@
   border-radius: var(--radius-m);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
   max-height: 100%;
 
   &__header {
@@ -14,6 +14,12 @@
       box-shadow: none;
       width: 100%;
       box-sizing: border-box;
+
+      &:focus-visible {
+        outline: 2px solid var(--colors-outline-primary-focus);
+        outline-offset: 1px;
+        box-shadow: none;
+      }
     }
   }
 
@@ -34,6 +40,12 @@
     align-items: center;
     gap: var(--spacing-2);
     margin-bottom: var(--spacing-3);
+  }
+
+  &__category-selection {
+    color: var(--colors-foreground-neutral-2);
+    font-size: var(--font-size-s);
+    line-height: var(--line-height-s);
   }
 
   &__category {

--- a/internal/portal/src/common/TopicPicker/TopicPicker.tsx
+++ b/internal/portal/src/common/TopicPicker/TopicPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 
 import "./TopicPicker.scss";
 import { Checkbox } from "../Checkbox/Checkbox";
@@ -34,27 +34,50 @@ const findFirstSeparator = (topic: string): string | null => {
   return firstSep;
 };
 
-const topics: Topic[] = (() => {
-  const topicsList = CONFIGS.TOPICS.split(",");
-
-  return topicsList.map((topic) => {
-    const separator = findFirstSeparator(topic);
-
-    return {
-      id: topic,
-      category: separator ? topic.split(separator)[0] : topic,
-    };
-  });
-})();
-
 const TopicPicker = ({
   maxHeight,
   selectedTopics,
   onTopicsChange,
 }: TopicPickerProps) => {
+  // Keep track of any custom topics seen during this component's lifecycle
+  // so they don't disappear if they are temporarily unselected or "Select All" is clicked.
+  const [seenTopics, setSeenTopics] = useState<string[]>([]);
+
+  useEffect(() => {
+    setSeenTopics((prev) => {
+      const next = new Set(prev);
+      let changed = false;
+      for (const t of selectedTopics) {
+        if (t !== "*" && !next.has(t)) {
+          next.add(t);
+          changed = true;
+        }
+      }
+      return changed ? Array.from(next) : prev;
+    });
+  }, [selectedTopics]);
+
+  // Combine statically configured topics with any custom topics already selected
+  const allTopics: Topic[] = useMemo(() => {
+    const configuredTopics = CONFIGS.TOPICS.split(",").filter(Boolean);
+    const combinedSet = new Set([
+      ...configuredTopics,
+      ...seenTopics,
+      ...selectedTopics.filter((t) => t !== "*"),
+    ]);
+
+    return Array.from(combinedSet).map((topic) => {
+      const separator = findFirstSeparator(topic);
+      return {
+        id: topic,
+        category: separator ? topic.split(separator)[0] : topic,
+      };
+    });
+  }, [selectedTopics, seenTopics]);
+
   const [searchQuery, setSearchQuery] = useState("");
   const [expandedCategories, setExpandedCategories] = useState<string[]>(
-    Array.from(new Set(topics.map((topic) => topic.category))),
+    Array.from(new Set(allTopics.map((topic) => topic.category))),
   );
 
   const isEverythingSelected = selectedTopics.includes("*");
@@ -69,7 +92,7 @@ const TopicPicker = ({
 
   // Group topics by category
   const categorizedTopics = useMemo(() => {
-    const filtered = topics.filter((topic) =>
+    const filtered = allTopics.filter((topic) =>
       topic.id.toLowerCase().includes(searchQuery.toLowerCase()),
     );
 
@@ -84,7 +107,7 @@ const TopicPicker = ({
       },
       {} as Record<string, Topic[]>,
     );
-  }, [topics, searchQuery]);
+  }, [allTopics, searchQuery]);
 
   const toggleCategory = (category: string) => {
     setExpandedCategories((prev) =>
@@ -94,30 +117,13 @@ const TopicPicker = ({
     );
   };
 
-  const toggleCategorySelection = (topicsInCategory: Topic[]) => {
-    if (isEverythingSelected) {
-      selectedTopics = [];
-    }
-
-    const categoryTopicIds = topicsInCategory.map((t) => t.id);
-    const areAllSelected = categoryTopicIds.every((id) =>
-      selectedTopics.includes(id),
-    );
-
-    if (areAllSelected) {
-      onTopicsChange(
-        selectedTopics.filter((id) => !categoryTopicIds.includes(id)),
-      );
-    } else {
-      const newSelected = new Set([...selectedTopics, ...categoryTopicIds]);
-      onTopicsChange(Array.from(newSelected));
-    }
-  };
-
   const toggleTopic = (topicId: string) => {
     if (isEverythingSelected) {
       selectedTopics = [];
     }
+
+    // Ensure if we manually add/toggle a custom topic it's immediately tracked
+    setSeenTopics((prev) => Array.from(new Set([...prev, topicId])));
 
     const newSelected = selectedTopics.includes(topicId)
       ? selectedTopics.filter((id) => id !== topicId)
@@ -125,39 +131,80 @@ const TopicPicker = ({
     onTopicsChange(newSelected);
   };
 
+  const exactMatchExists = allTopics.some(
+    (t) => t.id.toLowerCase() === searchQuery.toLowerCase(),
+  );
+
+  // The backend glob matcher (matchTopicPattern) natively supports '*' anywhere in the topic string.
+  const isWildcardSearch = searchQuery.includes("*");
+
+  const showAddTopic =
+    searchQuery.length > 0 && !exactMatchExists && isWildcardSearch;
+
   return (
     <div className="topic-picker" style={{ maxHeight: maxHeight }}>
       <div className="topic-picker__header">
         <SearchInput
           value={searchQuery}
           onChange={(value) => setSearchQuery(value)}
-          placeholder="Filter topics..."
+          placeholder="Filter or type a wildcard topic (e.g., order.*)"
         />
       </div>
       <div className="topic-picker__content">
         {searchQuery.length === 0 && (
           <div className="topic-picker__select-all">
             <Checkbox
-              label="Select All"
+              label="Select All (*)"
               checked={isEverythingSelected}
               onChange={toggleSelectAll}
             />
           </div>
         )}
-        {Object.entries(categorizedTopics).length === 0 && (
+        {showAddTopic && (
+          <div className="topic-picker__flat-topic">
+            <Checkbox
+              checked={false}
+              onChange={() => {
+                toggleTopic(searchQuery);
+                setSearchQuery("");
+              }}
+              label={`Add "${searchQuery}"`}
+              monospace
+              disabled={isEverythingSelected}
+            />
+          </div>
+        )}
+        {Object.entries(categorizedTopics).length === 0 && !showAddTopic && (
           <span className="body-m muted">No topics match your filter.</span>
         )}
         {Object.entries(categorizedTopics).map(([category, categoryTopics]) => {
           const isExpanded = expandedCategories.includes(category);
-          const selectedCount = categoryTopics.filter((topic) =>
+
+          const firstNormalTopic = categoryTopics.find(
+            (t) => !t.id.endsWith("*") && t.id !== category,
+          );
+          const separator = firstNormalTopic
+            ? findFirstSeparator(firstNormalTopic.id)
+            : ".";
+          const wildcardId = `${category}${separator || "."}*`;
+
+          const hasWildcard = selectedTopics.includes(wildcardId);
+          const visibleTopics = categoryTopics.filter(
+            (t) => t.id !== wildcardId,
+          );
+
+          const selectedCount = visibleTopics.filter((topic) =>
             selectedTopics.includes(topic.id),
           ).length;
-          const areAllSelected = selectedCount === categoryTopics.length;
-          const isIndeterminate = selectedCount > 0 && !areAllSelected;
+          // Always show indeterminate if any children are selected but the wildcard itself is not.
+          const isIndeterminate = !hasWildcard && selectedCount > 0;
 
           // Check if this is a flat topic (no actual nesting)
           const isFlatTopic =
-            categoryTopics.length === 1 && categoryTopics[0].id === category;
+            (categoryTopics.length === 1 &&
+              categoryTopics[0].id === category) ||
+            (categoryTopics.length === 1 &&
+              categoryTopics[0].id === wildcardId);
 
           if (isFlatTopic) {
             const topic = categoryTopics[0];
@@ -165,8 +212,7 @@ const TopicPicker = ({
               <div key={category} className="topic-picker__flat-topic">
                 <Checkbox
                   checked={
-                    isEverythingSelected ||
-                    selectedTopics.indexOf(topic.id) !== -1
+                    isEverythingSelected || selectedTopics.includes(topic.id)
                   }
                   onChange={() => toggleTopic(topic.id)}
                   label={topic.id}
@@ -180,39 +226,61 @@ const TopicPicker = ({
           return (
             <div key={category} className="topic-picker__category">
               <div className="topic-picker__category-header">
-                <button
-                  type="button"
-                  onClick={() => toggleCategory(category)}
-                  className="topic-picker__category-toggle"
-                >
-                  <span className={`arrow ${isExpanded ? "expanded" : ""}`}>
-                    <DropdownIcon />
-                  </span>
-                </button>
+                {visibleTopics.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => toggleCategory(category)}
+                    className="topic-picker__category-toggle"
+                  >
+                    <span className={`arrow ${isExpanded ? "expanded" : ""}`}>
+                      <DropdownIcon />
+                    </span>
+                  </button>
+                ) : (
+                  <span style={{ width: 24, display: "inline-block" }} />
+                )}
                 <Checkbox
-                  label={`${category
-                    .split(" ")
-                    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-                    .join(" ")}`}
-                  checked={isEverythingSelected || areAllSelected}
+                  label={`${category} ${
+                    hasWildcard || isEverythingSelected ? `(${wildcardId})` : ""
+                  }`.trim()}
+                  checked={isEverythingSelected || hasWildcard}
                   indeterminate={!isEverythingSelected && isIndeterminate}
-                  onChange={() => toggleCategorySelection(categoryTopics)}
+                  onChange={() => {
+                    if (isEverythingSelected) {
+                      selectedTopics = [];
+                    }
+                    if (hasWildcard) {
+                      onTopicsChange(
+                        selectedTopics.filter((id) => id !== wildcardId),
+                      );
+                    } else {
+                      // Clicking the parent immediately subscribes to the wildcard
+                      // and clears out any individual child selections for a clean state.
+                      const childrenIds = categoryTopics.map((t) => t.id);
+                      const newSelected = selectedTopics.filter(
+                        (id) => !childrenIds.includes(id),
+                      );
+                      newSelected.push(wildcardId);
+                      onTopicsChange(newSelected);
+                    }
+                  }}
                   disabled={isEverythingSelected}
                 />
               </div>
-              {isExpanded && (
+              {isExpanded && visibleTopics.length > 0 && (
                 <div className="topic-picker__topics">
-                  {categoryTopics.map((topic) => (
+                  {visibleTopics.map((topic) => (
                     <div key={topic.id} className="topic-picker__topic">
                       <Checkbox
                         checked={
                           isEverythingSelected ||
-                          selectedTopics.indexOf(topic.id) !== -1
+                          hasWildcard ||
+                          selectedTopics.includes(topic.id)
                         }
                         onChange={() => toggleTopic(topic.id)}
                         label={topic.id}
                         monospace
-                        disabled={isEverythingSelected}
+                        disabled={isEverythingSelected || hasWildcard}
                       />
                     </div>
                   ))}

--- a/internal/portal/src/common/TopicPicker/TopicPicker.tsx
+++ b/internal/portal/src/common/TopicPicker/TopicPicker.tsx
@@ -39,6 +39,8 @@ const TopicPicker = ({
   selectedTopics,
   onTopicsChange,
 }: TopicPickerProps) => {
+  const allowWildcardTopics = CONFIGS.TOPICS_ALLOW_WILDCARDS === "true";
+
   // Keep track of any custom topics seen during this component's lifecycle
   // so they don't disappear if they are temporarily unselected or "Select All" is clicked.
   const [seenTopics, setSeenTopics] = useState<string[]>([]);
@@ -117,6 +119,23 @@ const TopicPicker = ({
     );
   };
 
+  const toggleCategorySelection = (topicsInCategory: Topic[]) => {
+    const currentTopics = isEverythingSelected ? [] : selectedTopics;
+    const categoryTopicIds = topicsInCategory.map((t) => t.id);
+    const areAllSelected = categoryTopicIds.every((id) =>
+      currentTopics.includes(id),
+    );
+
+    if (areAllSelected) {
+      onTopicsChange(
+        currentTopics.filter((id) => !categoryTopicIds.includes(id)),
+      );
+    } else {
+      const newSelected = new Set([...currentTopics, ...categoryTopicIds]);
+      onTopicsChange(Array.from(newSelected));
+    }
+  };
+
   const toggleTopic = (topicId: string) => {
     const currentTopics = isEverythingSelected ? [] : selectedTopics;
 
@@ -133,11 +152,14 @@ const TopicPicker = ({
     (t) => t.id.toLowerCase() === searchQuery.toLowerCase(),
   );
 
-  // The backend glob matcher (matchTopicPattern) natively supports '*' anywhere in the topic string.
+  // The backend glob matcher supports '*' anywhere in the topic string when enabled.
   const isWildcardSearch = searchQuery.includes("*");
 
   const showAddTopic =
-    searchQuery.length > 0 && !exactMatchExists && isWildcardSearch;
+    allowWildcardTopics &&
+    searchQuery.length > 0 &&
+    !exactMatchExists &&
+    isWildcardSearch;
 
   return (
     <div className="topic-picker" style={{ maxHeight: maxHeight }}>
@@ -145,14 +167,18 @@ const TopicPicker = ({
         <SearchInput
           value={searchQuery}
           onChange={(value) => setSearchQuery(value)}
-          placeholder="Filter or type a wildcard topic (e.g., order.*)"
+          placeholder={
+            allowWildcardTopics
+              ? "Filter or type a wildcard topic (e.g., order.*)"
+              : "Filter topics..."
+          }
         />
       </div>
       <div className="topic-picker__content">
         {searchQuery.length === 0 && (
           <div className="topic-picker__select-all">
             <Checkbox
-              label="Select All (*)"
+              label="Select All"
               checked={isEverythingSelected}
               onChange={toggleSelectAll}
             />
@@ -186,22 +212,34 @@ const TopicPicker = ({
             : ".";
           const wildcardId = `${category}${separator || "."}*`;
 
-          const hasWildcard = selectedTopics.includes(wildcardId);
-          const visibleTopics = categoryTopics.filter(
-            (t) => t.id !== wildcardId,
-          );
+          const hasWildcard =
+            allowWildcardTopics && selectedTopics.includes(wildcardId);
+          const visibleTopics = allowWildcardTopics
+            ? categoryTopics.filter((t) => t.id !== wildcardId)
+            : categoryTopics;
 
           const selectedCount = visibleTopics.filter((topic) =>
             selectedTopics.includes(topic.id),
           ).length;
-          // Always show indeterminate if any children are selected but the wildcard itself is not.
-          const isIndeterminate = !hasWildcard && selectedCount > 0;
+          const groupSelectionLabel = allowWildcardTopics
+            ? hasWildcard || isEverythingSelected
+              ? "Selected and future topics"
+              : selectedCount > 0
+                ? "Selected topics only"
+                : ""
+            : "";
+          const areAllSelected =
+            visibleTopics.length > 0 && selectedCount === visibleTopics.length;
+          const isIndeterminate = allowWildcardTopics
+            ? !hasWildcard && selectedCount > 0
+            : selectedCount > 0 && !areAllSelected;
 
           // Check if this is a flat topic (no actual nesting)
           const isFlatTopic =
             (categoryTopics.length === 1 &&
               categoryTopics[0].id === category) ||
-            (categoryTopics.length === 1 &&
+            (allowWildcardTopics &&
+              categoryTopics.length === 1 &&
               categoryTopics[0].id === wildcardId);
 
           if (isFlatTopic) {
@@ -238,12 +276,18 @@ const TopicPicker = ({
                   <span style={{ width: 24, display: "inline-block" }} />
                 )}
                 <Checkbox
-                  label={`${category} ${
-                    hasWildcard || isEverythingSelected ? `(${wildcardId})` : ""
-                  }`.trim()}
-                  checked={isEverythingSelected || hasWildcard}
+                  label={category}
+                  checked={
+                    isEverythingSelected ||
+                    (allowWildcardTopics ? hasWildcard : areAllSelected)
+                  }
                   indeterminate={!isEverythingSelected && isIndeterminate}
                   onChange={() => {
+                    if (!allowWildcardTopics) {
+                      toggleCategorySelection(visibleTopics);
+                      return;
+                    }
+
                     const currentTopics = isEverythingSelected
                       ? []
                       : selectedTopics;
@@ -265,6 +309,11 @@ const TopicPicker = ({
                   }}
                   disabled={isEverythingSelected}
                 />
+                {groupSelectionLabel && (
+                  <span className="topic-picker__category-selection">
+                    {groupSelectionLabel}
+                  </span>
+                )}
               </div>
               {isExpanded && visibleTopics.length > 0 && (
                 <div className="topic-picker__topics">
@@ -273,13 +322,28 @@ const TopicPicker = ({
                       <Checkbox
                         checked={
                           isEverythingSelected ||
-                          hasWildcard ||
+                          (allowWildcardTopics && hasWildcard) ||
                           selectedTopics.includes(topic.id)
                         }
-                        onChange={() => toggleTopic(topic.id)}
+                        onChange={() => {
+                          if (allowWildcardTopics && hasWildcard) {
+                            const explicitTopics = visibleTopics
+                              .map((t) => t.id)
+                              .filter((id) => id !== topic.id);
+                            onTopicsChange([
+                              ...selectedTopics.filter(
+                                (id) => id !== wildcardId,
+                              ),
+                              ...explicitTopics,
+                            ]);
+                            return;
+                          }
+
+                          toggleTopic(topic.id);
+                        }}
                         label={topic.id}
                         monospace
-                        disabled={isEverythingSelected || hasWildcard}
+                        disabled={isEverythingSelected}
                       />
                     </div>
                   ))}

--- a/internal/portal/src/common/TopicPicker/TopicPicker.tsx
+++ b/internal/portal/src/common/TopicPicker/TopicPicker.tsx
@@ -118,16 +118,14 @@ const TopicPicker = ({
   };
 
   const toggleTopic = (topicId: string) => {
-    if (isEverythingSelected) {
-      selectedTopics = [];
-    }
+    const currentTopics = isEverythingSelected ? [] : selectedTopics;
 
     // Ensure if we manually add/toggle a custom topic it's immediately tracked
     setSeenTopics((prev) => Array.from(new Set([...prev, topicId])));
 
-    const newSelected = selectedTopics.includes(topicId)
-      ? selectedTopics.filter((id) => id !== topicId)
-      : [...selectedTopics, topicId];
+    const newSelected = currentTopics.includes(topicId)
+      ? currentTopics.filter((id) => id !== topicId)
+      : [...currentTopics, topicId];
     onTopicsChange(newSelected);
   };
 
@@ -246,18 +244,19 @@ const TopicPicker = ({
                   checked={isEverythingSelected || hasWildcard}
                   indeterminate={!isEverythingSelected && isIndeterminate}
                   onChange={() => {
-                    if (isEverythingSelected) {
-                      selectedTopics = [];
-                    }
+                    const currentTopics = isEverythingSelected
+                      ? []
+                      : selectedTopics;
+
                     if (hasWildcard) {
                       onTopicsChange(
-                        selectedTopics.filter((id) => id !== wildcardId),
+                        currentTopics.filter((id) => id !== wildcardId),
                       );
                     } else {
                       // Clicking the parent immediately subscribes to the wildcard
                       // and clears out any individual child selections for a clean state.
                       const childrenIds = categoryTopics.map((t) => t.id);
-                      const newSelected = selectedTopics.filter(
+                      const newSelected = currentTopics.filter(
                         (id) => !childrenIds.includes(id),
                       );
                       newSelected.push(wildcardId);

--- a/internal/portal/src/config.ts
+++ b/internal/portal/src/config.ts
@@ -8,6 +8,7 @@ const CONFIGS =
     REFRESH_URL: string;
     FORCE_THEME: string;
     TOPICS: string;
+    TOPICS_ALLOW_WILDCARDS: string;
     DISABLE_OUTPOST_BRANDING: string;
     DISABLE_TELEMETRY: string;
     BRAND_COLOR: string;

--- a/internal/publishmq/eventhandler_test.go
+++ b/internal/publishmq/eventhandler_test.go
@@ -262,6 +262,44 @@ func TestEventHandler_HandleResult(t *testing.T) {
 		require.Len(t, result.DestinationIDs, 3)
 	})
 
+	t.Run("normal publish with wildcard destination topics", func(t *testing.T) {
+		wildcardTenant := models.Tenant{
+			ID:        idgen.String(),
+			CreatedAt: time.Now(),
+		}
+		require.NoError(t, tenantStore.UpsertTenant(ctx, wildcardTenant))
+
+		destFactory := testutil.DestinationFactory
+		matchingDestinations := []models.Destination{
+			destFactory.Any(
+				destFactory.WithTenantID(wildcardTenant.ID),
+				destFactory.WithTopics([]string{"user.*"}),
+			),
+			destFactory.Any(
+				destFactory.WithTenantID(wildcardTenant.ID),
+				destFactory.WithTopics([]string{"*.created"}),
+			),
+		}
+		for _, dest := range matchingDestinations {
+			require.NoError(t, tenantStore.UpsertDestination(ctx, dest))
+		}
+		require.NoError(t, tenantStore.UpsertDestination(ctx, destFactory.Any(
+			destFactory.WithTenantID(wildcardTenant.ID),
+			destFactory.WithTopics([]string{"user.deleted*"}),
+		)))
+
+		event := testutil.EventFactory.AnyPointer(
+			testutil.EventFactory.WithTenantID(wildcardTenant.ID),
+			testutil.EventFactory.WithTopic("user.created"),
+		)
+
+		result, err := eventHandler.Handle(ctx, event)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.Duplicate)
+		require.ElementsMatch(t, []string{matchingDestinations[0].ID, matchingDestinations[1].ID}, result.DestinationIDs)
+	})
+
 	t.Run("no destinations matched", func(t *testing.T) {
 		event := testutil.EventFactory.AnyPointer(
 			testutil.EventFactory.WithTenantID(tenant.ID),

--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -189,7 +189,14 @@ func (b *ServiceBuilder) BuildAPIWorkers(baseRouter *gin.Engine) error {
 		idempotence.WithSuccessfulTTL(time.Duration(b.cfg.PublishIdempotencyKeyTTL)*time.Second),
 		idempotence.WithDeploymentID(b.cfg.DeploymentID),
 	)
-	eventHandler := publishmq.NewEventHandler(b.logger, svc.deliveryMQ, svc.tenantStore, svc.eventTracer, b.cfg.Topics, publishIdempotence)
+	eventHandler := publishmq.NewEventHandler(
+		b.logger,
+		svc.deliveryMQ,
+		svc.tenantStore,
+		svc.eventTracer,
+		b.cfg.Topics,
+		publishIdempotence,
+	)
 
 	// Create operator events emitter for subscription updates
 	oeCfg := b.cfg.OperatorEvents.ToConfig()
@@ -201,14 +208,15 @@ func (b *ServiceBuilder) BuildAPIWorkers(baseRouter *gin.Engine) error {
 
 	apiHandler := apirouter.NewRouter(
 		apirouter.RouterConfig{
-			ServiceName:  b.cfg.OpenTelemetry.GetServiceName(),
-			APIKey:       b.cfg.APIKey,
-			JWTSecret:    b.cfg.APIJWTSecret,
-			DeploymentID: b.cfg.DeploymentID,
-			Topics:       b.cfg.Topics,
-			Registry:     svc.destRegistry,
-			PortalConfig: b.cfg.GetPortalConfig(),
-			GinMode:      b.cfg.GinMode,
+			ServiceName:          b.cfg.OpenTelemetry.GetServiceName(),
+			APIKey:               b.cfg.APIKey,
+			JWTSecret:            b.cfg.APIJWTSecret,
+			DeploymentID:         b.cfg.DeploymentID,
+			Topics:               b.cfg.Topics,
+			TopicsAllowWildcards: b.cfg.TopicsAllowWildcards,
+			Registry:             svc.destRegistry,
+			PortalConfig:         b.cfg.GetPortalConfig(),
+			GinMode:              b.cfg.GinMode,
 		},
 		apirouter.RouterDeps{
 			TenantStore:         svc.tenantStore,

--- a/internal/tenantstore/drivertest/list.go
+++ b/internal/tenantstore/drivertest/list.go
@@ -319,6 +319,22 @@ func testListDestination(t *testing.T, newHarness HarnessMaker) {
 		})
 		require.NoError(t, err)
 		require.Len(t, destinations, 3)
+
+		for _, topics := range [][]string{{"user.*"}, {"*.created"}, {"user.deleted*"}} {
+			require.NoError(t, store.UpsertDestination(ctx, testutil.DestinationFactory.Any(
+				testutil.DestinationFactory.WithTenantID(data.tenant.ID),
+				testutil.DestinationFactory.WithTopics(topics),
+			)))
+		}
+
+		// The filter topic is treated as a concrete published topic. Destinations
+		// subscribed with wildcard patterns are included when they would receive it.
+		destinations, err = store.ListDestination(ctx, driver.ListDestinationRequest{
+			TenantID: data.tenant.ID,
+			Topics:   []string{"user.created"},
+		})
+		require.NoError(t, err)
+		require.Len(t, destinations, 5)
 	})
 }
 

--- a/internal/tenantstore/drivertest/match.go
+++ b/internal/tenantstore/drivertest/match.go
@@ -133,6 +133,75 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 		})
 	})
 
+	t.Run("MatchByWildcardTopic", func(t *testing.T) {
+		ctx := context.Background()
+		h, err := newHarness(ctx, t)
+		require.NoError(t, err)
+		t.Cleanup(h.Close)
+
+		store, err := h.MakeDriver(ctx)
+		require.NoError(t, err)
+
+		tenant := models.Tenant{ID: idgen.String()}
+		require.NoError(t, store.UpsertTenant(ctx, tenant))
+
+		destUserFamily := testutil.DestinationFactory.Any(
+			testutil.DestinationFactory.WithID("dest_user_family"),
+			testutil.DestinationFactory.WithTenantID(tenant.ID),
+			testutil.DestinationFactory.WithTopics([]string{"user.*"}),
+		)
+		destCreatedFamily := testutil.DestinationFactory.Any(
+			testutil.DestinationFactory.WithID("dest_created_family"),
+			testutil.DestinationFactory.WithTenantID(tenant.ID),
+			testutil.DestinationFactory.WithTopics([]string{"*.created"}),
+		)
+		destOrderCompletedFamily := testutil.DestinationFactory.Any(
+			testutil.DestinationFactory.WithID("dest_order_completed_family"),
+			testutil.DestinationFactory.WithTenantID(tenant.ID),
+			testutil.DestinationFactory.WithTopics([]string{"order.*.completed"}),
+		)
+		destExact := testutil.DestinationFactory.Any(
+			testutil.DestinationFactory.WithID("dest_exact"),
+			testutil.DestinationFactory.WithTenantID(tenant.ID),
+			testutil.DestinationFactory.WithTopics([]string{"user.created"}),
+		)
+
+		require.NoError(t, store.CreateDestination(ctx, destUserFamily))
+		require.NoError(t, store.CreateDestination(ctx, destCreatedFamily))
+		require.NoError(t, store.CreateDestination(ctx, destOrderCompletedFamily))
+		require.NoError(t, store.CreateDestination(ctx, destExact))
+
+		t.Run("matches prefix and suffix wildcard subscriptions", func(t *testing.T) {
+			event := testutil.EventFactory.Any(
+				testutil.EventFactory.WithTenantID(tenant.ID),
+				testutil.EventFactory.WithTopic("user.created"),
+			)
+			matched, err := store.MatchEvent(ctx, event)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"dest_user_family", "dest_created_family", "dest_exact"}, matched)
+		})
+
+		t.Run("matches separator agnostic middle wildcard subscription", func(t *testing.T) {
+			event := testutil.EventFactory.Any(
+				testutil.EventFactory.WithTenantID(tenant.ID),
+				testutil.EventFactory.WithTopic("order.payment.completed"),
+			)
+			matched, err := store.MatchEvent(ctx, event)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"dest_order_completed_family"}, matched)
+		})
+
+		t.Run("does not overmatch unrelated topic", func(t *testing.T) {
+			event := testutil.EventFactory.Any(
+				testutil.EventFactory.WithTenantID(tenant.ID),
+				testutil.EventFactory.WithTopic("order.payment.failed"),
+			)
+			matched, err := store.MatchEvent(ctx, event)
+			require.NoError(t, err)
+			assert.Empty(t, matched)
+		})
+	})
+
 	t.Run("MatchEventWithFilter", func(t *testing.T) {
 		ctx := context.Background()
 		h, err := newHarness(ctx, t)

--- a/internal/tenantstore/memtenantstore/memtenantstore.go
+++ b/internal/tenantstore/memtenantstore/memtenantstore.go
@@ -478,7 +478,7 @@ func matchDestFilter(filter *destinationFilter, dest models.Destination) bool {
 				return false
 			}
 			for _, topic := range filter.Topics {
-				if !slices.Contains(dest.Topics, topic) {
+				if !dest.Topics.MatchTopic(topic) {
 					return false
 				}
 			}

--- a/internal/tenantstore/redistenantstore/serialization.go
+++ b/internal/tenantstore/redistenantstore/serialization.go
@@ -368,14 +368,7 @@ func matchDestinationFilter(filter *destinationFilter, summary destinationSummar
 				return false
 			}
 			for _, topic := range filter.Topics {
-				found := false
-				for _, st := range summary.Topics {
-					if st == topic {
-						found = true
-						break
-					}
-				}
-				if !found {
+				if !summary.Topics.MatchTopic(topic) {
 					return false
 				}
 			}


### PR DESCRIPTION
## Summary

adds support for wildcard patterns in destination topic subscriptions.

destinations can now subscribe to topic families using `*` inside a topic string, for example:

- `user.*`
- `*.created`
- `order.*.completed`

exact topic subscriptions keep the existing behavior, and `"*"` still means subscribe to all topics.

closes #908

## Behavior

`*` inside a topic string matches any run of characters, separator-agnostic.

examples:

- `user.*` matches `user.created`
- `user.*` matches `user.profile.updated`
- `*.created` matches `user.created` and `order.created`
- `order.*.completed` matches `order.payment.completed`

published event topics are still exact topic strings. this only changes destination subscription matching/validation.

## Validation

if available topics are configured, wildcard patterns must match at least one available topic.

for example, with available topics:


`user.created`
`user.deleted`


this is valid:


`user.*`


this is rejected:


`order.*`


if no available topics are configured, wildcard patterns are accepted, same as other destination topics today.

## Implementation notes

topic matching is on the delivery hot path, so this avoids regex and avoids compiling/caching patterns.

the matcher uses a small allocation-free wildcard algorithm:

- exact strings still short-circuit
- `*` matches any run of characters
- matching is separator-agnostic
- benchmark coverage was added for exact match/miss and pattern match/miss

## Tests

verified with local test infra running:


`TESTINFRA=1 go test ./internal/publishmq -run 'TestEventHandler|TestIntegrationPublishMQEventHandler_Concurrency' -count=1`



`TESTINFRA=1 go test ./internal/models ./internal/tenantstore/memtenantstore ./internal/tenantstore/redistenantstore ./internal/apirouter ./internal/publishmq -count=1`


bench:


`TESTINFRA=1 go test ./internal/models -bench 'BenchmarkTopics_MatchTopic' -benchmem -run '^$'`


result on my machine:


| Benchmark                                      | Time        | Bytes/op | Allocs/op |
|-----------------------------------------------|-------------|----------|-----------|
| BenchmarkTopicsMatchTopic/exactmatch-8        | 34.26 ns/op | 0 B/op   | 0 allocs/op |
| BenchmarkTopicsMatchTopic/exactmiss-8         | 30.93 ns/op | 0 B/op   | 0 allocs/op |
| BenchmarkTopicsMatchTopic/patternmatch-8      | 77.37 ns/op | 0 B/op   | 0 allocs/op |
| BenchmarkTopicsMatchTopic/patternmiss-8       | 93.08 ns/op | 0 B/op   | 0 allocs/op |