### PR TITLE
test(spec-sdk): fix paginator response shape after Speakeasy 1.753.0

### DIFF
--- a/spec-sdk-tests/tests/events.test.ts
+++ b/spec-sdk-tests/tests/events.test.ts
@@ -168,7 +168,7 @@ describe('Events (PR #491)', () => {
         limit: 5,
       });
       expect(response).to.not.be.undefined;
-      expect(response?.models).to.be.an('array');
+      expect(response?.result?.models).to.be.an('array');
     });
 
     it('should list events by tenant', async function () {
@@ -191,7 +191,7 @@ describe('Events (PR #491)', () => {
           const response = await sdk.events.list({
             tenantId: client.getTenantId(),
           });
-          return response?.models || [];
+          return response?.result?.models || [];
         },
         30000,
         5000
@@ -209,7 +209,7 @@ describe('Events (PR #491)', () => {
       const response = await sdk.events.list({
         tenantId: client.getTenantId(),
       });
-      const events = response?.models || [];
+      const events = response?.result?.models || [];
 
       if (events.length === 0) {
         console.warn('No events found - skipping single event test');
@@ -253,7 +253,7 @@ describe('Events (PR #491)', () => {
             destinationId: destinationId,
             eventId,
           });
-          return response?.models ?? [];
+          return response?.result?.models ?? [];
         },
         45000,
         5000

--- a/spec-sdk-tests/tests/tenants.test.ts
+++ b/spec-sdk-tests/tests/tenants.test.ts
@@ -19,8 +19,8 @@ describe('Tenants - List with request object', () => {
     const result = await sdk.tenants.list({ limit: 5 });
 
     expect(result).to.not.be.undefined;
-    expect(result?.models).to.be.an('array');
-    (result?.models ?? []).forEach((t: { id?: string }, i: number) => {
+    expect(result?.result?.models).to.be.an('array');
+    (result?.result?.models ?? []).forEach((t: { id?: string }, i: number) => {
       expect(t, `tenant[${i}]`).to.be.an('object');
       if (t.id != null) expect(t.id, `tenant[${i}].id`).to.be.a('string');
     });


### PR DESCRIPTION
Speakeasy CLI bump (`1.741.7` → `1.753.0`, commit `3f311e0d`) wrapped list-operation responses in a `PageIterator`. The change wasn't flagged in the SDK regen PR changelog, so `spec-sdk-tests` silently went stale.

**Before:**
```ts
const response = await sdk.events.list({ tenantId });
const events = response.models;
```

**Now:**
```ts
// Direct access to the first page
const response = await sdk.events.list({ tenantId });
const events = response.result.models;

// Or iterate across pages
const response = await sdk.events.list({ tenantId });
for await (const page of response) {
  for (const event of page.result.models) { ... }
}

// Or step manually via the paginator
let page = await sdk.events.list({ tenantId });
while (page) {
  for (const event of page.result.models) { ... }
  page = await page.next();
}
```

This PR updates the affected tests (`events.test.ts`, `tenants.test.ts`) to the new accessor.

---

Not necessarily my personal preference (the extra `result` wrapper feels noisy for the common single-page case), but it appears to be Speakeasy convention for paginated operations — keeps the iterator metadata (`next`, `[Symbol.asyncIterator]`) co-located with the parsed body without colliding with response fields.