### PR TITLE
fix(docs-eval): align scenario 02 with TS SDK publish() and surface failing checks

### DIFF
--- a/docs/agent-evaluation/hookdeck-outpost-agent-prompt.md
+++ b/docs/agent-evaluation/hookdeck-outpost-agent-prompt.md
@@ -95,7 +95,7 @@ Use judgment; when two paths seem possible, prefer **Quick path** unless they cl
 - **Go** → **Go quickstart** + official Go SDK as that doc shows.
 - **curl**, **HTTP only**, or **REST** without a language SDK → **curl quickstart** + OpenAPI.
 
-Do **not** mix argument styles across languages (e.g. do not apply TypeScript `publish.event({ ... })` shapes to Python).
+Do **not** mix argument styles across languages (e.g. do not apply TypeScript `outpost.publish({ ... })` shapes to Python).
 
 ### Quick path — how to deliver
 

--- a/docs/agent-evaluation/scenarios/02-basics-typescript.md
+++ b/docs/agent-evaluation/scenarios/02-basics-typescript.md
@@ -32,7 +32,7 @@ Paste the **## Template** block from `[hookdeck-outpost-agent-prompt.mdoc](../..
 **Measurement:** Heuristic `scoreScenario02` in [`src/score-transcript.ts`](../src/score-transcript.ts); LLM judge maps the bullets below ([README.md § Measuring scenarios](../README.md#measuring-scenarios)). Execution row is manual.
 
 - Depends on `@hookdeck/outpost-sdk`; uses `Outpost` client with `apiKey` from `process.env.OUTPOST_API_KEY`.
-- Calls `tenants.upsert`, `destinations.create` (webhook), `publish.event`.
+- Calls `tenants.upsert`, `destinations.create` (webhook), `outpost.publish`.
 - Uses a topic that matches the dashboard list from the prompt (or asks which topic if ambiguous).
 - Webhook URL from `OUTPOST_TEST_WEBHOOK_URL` (or clearly documented env).
 - No API key in source; fails fast if env missing.

--- a/docs/agent-evaluation/src/run-agent-eval.ts
+++ b/docs/agent-evaluation/src/run-agent-eval.ts
@@ -1008,6 +1008,11 @@ Agent cwd is usually the run directory. Scenarios may define ## Eval harness (JS
         );
         if (report.overallTranscriptPass === false) {
           anyScoreFailure = true;
+          for (const c of report.transcript.checks) {
+            if (!c.pass) {
+              console.error(`  [FAIL] ${c.id}: ${c.detail}`);
+            }
+          }
         }
       }
 
@@ -1032,6 +1037,11 @@ Agent cwd is usually the run directory. Scenarios may define ## Eval harness (JS
         );
         if (!llmReport.overall_transcript_pass) {
           anyScoreFailure = true;
+          for (const c of llmReport.criteria) {
+            if (!c.pass) {
+              console.error(`  [FAIL] ${c.criterion}: ${c.evidence}`);
+            }
+          }
         }
       }
 

--- a/docs/agent-evaluation/src/score-transcript.ts
+++ b/docs/agent-evaluation/src/score-transcript.ts
@@ -323,11 +323,13 @@ function scoreScenario02(corpus: string, assistant: string): TranscriptScore {
     detail: dest ? "Calls destinations.create" : "Expected destinations.create",
   });
 
-  const pub = /publish\.event|publish\?\.event/.test(t);
+  // TS SDK >=1.3.0 exposes `outpost.publish(...)` directly. Keep `publish.event`
+  // as a fallback so older transcripts (and stray references in comments) still match.
+  const pub = /\.publish\s*\(|publish\.event|publish\?\.event/.test(t);
   checks.push({
     id: "publish_event",
     pass: pub,
-    detail: pub ? "Calls publish.event" : "Expected publish.event",
+    detail: pub ? "Calls outpost.publish(…) or publish.event" : "Expected outpost.publish(…) or publish.event",
   });
 
   const hookUrl = /OUTPOST_TEST_WEBHOOK_URL/.test(t);

--- a/docs/agent-evaluation/src/transcript-trajectory.ts
+++ b/docs/agent-evaluation/src/transcript-trajectory.ts
@@ -241,7 +241,7 @@ function toolInputWritePath(
 }
 
 const SDK_HINT_PATTERNS: ReadonlyArray<{ id: string; re: RegExp }> = [
-  { id: "ts_publish.event", re: /\bpublish\.event\b/i },
+  { id: "ts_publish", re: /\.publish\s*\(/ },
   { id: "ts_tenants.upsert", re: /\btenants\.upsert\b/i },
   { id: "ts_destinations.create", re: /\bdestinations\.create\b/i },
   { id: "py_publish", re: /\bpublish\.event\b/i },


### PR DESCRIPTION
## Summary

- Heuristic check `publish_event` in `scoreScenario02` was looking for the literal string `publish.event`, which matched the pre-1.3.0 TS SDK shape (`outpost.publish.event(...)`). The SDK regen in #905 (commit d875c662) flattened it to `outpost.publish(...)`, but the eval check, scenario 02 success criterion, and the agent prompt were never updated.
- Prior runs passed only because the agent often echoed `publish.event` from the prompt's prose in a comment — accidentally satisfying a string-presence check. #945 stuck to the current SDK README's wording, so the rescue stopped working and CI exited 1 with no detail in the GH Actions main log.

## Changes

- `src/score-transcript.ts` — `scoreScenario02` regex now matches `.publish(` (current SDK) and still accepts `publish.event` as a fallback for older transcripts.
- `src/run-agent-eval.ts` — on heuristic/LLM `pass=false`, log each failing check id+detail / criterion+evidence to stderr so the CI log surfaces the cause without needing to download the artifact.
- `scenarios/02-basics-typescript.md` — success criterion lists `outpost.publish` instead of `publish.event`.
- `hookdeck-outpost-agent-prompt.md` — TS counter-example uses `outpost.publish({ ... })`.
- `src/transcript-trajectory.ts` — TS SDK hint pattern renamed to `ts_publish` with regex `/\.publish\s*\(/`.

Verified the new regex matches `.publish(` in the failing PR #945 transcript; `npm run typecheck` and `npm run test:trajectory` pass.

## Test plan

- [ ] CI eval slice runs green on this branch.
- [ ] Sanity: re-run PR #945's failing eval against this branch's scorer (the agent transcript on file already contains `.publish(`, so the heuristic now passes).
- [ ] Confirm the log line `[FAIL] <id>: <detail>` appears in the GH Actions main log if a future heuristic check fails (cosmetic — only triggers on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)