### PR TITLE
feat(portal): mobile-responsive layout

### DIFF
--- a/internal/portal/src/app.scss
+++ b/internal/portal/src/app.scss
@@ -8,6 +8,16 @@
   padding-left: calc(var(--base-grid-multiplier) * 24);
   padding-right: calc(var(--base-grid-multiplier) * 24);
 
+  @media (max-width: 1024px) {
+    padding-left: var(--spacing-6);
+    padding-right: var(--spacing-6);
+  }
+
+  @media (max-width: 640px) {
+    padding-left: var(--spacing-4);
+    padding-right: var(--spacing-4);
+  }
+
   &__loading {
     display: flex;
     justify-content: center;
@@ -22,6 +32,11 @@
     gap: var(--spacing-2);
     margin-top: calc(var(--base-grid-multiplier) * 20);
     margin-bottom: calc(var(--base-grid-multiplier) * 12);
+
+    @media (max-width: 640px) {
+      margin-top: var(--spacing-6);
+      margin-bottom: var(--spacing-6);
+    }
 
     a {
       color: var(--colors-foreground-neutral-3);
@@ -46,6 +61,9 @@
     display: flex;
     gap: var(--spacing-2);
     color: var(--colors-foreground-neutral-3);
+    flex-wrap: wrap;
+    align-items: center;
+    width: 100%;
 
     span,
     a {
@@ -65,6 +83,12 @@
   bottom: var(--spacing-3);
   left: var(--spacing-4);
   color: var(--colors-foreground-neutral-2);
+
+  @media (max-width: 640px) {
+    position: static;
+    text-align: center;
+    padding: var(--spacing-4);
+  }
 
   a {
     color: var(--colors-foreground-neutral-2);

--- a/internal/portal/src/common/MetricsChart/MetricsBreakdown.scss
+++ b/internal/portal/src/common/MetricsChart/MetricsBreakdown.scss
@@ -46,6 +46,11 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    @media (max-width: 640px) {
+      min-width: 72px;
+      max-width: 72px;
+    }
   }
 
   &__bar-container {

--- a/internal/portal/src/common/SearchInput/SearchInput.scss
+++ b/internal/portal/src/common/SearchInput/SearchInput.scss
@@ -6,6 +6,8 @@
   padding-right: var(--spacing-8);
   padding-left: var(--spacing-9);
   min-width: 368px;
+  width: 100%;
+  box-sizing: border-box;
   &::placeholder {
     color: var(--colors-foreground-neutral-3);
   }

--- a/internal/portal/src/common/Sidebar/Sidebar.scss
+++ b/internal/portal/src/common/Sidebar/Sidebar.scss
@@ -1,5 +1,22 @@
 .sidebar-open #root {
   margin-right: 408px;
+
+  // Below 1024px the sidebar overlays content instead of pushing it.
+  @media (max-width: 1024px) {
+    margin-right: 0;
+  }
+}
+
+#sidebar-backdrop {
+  display: none;
+
+  @media (max-width: 1024px) {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.32);
+    z-index: 9;
+  }
 }
 
 #sidebar {
@@ -12,6 +29,14 @@
   border-left: 1px solid var(--colors-outline-neutral);
   overflow-y: auto;
   box-sizing: border-box;
+  background: var(--colors-background);
+  z-index: 10;
+
+  @media (max-width: 640px) {
+    width: 100vw;
+    max-width: 100vw;
+    padding: var(--spacing-4);
+  }
 
   .close-button {
     margin-left: calc(var(--spacing-2) * -1);

--- a/internal/portal/src/common/Sidebar/Sidebar.tsx
+++ b/internal/portal/src/common/Sidebar/Sidebar.tsx
@@ -78,12 +78,15 @@ const SidebarPortal = ({
   }
 
   return createPortal(
-    <div id="sidebar">
-      <Button minimal onClick={onClose} className="close-button">
-        <CollapseIcon />
-      </Button>
-      {state.content}
-    </div>,
+    <>
+      <div id="sidebar-backdrop" onClick={onClose} aria-hidden="true" />
+      <div id="sidebar">
+        <Button minimal onClick={onClose} className="close-button">
+          <CollapseIcon />
+        </Button>
+        {state.content}
+      </div>
+    </>,
     document.body,
   );
 };

--- a/internal/portal/src/common/Table/Table.scss
+++ b/internal/portal/src/common/Table/Table.scss
@@ -6,6 +6,23 @@
   border: 1px solid var(--colors-outline-neutral);
   background-color: var(--colors-background);
 
+  @media (max-width: 1024px) {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+
+    .table__header,
+    .table__body,
+    .table__body-row,
+    .table__footer {
+      min-width: var(--table-min-width, max-content);
+    }
+
+    .table__body {
+      overflow-x: visible;
+    }
+  }
+
   &__header {
     display: grid;
     background-color: var(--colors-background-neutral-2);

--- a/internal/portal/src/common/Table/Table.tsx
+++ b/internal/portal/src/common/Table/Table.tsx
@@ -37,9 +37,9 @@ const Table: React.FC<TableProps> = ({
     .map((column) => (column.width ? `${column.width}px` : "1fr"))
     .join(" ");
 
-  const fallback_flex_column_width = 160;
-  const table_min_width = columns.reduce(
-    (sum, column) => sum + (column.width ?? fallback_flex_column_width),
+  const fallbackFlexColumnWidth = 160;
+  const tableMinWidth = columns.reduce(
+    (sum, column) => sum + (column.width ?? fallbackFlexColumnWidth),
     0,
   );
 
@@ -48,7 +48,7 @@ const Table: React.FC<TableProps> = ({
       className="table"
       style={
         {
-          "--table-min-width": `${table_min_width}px`,
+          "--table-min-width": `${tableMinWidth}px`,
         } as React.CSSProperties
       }
     >

--- a/internal/portal/src/common/Table/Table.tsx
+++ b/internal/portal/src/common/Table/Table.tsx
@@ -37,8 +37,21 @@ const Table: React.FC<TableProps> = ({
     .map((column) => (column.width ? `${column.width}px` : "1fr"))
     .join(" ");
 
+  const fallback_flex_column_width = 160;
+  const table_min_width = columns.reduce(
+    (sum, column) => sum + (column.width ?? fallback_flex_column_width),
+    0,
+  );
+
   return (
-    <div className="table">
+    <div
+      className="table"
+      style={
+        {
+          "--table-min-width": `${table_min_width}px`,
+        } as React.CSSProperties
+      }
+    >
       <div
         className="table__header"
         style={{

--- a/internal/portal/src/global.scss
+++ b/internal/portal/src/global.scss
@@ -4,10 +4,6 @@ $BASE_GRID_MULTIPLIER: 4px !default;
 $RADIUS_S: 4px !default;
 $RADIUS_M: 6px !default;
 
-// Responsive breakpoints
-$BREAKPOINT_MOBILE: 640px !default;
-$BREAKPOINT_TABLET: 1024px !default;
-
 // Background Colors
 
 /// Neutral
@@ -362,7 +358,7 @@ body {
 
 // Prevent iOS Safari from zooming the viewport when focusing inputs:
 // browsers only zoom inputs whose computed font-size is < 16px.
-@media (max-width: $BREAKPOINT_MOBILE) {
+@media (max-width: 640px) {
   input,
   textarea,
   select {

--- a/internal/portal/src/global.scss
+++ b/internal/portal/src/global.scss
@@ -4,6 +4,10 @@ $BASE_GRID_MULTIPLIER: 4px !default;
 $RADIUS_S: 4px !default;
 $RADIUS_M: 6px !default;
 
+// Responsive breakpoints
+$BREAKPOINT_MOBILE: 640px !default;
+$BREAKPOINT_TABLET: 1024px !default;
+
 // Background Colors
 
 /// Neutral
@@ -352,6 +356,18 @@ body {
   margin: 0;
   background: var(--colors-background);
   font-size: 1rem;
+  overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
+}
+
+// Prevent iOS Safari from zooming the viewport when focusing inputs:
+// browsers only zoom inputs whose computed font-size is < 16px.
+@media (max-width: $BREAKPOINT_MOBILE) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
 }
 
 @mixin generate-spacing-variables {

--- a/internal/portal/src/scenes/CreateDestination/CreateDestination.scss
+++ b/internal/portal/src/scenes/CreateDestination/CreateDestination.scss
@@ -7,12 +7,23 @@
   flex-direction: row;
   padding-top: calc(var(--base-grid-multiplier) * 18);
 
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-8);
+    padding-top: var(--spacing-8);
+  }
+
   &__sidebar {
     display: flex;
     flex-direction: column;
     position: sticky;
     top: calc(var(--base-grid-multiplier) * 18);
     align-self: start;
+
+    @media (max-width: 1024px) {
+      position: static;
+      top: auto;
+    }
 
     &__steps {
       margin-top: var(--spacing-8);
@@ -71,6 +82,12 @@
         margin-bottom: 0;
         ~ p {
           margin-top: 0;
+        }
+
+        @media (max-width: 640px) {
+          margin-top: var(--spacing-4);
+          font-size: var(--font-size-2xl);
+          line-height: var(--line-height-2xl);
         }
       }
     }

--- a/internal/portal/src/scenes/Destination/Destination.scss
+++ b/internal/portal/src/scenes/Destination/Destination.scss
@@ -3,6 +3,10 @@
   align-items: center;
   gap: var(--spacing-6);
 
+  @media (max-width: 640px) {
+    gap: var(--spacing-4);
+  }
+
   &__icon {
     display: flex;
     align-items: center;
@@ -38,11 +42,21 @@
 .tabs-container {
   margin-top: 24px;
   border-bottom: 1px solid var(--colors-outline-neutral);
+
+  @media (max-width: 640px) {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 
 .tabs {
   display: flex;
   gap: var(--spacing-4);
+
+  @media (max-width: 640px) {
+    gap: var(--spacing-2);
+    white-space: nowrap;
+  }
 }
 
 .tab {
@@ -91,6 +105,21 @@
         align-items: center;
         gap: var(--spacing-1);
       }
+
+      @media (max-width: 640px) {
+        flex-direction: column;
+        gap: var(--spacing-1);
+
+        > span:first-child {
+          width: auto;
+          min-width: 0;
+        }
+
+        > span:last-child {
+          min-width: 0;
+          word-break: break-word;
+        }
+      }
     }
   }
 }
@@ -132,6 +161,8 @@
     align-items: center;
     justify-content: space-between;
     margin-bottom: var(--spacing-4);
+    gap: var(--spacing-3);
+    flex-wrap: wrap;
 
     h2 {
       margin: 0;
@@ -178,6 +209,15 @@
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     gap: var(--spacing-6);
+
+    @media (max-width: 1024px) {
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--spacing-4);
+    }
+
+    @media (max-width: 640px) {
+      grid-template-columns: 1fr;
+    }
   }
 
   &__cell {
@@ -195,6 +235,16 @@
 
     &--row2-half {
       grid-column: span 3;
+    }
+
+    @media (max-width: 1024px) {
+      grid-column: span 1 !important;
+      padding: var(--spacing-4);
+    }
+
+    @media (max-width: 640px) {
+      height: auto;
+      min-height: 280px;
     }
   }
 }

--- a/internal/portal/src/scenes/Destination/DestinationSettings/DestinationSettings.scss
+++ b/internal/portal/src/scenes/Destination/DestinationSettings/DestinationSettings.scss
@@ -46,6 +46,12 @@
     display: flex;
     gap: var(--spacing-3);
     margin-top: var(--spacing-4);
+    flex-wrap: wrap;
+
+    @media (max-width: 640px) {
+      flex-direction: column;
+      align-items: stretch;
+    }
   }
 
   &__actions {

--- a/internal/portal/src/scenes/Destination/Events/Attempts.scss
+++ b/internal/portal/src/scenes/Destination/Events/Attempts.scss
@@ -14,11 +14,13 @@
     align-items: center;
     gap: var(--spacing-2);
     justify-content: space-between;
+    flex-wrap: wrap;
 
     &-filters {
       display: flex;
       align-items: center;
       gap: var(--spacing-3);
+      flex-wrap: wrap;
     }
 
     &-title .badge {
@@ -70,10 +72,21 @@
     &--active {
       grid-template-columns: 1fr 516px;
 
+      @media (max-width: 1024px) {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto auto;
+      }
+
       .table {
         height: 100%;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
+
+        @media (max-width: 1024px) {
+          border-radius: var(--radius-m);
+          border-bottom-left-radius: 0;
+          border-bottom-right-radius: 0;
+        }
       }
 
       .drawer {
@@ -84,6 +97,12 @@
         border: 1px solid var(--colors-outline-neutral);
         border-top-right-radius: var(--radius-m);
         border-bottom-right-radius: var(--radius-m);
+
+        @media (max-width: 1024px) {
+          border-top: none;
+          border-radius: 0 0 var(--radius-m) var(--radius-m);
+          max-height: 60vh;
+        }
 
         &__header {
           display: flex;
@@ -159,6 +178,9 @@ dl.description-list {
     padding-top: var(--spacing-4);
     padding-bottom: var(--spacing-4);
     border-bottom: 1px solid var(--colors-outline-neutral);
+    // Allow long values (e.g. IDs, URLs) to wrap onto a new line under the
+    // label on narrow viewports without forcing every row to stack.
+    flex-wrap: wrap;
 
     &:last-child {
       border-bottom: none;

--- a/internal/portal/src/scenes/DestinationsList/DestinationList.scss
+++ b/internal/portal/src/scenes/DestinationsList/DestinationList.scss
@@ -17,9 +17,17 @@
   &__actions {
     display: flex;
     gap: var(--spacing-2);
+    flex-wrap: wrap;
 
     *:last-child {
       margin-left: auto;
+    }
+
+    @media (max-width: 640px) {
+      *:last-child {
+        margin-left: 0;
+        width: 100%;
+      }
     }
   }
 
@@ -37,6 +45,11 @@
   border: 1px dashed var(--colors-outline-neutral);
   border-radius: var(--radius-m);
   padding: var(--spacing-14);
+
+  @media (max-width: 640px) {
+    padding: var(--spacing-8) var(--spacing-4);
+    text-align: center;
+  }
 }
 
 .dropdown-item {

--- a/internal/portal/src/scenes/DestinationsList/DestinationList.scss
+++ b/internal/portal/src/scenes/DestinationsList/DestinationList.scss
@@ -24,9 +24,11 @@
     }
 
     @media (max-width: 640px) {
+      .search_input_container {
+        width: 100%;
+      }
       *:last-child {
         margin-left: 0;
-        width: 100%;
       }
     }
   }

--- a/internal/portal/src/scenes/DestinationsList/DestinationList.scss
+++ b/internal/portal/src/scenes/DestinationsList/DestinationList.scss
@@ -25,8 +25,14 @@
 
     @media (max-width: 640px) {
       .search_input_container {
+        min-width: 0;
         width: 100%;
       }
+
+      .search_input {
+        min-width: 0;
+      }
+
       *:last-child {
         margin-left: 0;
       }


### PR DESCRIPTION
Add responsive styles and small-viewport behavior across the portal UI. Key changes:

- app.scss: responsive paddings, loading margins, header layout and small-viewport positioning.
- global.scss: add $BREAKPOINT_* variables, prevent iOS zoom on inputs, hide horizontal overflow.
- Sidebar: overlay behavior below 1024px, backdrop element, mobile full-width sidebar and z-index (SCSS + Sidebar.tsx portal markup).
- Table: enable horizontal scrolling on narrow screens and set CSS var --table-min-width computed in Table.tsx (adds fallback column width calculation).
- MetricsBreakdown: constrain label widths on mobile.
- Scenes (CreateDestination, Destination, DestinationSettings, Attempts, DestinationsList): multiple layout, wrapping, grid and spacing adjustments for tablet/mobile viewports; improved wrapping for long values and tooltips.

These changes improve usability on tablet/phone widths and add safeguards for mobile browsers.

<img width="2172" height="2733" alt="Group 427320736" src="https://github.com/user-attachments/assets/637fbdc4-b7a3-48ba-8c6b-4101e59c11fc" />
