### PR TITLE
fix(spec): order EventFull before EventSummary in Attempt.event oneOf

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -2535,8 +2535,8 @@ components:
         event:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/EventSummary"
             - $ref: "#/components/schemas/EventFull"
+            - $ref: "#/components/schemas/EventSummary"
           description: The associated event object. Only present when include=event or include=event.data.
         destination:
           nullable: true


### PR DESCRIPTION
Stacked on #917.

Swaps the `oneOf` order under `Attempt.event` so `EventFull` is declared first. Speakeasy's TS generator emits the corresponding zod union in declaration order, and `z.union` matches the first member that validates — the non-strict `EventSummary` was silently stripping `data` from the payload before `EventFull` ever got a turn.

```diff
 event:
   nullable: true
   oneOf:
-    - $ref: "#/components/schemas/EventSummary"
     - $ref: "#/components/schemas/EventFull"
+    - $ref: "#/components/schemas/EventSummary"
```

## Verified locally

- Regenerated TS SDK (`./spec-sdk-tests/scripts/regenerate-sdk.sh TS`) — `EventUnion$inboundSchema` now lists `EventFull` first
- Failing test from #917 now passes
- Full `spec-sdk-tests` suite: 152 passing, 1 unrelated pre-existing SQS failure

## Follow-up

SDK regen will follow via the standard Speakeasy bot flow once this merges. Considering an upstream Speakeasy request later so order-independence isn't required.