### PR TITLE
fix(openapi): add type discriminator to DestinationUpdate union

### DIFF
--- a/docs/apis/openapi.yaml
+++ b/docs/apis/openapi.yaml
@@ -1909,8 +1909,25 @@ components:
           kafka: "#/components/schemas/DestinationCreateKafka"
 
     # Type-Specific Destination Update Schemas (for Request Bodies)
+    # Type-Specific Partial Schemas for PATCH Request Bodies
+    # All fields are optional — RFC 7396 JSON merge-patch semantics apply:
+    # omit a field to leave it unchanged; include a field to update it in place.
+    WebhookConfigUpdate:
+      type: object
+      description: Partial Webhook config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        url:
+          type: string
+          format: url
+          description: The URL to send the webhook events to.
+          example: "https://example.com/webhooks/user"
+        custom_headers:
+          type: string
+          description: JSON string of custom HTTP headers to include with every webhook request.
+          example: '{"x-api-key":"secret123","x-tenant-id":"customer-456"}'
     WebhookCredentialsUpdate:
       type: object
+      description: Partial Webhook credentials for PATCH updates (RFC 7396 merge-patch).
       properties:
         secret:
           type: string
@@ -1925,17 +1942,207 @@ components:
         rotate_secret:
           type: boolean
           description: Set to true to rotate the secret. The current secret becomes the previous_secret, and a new secret is generated. `previous_secret_invalid_at` defaults to 24h if not provided.
+    AWSSQSConfigUpdate:
+      type: object
+      description: Partial AWS SQS config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        endpoint:
+          type: string
+          format: url
+          description: Optional. Custom AWS endpoint URL (e.g., for LocalStack or specific regions).
+          example: "https://sqs.us-east-1.amazonaws.com"
+        queue_url:
+          type: string
+          format: url
+          description: The URL of the SQS queue.
+          example: "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
+    AWSSQSCredentialsUpdate:
+      type: object
+      description: Partial AWS SQS credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        key:
+          type: string
+          description: AWS Access Key ID.
+        secret:
+          type: string
+          description: AWS Secret Access Key.
+        session:
+          type: string
+          description: Optional AWS Session Token (for temporary credentials).
+    RabbitMQConfigUpdate:
+      type: object
+      description: Partial RabbitMQ config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        server_url:
+          type: string
+          description: RabbitMQ server address (host:port).
+        exchange:
+          type: string
+          description: The exchange to publish messages to.
+        tls:
+          type: string
+          enum: ["true", "false"]
+          description: Whether to use TLS connection (amqps).
+    RabbitMQCredentialsUpdate:
+      type: object
+      description: Partial RabbitMQ credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        username:
+          type: string
+          description: RabbitMQ username.
+        password:
+          type: string
+          description: RabbitMQ password.
+    HookdeckCredentialsUpdate:
+      type: object
+      description: Partial Hookdeck credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        token:
+          type: string
+          description: Hookdeck authentication token.
+    AWSKinesisConfigUpdate:
+      type: object
+      description: Partial AWS Kinesis config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        stream_name:
+          type: string
+          description: The name of the AWS Kinesis stream.
+        region:
+          type: string
+          description: The AWS region where the Kinesis stream is located.
+        endpoint:
+          type: string
+          format: url
+          description: Optional. Custom AWS endpoint URL (e.g., for LocalStack or VPC endpoints).
+        partition_key_template:
+          type: string
+          description: Optional. JMESPath template to extract the partition key from the event payload.
+    AWSKinesisCredentialsUpdate:
+      type: object
+      description: Partial AWS Kinesis credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        key:
+          type: string
+          description: AWS Access Key ID.
+        secret:
+          type: string
+          description: AWS Secret Access Key.
+        session:
+          type: string
+          description: Optional AWS Session Token (for temporary credentials).
+    AzureServiceBusConfigUpdate:
+      type: object
+      description: Partial Azure Service Bus config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        name:
+          type: string
+          description: The name of the Azure Service Bus queue or topic to publish messages to.
+    AzureServiceBusCredentialsUpdate:
+      type: object
+      description: Partial Azure Service Bus credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        connection_string:
+          type: string
+          description: The connection string for the Azure Service Bus namespace.
+    AWSS3ConfigUpdate:
+      type: object
+      description: Partial AWS S3 config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        bucket:
+          type: string
+          description: The name of your AWS S3 bucket.
+        region:
+          type: string
+          pattern: "^[a-z]{2}-[a-z]+-[0-9]+$"
+          description: The AWS region where your bucket is located.
+        key_template:
+          type: string
+          description: JMESPath expression for generating S3 object keys.
+        storage_class:
+          type: string
+          description: The storage class for the S3 objects.
+    AWSS3CredentialsUpdate:
+      type: object
+      description: Partial AWS S3 credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        key:
+          type: string
+          description: AWS Access Key ID.
+        secret:
+          type: string
+          description: AWS Secret Access Key.
+        session:
+          type: string
+          description: Optional AWS Session Token (for temporary credentials).
+    GCPPubSubConfigUpdate:
+      type: object
+      description: Partial GCP Pub/Sub config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        project_id:
+          type: string
+          description: The GCP project ID.
+        topic:
+          type: string
+          description: The Pub/Sub topic name.
+        endpoint:
+          type: string
+          description: Optional. Custom endpoint URL (e.g., localhost:8085 for emulator).
+    GCPPubSubCredentialsUpdate:
+      type: object
+      description: Partial GCP Pub/Sub credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        service_account_json:
+          type: string
+          description: Service account key JSON. The entire JSON key file content as a string.
+    KafkaConfigUpdate:
+      type: object
+      description: Partial Kafka config for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        brokers:
+          type: string
+          description: Comma-separated list of Kafka broker addresses.
+        topic:
+          type: string
+          description: The Kafka topic to publish messages to.
+        sasl_mechanism:
+          type: string
+          enum: [plain, scram-sha-256, scram-sha-512]
+          description: SASL authentication mechanism.
+        tls:
+          type: string
+          enum: ["true", "false"]
+          description: Whether to enable TLS for the connection.
+        partition_key_template:
+          type: string
+          description: Optional JMESPath template to extract the partition key from the event payload.
+    KafkaCredentialsUpdate:
+      type: object
+      description: Partial Kafka credentials for PATCH updates (RFC 7396 merge-patch).
+      properties:
+        username:
+          type: string
+          description: SASL username for authentication.
+        password:
+          type: string
+          description: SASL password for authentication.
+
     DestinationUpdateWebhook:
       type: object
       x-docs-type: "Webhook"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [webhook]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "webhook"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/WebhookConfig" # URL is required here, but PATCH means it's optional in the request
+          $ref: "#/components/schemas/WebhookConfigUpdate"
         credentials:
           $ref: "#/components/schemas/WebhookCredentialsUpdate"
         delivery_metadata:
@@ -1977,15 +2184,21 @@ components:
       type: object
       x-docs-type: "AWS SQS"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [aws_sqs]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "aws_sqs"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/AWSSQSConfig" # queue_url is required here, but PATCH means it's optional
+          $ref: "#/components/schemas/AWSSQSConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/AWSSQSCredentials" # key/secret required here, but PATCH means optional
+          $ref: "#/components/schemas/AWSSQSCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2025,15 +2238,21 @@ components:
       type: object
       x-docs-type: "RabbitMQ"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [rabbitmq]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "rabbitmq"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/RabbitMQConfig" # server_url/exchange required here, but PATCH means optional
+          $ref: "#/components/schemas/RabbitMQConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/RabbitMQCredentials" # username/password required here, but PATCH means optional
+          $ref: "#/components/schemas/RabbitMQCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2073,14 +2292,20 @@ components:
       type: object
       x-docs-type: "Hookdeck Event Gateway"
       # Properties duplicated from DestinationUpdateBase
+      # Hookdeck has no updatable `config`.
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [hookdeck]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "hookdeck"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
-        config: {} # Empty config, cannot be updated
         credentials:
-          $ref: "#/components/schemas/HookdeckCredentials" # token required here, but PATCH means optional
+          $ref: "#/components/schemas/HookdeckCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2120,15 +2345,21 @@ components:
       type: object
       x-docs-type: "AWS Kinesis"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [aws_kinesis]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "aws_kinesis"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/AWSKinesisConfig" # stream_name/region required here, but PATCH means optional
+          $ref: "#/components/schemas/AWSKinesisConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/AWSKinesisCredentials" # key/secret required here, but PATCH means optional
+          $ref: "#/components/schemas/AWSKinesisCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2168,15 +2399,21 @@ components:
       type: object
       x-docs-type: "Azure Service Bus"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [azure_servicebus]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "azure_servicebus"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/AzureServiceBusConfig" # name required here, but PATCH means optional
+          $ref: "#/components/schemas/AzureServiceBusConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/AzureServiceBusCredentials" # connection_string required here, but PATCH means optional
+          $ref: "#/components/schemas/AzureServiceBusCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2217,15 +2454,21 @@ components:
       type: object
       x-docs-type: "AWS S3"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [aws_s3]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "aws_s3"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/AWSS3Config" # bucket/region required here, but PATCH means optional
+          $ref: "#/components/schemas/AWSS3ConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/AWSS3Credentials" # key/secret required here, but PATCH means optional
+          $ref: "#/components/schemas/AWSS3CredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2265,15 +2508,21 @@ components:
       type: object
       x-docs-type: "GCP PubSub"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [gcp_pubsub]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "gcp_pubsub"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/GCPPubSubConfig" # project_id/topic required here, but PATCH means optional
+          $ref: "#/components/schemas/GCPPubSubConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/GCPPubSubCredentials" # service_account_json required here, but PATCH means optional
+          $ref: "#/components/schemas/GCPPubSubCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2313,15 +2562,21 @@ components:
       type: object
       x-docs-type: "Apache Kafka"
       # Properties duplicated from DestinationUpdateBase
+      required: [type]
       properties:
+        type:
+          type: string
+          enum: [kafka]
+          description: Destination type discriminator. Must equal the existing destination's type — type itself cannot be changed via PATCH.
+          example: "kafka"
         topics:
           $ref: "#/components/schemas/Topics"
         filter:
           $ref: "#/components/schemas/Filter"
         config:
-          $ref: "#/components/schemas/KafkaConfig" # brokers/topic/sasl_mechanism required here, but PATCH means optional
+          $ref: "#/components/schemas/KafkaConfigUpdate"
         credentials:
-          $ref: "#/components/schemas/KafkaCredentials" # username/password required here, but PATCH means optional
+          $ref: "#/components/schemas/KafkaCredentialsUpdate"
         delivery_metadata:
           type: object
           additionalProperties:
@@ -2370,6 +2625,18 @@ components:
         - $ref: "#/components/schemas/DestinationUpdateGCPPubSub"
         - $ref: "#/components/schemas/DestinationUpdateRabbitMQ"
         - $ref: "#/components/schemas/DestinationUpdateKafka"
+      discriminator:
+        propertyName: type
+        mapping:
+          webhook: "#/components/schemas/DestinationUpdateWebhook"
+          aws_sqs: "#/components/schemas/DestinationUpdateAWSSQS"
+          rabbitmq: "#/components/schemas/DestinationUpdateRabbitMQ"
+          hookdeck: "#/components/schemas/DestinationUpdateHookdeck"
+          aws_kinesis: "#/components/schemas/DestinationUpdateAWSKinesis"
+          azure_servicebus: "#/components/schemas/DestinationUpdateAzureServiceBus"
+          aws_s3: "#/components/schemas/DestinationUpdateAWSS3"
+          gcp_pubsub: "#/components/schemas/DestinationUpdateGCPPubSub"
+          kafka: "#/components/schemas/DestinationUpdateKafka"
     # Event Schemas
     PublishRequest:
       type: object

--- a/spec-sdk-tests/tests/destinations/aws-kinesis.test.ts
+++ b/spec-sdk-tests/tests/destinations/aws-kinesis.test.ts
@@ -246,7 +246,7 @@ describe('AWS Kinesis Destinations - Contract Tests (SDK-based validation)', () 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -321,12 +321,13 @@ describe('AWS Kinesis Destinations - Contract Tests (SDK-based validation)', () 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_kinesis',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -341,6 +342,7 @@ describe('AWS Kinesis Destinations - Contract Tests (SDK-based validation)', () 
     // See TEST_STATUS.md for detailed analysis
     it.skip('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_kinesis',
         config: {
           streamName: 'updated-stream',
         },
@@ -355,6 +357,7 @@ describe('AWS Kinesis Destinations - Contract Tests (SDK-based validation)', () 
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_kinesis',
         credentials: {
           key: 'AKIAIOSFODNN7UPDATED',
           secret: 'updatedSecretKey',
@@ -368,6 +371,7 @@ describe('AWS Kinesis Destinations - Contract Tests (SDK-based validation)', () 
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'aws_kinesis',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/destinations/aws-s3.test.ts
+++ b/spec-sdk-tests/tests/destinations/aws-s3.test.ts
@@ -246,7 +246,7 @@ describe('AWS S3 Destinations - Contract Tests (SDK-based validation)', () => {
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -321,12 +321,13 @@ describe('AWS S3 Destinations - Contract Tests (SDK-based validation)', () => {
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_s3',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -338,6 +339,7 @@ describe('AWS S3 Destinations - Contract Tests (SDK-based validation)', () => {
 
     it('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_s3',
         config: {
           bucket: 'updated-bucket',
         },
@@ -352,6 +354,7 @@ describe('AWS S3 Destinations - Contract Tests (SDK-based validation)', () => {
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_s3',
         credentials: {
           key: 'AKIAIOSFODNN7UPDATED',
           secret: 'updatedSecretKey',
@@ -365,6 +368,7 @@ describe('AWS S3 Destinations - Contract Tests (SDK-based validation)', () => {
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'aws_s3',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/destinations/aws-sqs.test.ts
+++ b/spec-sdk-tests/tests/destinations/aws-sqs.test.ts
@@ -213,7 +213,7 @@ describe('AWS SQS Destinations - Contract Tests (SDK-based validation)', () => {
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -286,12 +286,13 @@ describe('AWS SQS Destinations - Contract Tests (SDK-based validation)', () => {
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_sqs',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -303,6 +304,7 @@ describe('AWS SQS Destinations - Contract Tests (SDK-based validation)', () => {
 
     it('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_sqs',
         config: {
           queueUrl: 'https://sqs.us-west-2.amazonaws.com/123456789012/updated-queue',
         },
@@ -319,6 +321,7 @@ describe('AWS SQS Destinations - Contract Tests (SDK-based validation)', () => {
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'aws_sqs',
         credentials: {
           key: 'AKIAIOSFODNN7UPDATED',
           secret: 'updatedSecretKey',
@@ -332,6 +335,7 @@ describe('AWS SQS Destinations - Contract Tests (SDK-based validation)', () => {
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'aws_sqs',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/destinations/azure-servicebus.test.ts
+++ b/spec-sdk-tests/tests/destinations/azure-servicebus.test.ts
@@ -213,7 +213,7 @@ describe('Azure Service Bus Destinations - Contract Tests (SDK-based validation)
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -286,12 +286,13 @@ describe('Azure Service Bus Destinations - Contract Tests (SDK-based validation)
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'azure_servicebus',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -303,6 +304,7 @@ describe('Azure Service Bus Destinations - Contract Tests (SDK-based validation)
 
     it('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'azure_servicebus',
         config: {
           name: 'updated-queue',
         },
@@ -317,6 +319,7 @@ describe('Azure Service Bus Destinations - Contract Tests (SDK-based validation)
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'azure_servicebus',
         credentials: {
           connectionString:
             'Endpoint=sb://updated.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=updatedkey',
@@ -330,6 +333,7 @@ describe('Azure Service Bus Destinations - Contract Tests (SDK-based validation)
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'azure_servicebus',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/destinations/gcp-pubsub.test.ts
+++ b/spec-sdk-tests/tests/destinations/gcp-pubsub.test.ts
@@ -330,7 +330,7 @@ describe('GCP Pub/Sub Destinations - Contract Tests (SDK-based validation)', () 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -458,12 +458,13 @@ describe('GCP Pub/Sub Destinations - Contract Tests (SDK-based validation)', () 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'gcp_pubsub',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -475,6 +476,7 @@ describe('GCP Pub/Sub Destinations - Contract Tests (SDK-based validation)', () 
 
     it('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'gcp_pubsub',
         config: {
           topic: 'updated-topic-name',
         },
@@ -489,6 +491,7 @@ describe('GCP Pub/Sub Destinations - Contract Tests (SDK-based validation)', () 
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'gcp_pubsub',
         credentials: {
           serviceAccountJson: '{"type":"service_account","projectId":"updated"}',
         },
@@ -501,6 +504,7 @@ describe('GCP Pub/Sub Destinations - Contract Tests (SDK-based validation)', () 
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'gcp_pubsub',
           topics: '*',
         });
       } catch (error: any) {
@@ -522,6 +526,7 @@ describe('GCP Pub/Sub Destinations - Contract Tests (SDK-based validation)', () 
       let errorThrown = false;
       try {
         await client.updateDestination(destinationId, {
+          type: 'gcp_pubsub',
           config: {
             // Missing required fields
           },

--- a/spec-sdk-tests/tests/destinations/hookdeck.test.ts
+++ b/spec-sdk-tests/tests/destinations/hookdeck.test.ts
@@ -177,7 +177,7 @@ describe('Hookdeck Destinations - Contract Tests (SDK-based validation)', () => 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -250,12 +250,13 @@ describe('Hookdeck Destinations - Contract Tests (SDK-based validation)', () => 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'hookdeck',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -267,6 +268,7 @@ describe('Hookdeck Destinations - Contract Tests (SDK-based validation)', () => 
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'hookdeck',
         credentials: {
           token: 'hk_updated_token',
         },
@@ -279,6 +281,7 @@ describe('Hookdeck Destinations - Contract Tests (SDK-based validation)', () => 
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'hookdeck',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/destinations/rabbitmq.test.ts
+++ b/spec-sdk-tests/tests/destinations/rabbitmq.test.ts
@@ -246,7 +246,7 @@ describe('RabbitMQ Destinations - Contract Tests (SDK-based validation)', () => 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -321,12 +321,13 @@ describe('RabbitMQ Destinations - Contract Tests (SDK-based validation)', () => 
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'rabbitmq',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -338,6 +339,7 @@ describe('RabbitMQ Destinations - Contract Tests (SDK-based validation)', () => 
 
     it('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'rabbitmq',
         config: {
           exchange: 'updated-exchange',
         },
@@ -352,6 +354,7 @@ describe('RabbitMQ Destinations - Contract Tests (SDK-based validation)', () => 
 
     it('should update destination credentials', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'rabbitmq',
         credentials: {
           username: 'newuser',
           password: 'newpass',
@@ -365,6 +368,7 @@ describe('RabbitMQ Destinations - Contract Tests (SDK-based validation)', () => 
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'rabbitmq',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/destinations/webhook-merge-patch.test.ts
+++ b/spec-sdk-tests/tests/destinations/webhook-merge-patch.test.ts
@@ -18,12 +18,11 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
     }
   });
 
-  after(async () => {
-    for (const id of createdDestinations) {
-      try {
-        await client.deleteDestination(id);
-      } catch {}
-    }
+  after(async function () {
+    this.timeout(30000);
+    await Promise.all(
+      createdDestinations.map((id) => client.deleteDestination(id).catch(() => {}))
+    );
     try {
       await client.deleteTenant();
     } catch {}
@@ -42,6 +41,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ metadata: { env: 'prod' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         metadata: { env: 'prod', team: 'platform' },
       });
 
@@ -52,6 +52,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ metadata: { env: 'prod' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         metadata: { env: 'staging' },
       });
 
@@ -62,6 +63,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ metadata: { env: 'prod', region: 'us-east-1' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         metadata: { env: 'prod', region: null },
       });
 
@@ -73,6 +75,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ metadata: { env: 'prod' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         metadata: null,
       });
 
@@ -87,6 +90,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ metadata: { env: 'prod' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         metadata: {},
       });
 
@@ -97,6 +101,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ metadata: { env: 'prod' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         topics: ['*'],
       });
 
@@ -109,6 +114,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         metadata: { keep: 'v', remove: null, update: 'new', add: 'v' },
       });
 
@@ -124,6 +130,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ deliveryMetadata: { source: 'outpost' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         deliveryMetadata: { source: 'outpost', version: '1.0' },
       });
 
@@ -136,6 +143,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         deliveryMetadata: { source: 'outpost', version: null },
       });
 
@@ -146,6 +154,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ deliveryMetadata: { source: 'outpost' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         deliveryMetadata: null,
       });
 
@@ -161,6 +170,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       const id = await createDest({ deliveryMetadata: { source: 'outpost' } });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         deliveryMetadata: {},
       });
 
@@ -177,6 +187,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         filter: { body: { status: 'active' } },
       });
 
@@ -189,6 +200,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         filter: {},
       });
 
@@ -205,6 +217,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         filter: null,
       });
 
@@ -221,6 +234,7 @@ describe('Webhook Destinations - Merge-Patch Semantics (RFC 7396)', () => {
       });
 
       const updated = await client.updateDestination(id, {
+        type: 'webhook',
         topics: ['*'],
       });
 

--- a/spec-sdk-tests/tests/destinations/webhook.test.ts
+++ b/spec-sdk-tests/tests/destinations/webhook.test.ts
@@ -180,7 +180,7 @@ describe('Webhook Destinations - Contract Tests (SDK-based validation)', () => {
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -253,12 +253,13 @@ describe('Webhook Destinations - Contract Tests (SDK-based validation)', () => {
       try {
         await client.deleteDestination(destinationId);
       } catch (error) {
-        console.warn('Failed to cleanup destination:', error);
+        console.warn('Failed to cleanup destination:', error instanceof Error ? error.message : String(error));
       }
     });
 
     it('should update destination topics', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'webhook',
         topics: ['user.created', 'user.updated'],
       });
 
@@ -270,6 +271,7 @@ describe('Webhook Destinations - Contract Tests (SDK-based validation)', () => {
 
     it('should update destination config', async () => {
       const updated = await client.updateDestination(destinationId, {
+        type: 'webhook',
         config: {
           url: 'https://updated.example.com/webhook',
         },
@@ -286,6 +288,7 @@ describe('Webhook Destinations - Contract Tests (SDK-based validation)', () => {
       let errorThrown = false;
       try {
         await client.updateDestination('non-existent-id-12345', {
+          type: 'webhook',
           topics: ['test'],
         });
       } catch (error: any) {

--- a/spec-sdk-tests/tests/events.test.ts
+++ b/spec-sdk-tests/tests/events.test.ts
@@ -168,7 +168,7 @@ describe('Events (PR #491)', () => {
         limit: 5,
       });
       expect(response).to.not.be.undefined;
-      expect(response?.models).to.be.an('array');
+      expect(response?.result?.models).to.be.an('array');
     });
 
     it('should list events by tenant', async function () {
@@ -191,7 +191,7 @@ describe('Events (PR #491)', () => {
           const response = await sdk.events.list({
             tenantId: client.getTenantId(),
           });
-          return response?.models || [];
+          return response?.result?.models || [];
         },
         30000,
         5000
@@ -209,7 +209,7 @@ describe('Events (PR #491)', () => {
       const response = await sdk.events.list({
         tenantId: client.getTenantId(),
       });
-      const events = response?.models || [];
+      const events = response?.result?.models || [];
 
       if (events.length === 0) {
         console.warn('No events found - skipping single event test');
@@ -253,7 +253,7 @@ describe('Events (PR #491)', () => {
             destinationId: destinationId,
             eventId,
           });
-          return response?.models ?? [];
+          return response?.result?.models ?? [];
         },
         45000,
         5000

--- a/spec-sdk-tests/tests/tenants.test.ts
+++ b/spec-sdk-tests/tests/tenants.test.ts
@@ -19,8 +19,8 @@ describe('Tenants - List with request object', () => {
     const result = await sdk.tenants.list({ limit: 5 });
 
     expect(result).to.not.be.undefined;
-    expect(result?.models).to.be.an('array');
-    (result?.models ?? []).forEach((t: { id?: string }, i: number) => {
+    expect(result?.result?.models).to.be.an('array');
+    (result?.result?.models ?? []).forEach((t: { id?: string }, i: number) => {
       expect(t, `tenant[${i}]`).to.be.an('object');
       if (t.id != null) expect(t.id, `tenant[${i}].id`).to.be.a('string');
     });

--- a/spec-sdk-tests/utils/sdk-client.ts
+++ b/spec-sdk-tests/utils/sdk-client.ts
@@ -46,6 +46,16 @@ export class SdkClient {
       serverURL: baseURL,
       apiKey: config.apiKey || process.env.API_KEY || '',
       timeoutMs: config.timeout || 10000,
+      retryConfig: {
+        strategy: 'backoff',
+        backoff: {
+          initialInterval: 250,
+          maxInterval: 4000,
+          exponent: 2,
+          maxElapsedTime: 20000,
+        },
+        retryConnectionErrors: true,
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

Two distinct-but-intertwined bugs in destination PATCH, both rooted in the spec. This PR fixes both at the source.

### Bug 1 — Wire-serialization (runtime, silent failure)

PATCH requests that try to update part of a non-Webhook destination's `config` silently fail. The API returns `200 OK`, but the destination's config is unchanged.

**Concretely** — calling the TS SDK to change an AWS SQS destination's queue URL:

```ts
await outpost.destinations.update("test-tenant", "des_123", {
  config: { queueUrl: "https://sqs.us-west-2.amazonaws.com/.../updated-queue" },
});
```

The TS-facing field is `queueUrl` (camelCase), which the SQS outbound schema is supposed to remap to `queue_url` (snake_case) on the wire. But the request actually goes out as `{ "config": { "queueUrl": "..." } }` — camelCase reaches the server. Merge-patch doesn't recognize the key, leaves `queue_url` untouched, and the response shows the old queue.

**Why:** the `DestinationUpdate` `oneOf` has no `discriminator` (removed in [`8be278c5`](https://github.com/hookdeck/outpost/commit/8be278c5), May 2025, when `type` wasn't yet accepted on PATCH). Without one, the SDK picks a union variant by structural shape-matching. `DestinationUpdateHookdeck`'s `config: {}` (intent: "no updatable config"; OpenAPI: "any value allowed") wins for every partial-config payload because it accepts anything. **Hookdeck's variant has no field-name remap** — that's the actual mis-serialization. Affects AWS SQS, S3, Kinesis, RabbitMQ, GCP Pub/Sub, Azure Service Bus, and Kafka partial-config updates.

### Bug 2 — Typing (compile-time, blocks correct usage)

Even fully correct payloads couldn't be expressed as partial updates. The spec referenced the full `*Config` / `*Credentials` schemas — which require their fields — from the `DestinationUpdate*` variants. So:

```ts
// Before this PR — TS error: `queueUrl` is required on AWSSQSConfig
update("t", "id", { config: { endpoint: "https://..." } });
```

The OpenAPI source even acknowledges the gap with inline comments like `# queue_url is required here, but PATCH means it's optional`. The fix has been a TODO note in production.

### Fix

- Add `type` (required, enum-locked) to every `DestinationUpdate*` variant and `discriminator: propertyName: type` on the union (mirrors `DestinationCreate`) → resolves Bug 1.
- Introduce 17 new `*ConfigUpdate` / `*CredentialsUpdate` companion schemas (all-optional fields, RFC 7396 merge-patch documented) and reference these from `DestinationUpdate*` variants → resolves Bug 2.
- Remove `config: {}` from `DestinationUpdateHookdeck`. Hookdeck has no updatable config; `HookdeckCredentialsUpdate` handles partial credential updates.

Server-side merge-patch landed in [`bd7701b5`](https://github.com/hookdeck/outpost/commit/bd7701b5) (April 2026), so the runtime side is already correct — only the spec needed to catch up.

## TS SDK typing after regen

`DestinationUpdate` becomes a true discriminated union — `type: "aws_sqs"` literal types narrow `config` to the matching `*ConfigUpdate`. Examples:

```ts
update("t", "id", { config: { queueUrl: "x" } });
// ❌ Missing required `type`

update("t", "id", { type: "aws_sqs", config: { streamName: "x" } });
// ❌ `streamName` doesn't exist on AWSSQSConfigUpdate (it's `queueUrl` / `endpoint`)

update("t", "id", { type: "aws_kinesis", config: { streamName: "x" } });
// ✅ Narrowed to DestinationUpdateAWSKinesis; only Kinesis fields allowed; partial config ok
```

IDE autocomplete on `config:` now shows only fields valid for the chosen `type`.

(Zod note: the regen emits `z.union([…])`, not `z.discriminatedUnion(…)`. Functionally equivalent here — every variant requires `type: z.literal("…")`, so only the matching variant parses. Speakeasy's choice; not worth chasing in this PR.)

## Spec changes

- `type` added to every `DestinationUpdate*` variant: required, enum-locked, documented as immutable on PATCH.
- `discriminator: propertyName: type` added to `DestinationUpdate`.
- 17 new `*ConfigUpdate` / `*CredentialsUpdate` companion schemas — all fields optional, RFC 7396 merge-patch documented. Variants now reference these instead of the full `*Config` / `*Credentials`.
- `config: {}` removed from `DestinationUpdateHookdeck`.

## Consumer impact

| Consumer | Impact |
|---|---|
| Typed SDK (TS / Python / Go) | **Breaking after regen.** `update()` payloads must include `type: '<destination>'`. Compile-error otherwise. |
| Raw HTTP | Server still accepts PATCH without `type` at runtime — calls keep working but are spec-noncompliant. Server-side enforcement is a separate decision. |
| API ref docs / code samples / MCP server | Regenerated as part of the SDK regen PR. |

## What's NOT in this PR (deliberately)

- **SDK regen** — bot-driven via `.github/workflows/sdk_generation_outpost_*.yaml`. Tests here were validated locally against a TS regen (1.4.1); CI compile-check on this PR will fail until the regen PR lands.
- **Server-side enforcement of required `type`** — separate decision.
- **CI for `spec-sdk-tests`** — confirmed none exists today (verified across `.github/workflows` and `.speakeasy`). Follow-up PR.

## spec-sdk-tests changes (knock-on)

- `type: '<destination>'` inserted into 46 `updateDestination` payloads across 9 files.
- Paginator response shape fixed (`response.result.models`) in `events.test.ts` / `tenants.test.ts` — **supersedes [`fix/spec-sdk-tests-paginator-shape`](https://github.com/hookdeck/outpost/tree/fix/spec-sdk-tests-paginator-shape)**.
- SDK retries enabled (backoff on 429/5xx) in `utils/sdk-client.ts` — managed-Outpost rate limits no longer flake tests.
- Cleanup parallelized in webhook-merge-patch `after` hook (15 destinations × serial DELETE was exceeding mocha's 10s hook timeout).
- `console.warn('Failed to cleanup destination:', error)` → safe `String(error)` form in all 17 cleanup hooks (node `util.inspect` was crashing on SDK errors with getter-only descriptors).

## Test status

Against managed Outpost (`api.outpost.hookdeck.com`), locally with regen'd TS SDK 1.4.1:

| | Passing | Failing | Pending |
|---|---|---|---|
| Before | 133 | 14 | 15 |
| After  | 152 | 0  | 15 |

The 15 pending are the same skipped tests as before (Hookdeck token verification, GCP Pub/Sub validation gaps — pre-existing backend limitations).

Also of note: `spec-sdk-tests/TEST_STATUS.md` had attributed the AWS Kinesis partial-config update failure to a "backend bug." It's the same SDK-side dispatch issue this PR fixes — the Kinesis test should pass after regen and can be un-skipped in a follow-up.

## Test plan

- [x] Spec validates (`swagger-cli validate`) — re-run on final branch state.
- [ ] SDK regen PR merges → CI compile-check goes green on this PR.
- [x] Full `spec-sdk-tests` run against managed Outpost — re-run on final branch state: **152 passing / 0 failing / 15 pending**.
- [ ] Add `spec-sdk-tests` CI workflow — tracked in #921.
- [ ] Decide whether to enforce required `type` server-side (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

