### PR TITLE
ci(sdk-regen): use SDK_REGEN_GITHUB_PAT for TS regen so downstream CI fires

### DIFF
--- a/.github/workflows/sdk-generate-on-release.yml
+++ b/.github/workflows/sdk-generate-on-release.yml
@@ -65,6 +65,6 @@ jobs:
       pr_base_is_main: true
       set_version: ${{ github.event.inputs.release_tag == 'v1.0.0' && '1.0.0' || '' }}
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.SDK_REGEN_GITHUB_PAT }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
       npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sdk_generation_outpost_ts.yaml
+++ b/.github/workflows/sdk_generation_outpost_ts.yaml
@@ -19,6 +19,6 @@ jobs:
       force: ${{ github.event.inputs.force == 'true' }}
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.SDK_REGEN_GITHUB_PAT }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
       npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #939.

## What

Two-site swap of `secrets.GITHUB_TOKEN` → `secrets.SDK_REGEN_GITHUB_PAT` in the TS SDK regen workflow chain. Go and Python keep `GITHUB_TOKEN` (their bot PRs aren't gated by a TS-only test suite).

| File | Change |
|---|---|
| `.github/workflows/sdk_generation_outpost_ts.yaml` | The standalone TS dispatcher |
| `.github/workflows/sdk-generate-on-release.yml` | Only the `generate-ts` job (Go and Python jobs unchanged) |

## Why

GitHub Actions deliberately suppresses workflow triggers for PRs opened with `GITHUB_TOKEN`. Empirically confirmed today: Go (#935) and Python (#937) v1.4.0 bot PRs merged without `spec-sdk-tests.yml` (#925) or `spec-sdk-tests-vs-release.yml` (#927) firing — the whole point of those workflows was to gate exactly that scenario.

By swapping to a PAT, PR events look like they came from a user and trigger downstream workflows normally.

## Required before merge

Create the `SDK_REGEN_GITHUB_PAT` repo secret. Fine-grained PAT on `hookdeck/outpost` with:
- **Contents**: read + write (push branches)
- **Pull requests**: read + write (open PRs)
- **Workflows**: read + write (in case Speakeasy ever modifies workflow files)

## Test plan

- [ ] PAT secret configured.
- [ ] After this lands, dispatch `sdk_generation_outpost_ts.yaml` and confirm the resulting bot PR triggers `spec-sdk-tests.yml`.
- [ ] Next natural TS regen (post-Outpost-release) also triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)