### PR TITLE
fix(spec): expose event.data on Attempt when include=event.data

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2535,8 +2535,8 @@ components:
         event:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/EventSummary"
             - $ref: "#/components/schemas/EventFull"
+            - $ref: "#/components/schemas/EventSummary"
           description: The associated event object. Only present when include=event or include=event.data.
         destination:
           nullable: true

--- a/spec-sdk-tests/tests/events.test.ts
+++ b/spec-sdk-tests/tests/events.test.ts
@@ -168,7 +168,7 @@ describe('Events (PR #491)', () => {
         limit: 5,
       });
       expect(response).to.not.be.undefined;
-      expect(response?.models).to.be.an('array');
+      expect(response?.result?.models).to.be.an('array');
     });
 
     it('should list events by tenant', async function () {
@@ -191,7 +191,7 @@ describe('Events (PR #491)', () => {
           const response = await sdk.events.list({
             tenantId: client.getTenantId(),
           });
-          return response?.models || [];
+          return response?.result?.models || [];
         },
         30000,
         5000
@@ -209,7 +209,7 @@ describe('Events (PR #491)', () => {
       const response = await sdk.events.list({
         tenantId: client.getTenantId(),
       });
-      const events = response?.models || [];
+      const events = response?.result?.models || [];
 
       if (events.length === 0) {
         console.warn('No events found - skipping single event test');
@@ -253,7 +253,7 @@ describe('Events (PR #491)', () => {
             destinationId: destinationId,
             eventId,
           });
-          return response?.models ?? [];
+          return response?.result?.models ?? [];
         },
         45000,
         5000

--- a/spec-sdk-tests/tests/events.test.ts
+++ b/spec-sdk-tests/tests/events.test.ts
@@ -265,5 +265,39 @@ describe('Events (PR #491)', () => {
       expect(attempt.status).to.equal('success', 'Delivery to mock.hookdeck.com should succeed');
       console.log(`Event ${eventId} generated attempt; status: ${attempt.status}`);
     });
+
+    it('listAttempts with include=event.data should expose event.data on the parsed attempt', async function () {
+      this.timeout(60000);
+
+      const sdk: Outpost = client.getSDK();
+
+      const payload = { marker: `include-event-data-${Date.now()}` };
+      const publishResponse = await sdk.publish({
+        tenantId: client.getTenantId(),
+        topic: TEST_TOPICS[0],
+        data: payload,
+      });
+      const eventId = publishResponse.id;
+
+      const attempts = await pollForAttempts(
+        async () => {
+          const response = await sdk.destinations.listAttempts({
+            tenantId: client.getTenantId(),
+            destinationId: destinationId,
+            eventId,
+            include: ['event.data', 'response_data'],
+          });
+          return response?.result?.models ?? [];
+        },
+        45000,
+        5000
+      );
+
+      expect(attempts.length).to.be.at.least(1, 'Expected at least one attempt');
+      const attempt = attempts[0];
+      expect(attempt.responseData, 'response_data should be populated when include=response_data').to.exist;
+      expect(attempt.event, 'event should be populated when include=event.data').to.exist;
+      expect((attempt.event as { data?: unknown }).data, 'event.data should be populated when include=event.data').to.deep.equal(payload);
+    });
   });
 });

--- a/spec-sdk-tests/tests/tenants.test.ts
+++ b/spec-sdk-tests/tests/tenants.test.ts
@@ -19,8 +19,8 @@ describe('Tenants - List with request object', () => {
     const result = await sdk.tenants.list({ limit: 5 });
 
     expect(result).to.not.be.undefined;
-    expect(result?.models).to.be.an('array');
-    (result?.models ?? []).forEach((t: { id?: string }, i: number) => {
+    expect(result?.result?.models).to.be.an('array');
+    (result?.result?.models ?? []).forEach((t: { id?: string }, i: number) => {
       expect(t, `tenant[${i}]`).to.be.an('object');
       if (t.id != null) expect(t.id, `tenant[${i}].id`).to.be.a('string');
     });


### PR DESCRIPTION
Stacked on #916.

## The bug

`listAttempts({ include: ['event.data', 'response_data'] })` was returning `attempt.event` without the `data` payload, even though the server returns it on the wire.

Speakeasy's TS generator emits zod unions in declaration order, and `z.union` matches the first member that validates — it does not pick the best fit. The OpenAPI spec listed `EventSummary` before `EventFull`, and `EventSummary` is a plain (non-strict) `z.object` that silently accepts and strips any unknown keys — including `data`. So the union matched `EventSummary` first and dropped `data` before `EventFull` ever got a turn.

`sdks/outpost-typescript/src/models/components/attempt.ts` (before):

```ts
export const EventUnion$inboundSchema = z.union([
  z.lazy(() => EventSummary$inboundSchema),  // ← matches first, drops `data`
  z.lazy(() => EventFull$inboundSchema),
]);

export const EventSummary$inboundSchema = z.object({
  id: z.string().optional(),
  // …
  // no `data` field, no `.strict()` — extras silently dropped
});
```

This is a Speakeasy TS-generator pattern (not an OpenAPI spec problem, not a server problem). Other SDKs are unaffected:
- **Python** — Pydantic v2 smart-union picks `EventFull` when `data` is present ✅
- **Go** — tries `EventSummary` with `disallowUnknownFields=true`, falls through to `EventFull` ✅
- **TS** — Zod has no equivalent in `z.union`, so spec order matters ❌

## Fix

Swap the `oneOf` order so `EventFull` is declared first:

```diff
 event:
   nullable: true
   oneOf:
-    - $ref: "#/components/schemas/EventSummary"
     - $ref: "#/components/schemas/EventFull"
+    - $ref: "#/components/schemas/EventSummary"
```

After regen, `EventUnion$inboundSchema` lists `EventFull` first and matches when `data` is present.

## Test

TDD: failing test added that asserts `attempt.event.data` round-trips through `listAttempts({ include: ['event.data', …] })`.

## Verified locally

- Regenerated TS SDK (`./spec-sdk-tests/scripts/regenerate-sdk.sh TS`) — `EventUnion$inboundSchema` now lists `EventFull` first
- New test passes
- Full `spec-sdk-tests` suite: 152 passing, 1 unrelated pre-existing SQS failure

SDK regen will follow via the standard Speakeasy bot flow once this merges. Considering an upstream Speakeasy request later so order-independence isn't required.