### PR TITLE
ci(spec-sdk-tests-vs-release): pin spec-sdk-tests/ alongside SDK on sdk_version override

### DIFF
--- a/.github/workflows/spec-sdk-tests-vs-release.yml
+++ b/.github/workflows/spec-sdk-tests-vs-release.yml
@@ -121,7 +121,12 @@ jobs:
         # `gh release view` returns the wrong thing.
         run: |
           if [ -n "$OVERRIDE" ]; then
-            tag="v${OVERRIDE#v}"
+            ver="${OVERRIDE#v}"
+            if ! [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::outpost_version must be a strict X.Y.Z version (got: '$OVERRIDE')"
+              exit 1
+            fi
+            tag="v${ver}"
             echo "Using outpost_version override: $tag"
           else
             tag=$(gh api repos/${{ github.repository }}/releases \
@@ -220,6 +225,10 @@ jobs:
           SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
         run: |
           ver="${SDK_VERSION_INPUT#v}"
+          if ! [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::sdk_version must be a strict X.Y.Z version (got: '$SDK_VERSION_INPUT')"
+            exit 1
+          fi
           full_tag="sdks/outpost-typescript/v${ver}"
           echo "Pinning SDK + tests to $full_tag"
           git fetch --depth=1 origin "refs/tags/$full_tag:refs/tags/$full_tag"

--- a/.github/workflows/spec-sdk-tests-vs-release.yml
+++ b/.github/workflows/spec-sdk-tests-vs-release.yml
@@ -23,7 +23,9 @@
 #
 # workflow_dispatch inputs (UI overrides, ignored on PR runs):
 #   sdk_version     — pin SDK to a specific TS release (e.g. "1.3.0" or "v1.3.0").
-#                     Empty = use the dispatch branch's current SDK contents.
+#                     When set, ALSO pins spec-sdk-tests/ to the same release
+#                     point so tests + SDK shape stay aligned. Empty = use the
+#                     dispatch branch's current SDK + test contents.
 #   outpost_version — pin Outpost server to a specific release (e.g. "1.0.3" or "v1.0.3").
 #                     Empty = latest non-prerelease Outpost release.
 name: Spec SDK tests vs released Outpost
@@ -32,7 +34,7 @@ on:
   workflow_dispatch:
     inputs:
       sdk_version:
-        description: 'TS SDK version to test (e.g. "1.3.0" or "v1.3.0"). Empty = use this branch''s SDK contents.'
+        description: 'TS SDK version to test (e.g. "1.3.0" or "v1.3.0"). When set, also pins spec-sdk-tests/ to the same release point. Empty = use this branch''s SDK + test contents.'
         required: false
         type: string
       outpost_version:
@@ -202,23 +204,29 @@ jobs:
           docker logs outpost || true
           exit 1
 
-      - name: Override SDK with sdk_version (workflow_dispatch only)
+      - name: Override SDK + tests with sdk_version (workflow_dispatch only)
         # Guard event_name first so the inputs.* reference is short-circuited
         # away on pull_request runs (where inputs.* isn't populated).
         if: github.event_name == 'workflow_dispatch' && inputs.sdk_version != ''
-        # Replace the working tree's sdks/outpost-typescript with the contents
-        # at the SDK release tag. SDK tags are namespaced as
-        # sdks/outpost-typescript/v<x>. Accept either "1.3.0" or "v1.3.0" by
-        # stripping any leading "v" and re-adding it.
+        # Replace BOTH sdks/outpost-typescript/ AND spec-sdk-tests/ with the
+        # contents at the SDK release tag. The SDK tag is namespaced
+        # (sdks/outpost-typescript/v<x>) but points at a full repo commit,
+        # so checking out that tag for spec-sdk-tests/ gives us the tests as
+        # they were at SDK release time — guaranteed aligned with the pinned
+        # SDK shape. Without this, main's newer tests would reference SDK
+        # fields the pinned SDK doesn't have, causing TS compile errors.
+        # Accept either "1.3.0" or "v1.3.0" by stripping any leading "v".
         env:
           SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
         run: |
           ver="${SDK_VERSION_INPUT#v}"
           full_tag="sdks/outpost-typescript/v${ver}"
-          echo "Pinning SDK to $full_tag"
+          echo "Pinning SDK + tests to $full_tag"
           git fetch --depth=1 origin "refs/tags/$full_tag:refs/tags/$full_tag"
           rm -rf sdks/outpost-typescript
           git checkout "$full_tag" -- sdks/outpost-typescript
+          rm -rf spec-sdk-tests
+          git checkout "$full_tag" -- spec-sdk-tests
 
       - name: Build TypeScript SDK
         working-directory: sdks/outpost-typescript


### PR DESCRIPTION
## Why

`workflow_dispatch` runs with `sdk_version` set were failing at TS compile. Verified empirically on a dispatch with `sdk_version=1.3.0`:

```
error TS2353: 'type' does not exist in type 'DestinationUpdate'.
```

Root cause: the override pinned `sdks/outpost-typescript/` to the v1.3.0 release tag but left `spec-sdk-tests/` on `main`'s current shape. Tests on `main` reference fields the pinned SDK doesn't have.

## Fix

When `sdk_version` is set, also `git checkout sdks/outpost-typescript/v<x> -- spec-sdk-tests/` so tests come from the same point in time as the SDK. SDK release tags are namespaced but point at full repo commits, so this works.

Bot regen PR case (the workflow's primary purpose) is unchanged: `sdk_version` stays empty, the PR's own SDK and tests are both used, alignment guaranteed by the bot's regen.

Also adds strict `X.Y.Z` validation for both `sdk_version` and `outpost_version` inputs (Copilot review feedback) — typos now produce a clear `::error::` instead of cryptic git refspec failures.

## What we learned about historical SDK releases

Walked every TS SDK release tag and checked tests-at-tag vs SDK-at-tag alignment:

| SDK version | `events.list()` return type | Tests use | Aligned? |
|---|---|---|---|
| v0.7.0, v0.8.0 | `Promise<EventPaginatedResult>` (flat) | `response.models` | ✅ |
| v0.9.0 → v1.3.0 | `Promise<PageIterator<{result: EventPaginatedResult}>>` | `response.models` | ❌ |
| v1.4.0+ (future) | aligned by construction (gated by #925) | — | ✅ |

The break at v0.9.0 was a Speakeasy CLI bump introducing `PageIterator` without anything updating tests to match. Six SDK releases (v0.9.0, v0.9.1, v0.9.2, v0.10.0, v0.10.1, v1.0.0+ through v1.3.0) shipped with tests that couldn't compile against them. Manual AT runs at release time stopped catching this around the same point. This PR + #925 close the loop: no SDK release can merge without `spec-sdk-tests.yml` passing against its regen'd SDK.

## Test plan

- [x] Workflow YAML lints clean.
- [x] Dispatched `sdk_version=1.3.0` + `outpost_version=1.0.3` — reproduces the predicted v1.3.0 alignment bug ([run 26649985084](https://github.com/hookdeck/outpost/actions/runs/26649985084)). Confirms the fix doesn't hide existing breakage.
- [x] Dispatched `sdk_version=0.8.0` + `outpost_version=0.17.2` — **135 passing / 0 failing / 15 pending** ([run 26655324437](https://github.com/hookdeck/outpost/actions/runs/26655324437)). First green run of this workflow ever, validates the mechanism end-to-end against a known-aligned historical pairing.
- [x] Input validation: typos produce `::error::sdk_version must be a strict X.Y.Z version (got: ...)` instead of cryptic git errors.
- [ ] After #929 merges + the bot regen pipeline produces v1.4.0+ SDK, validate the modern-pairing path against a release that's aligned by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)