### PR TITLE
fix(apirouter): log 4xx at Warn, keep 5xx at Error

### DIFF
--- a/internal/apirouter/logger_middleware.go
+++ b/internal/apirouter/logger_middleware.go
@@ -62,7 +62,7 @@ func LoggerMiddlewareWithSanitizer(logger *logging.Logger, sanitizer *RequestBod
 				hub.CaptureException(getErrorWithStackTrace(c.Errors.Last().Err))
 			}
 		case status >= 400:
-			logger.Info("request completed", fields...)
+			logger.Warn("request completed", fields...)
 		default:
 			logger.Debug("request completed", fields...)
 		}


### PR DESCRIPTION
## Summary
- `internal/apirouter/logger_middleware.go`: 4xx responses now log at Warn (was Info). 5xx stays at Error, <400 stays at Debug.

## Test plan
- [x] `go test ./internal/apirouter/...`
- [ ] Eyeball logs locally after `make up` — hit a 404 and a 500, confirm levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)