### PR TITLE
fix: handle duplicate log messages idempotently

### DIFF
--- a/internal/alert/monitor.go
+++ b/internal/alert/monitor.go
@@ -146,11 +146,25 @@ func (m *alertMonitor) HandleAttempt(ctx context.Context, attempt DeliveryAttemp
 	}
 
 	// Consecutive failure tracking
-	count, err := m.store.IncrementConsecutiveFailureCount(ctx, attempt.Destination.TenantID, attempt.Destination.ID, attempt.Attempt.ID)
+	res, err := m.store.IncrementConsecutiveFailureCount(ctx, attempt.Destination.TenantID, attempt.Destination.ID, attempt.Attempt.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get alert state: %w", err)
 	}
 
+	// Replayed attempt (MQ redelivery, producer re-publish) that already
+	// completed a full evaluation — skip re-emitting alerts. Attempts that
+	// were counted but never marked evaluated (eval failed mid-way and the
+	// message was nacked) fall through and re-run as recovery.
+	if !res.NewlyCounted && res.AlreadyEvaluated {
+		m.logger.Ctx(ctx).Debug("skipping replayed attempt: already evaluated",
+			zap.String("attempt_id", attempt.Attempt.ID),
+			zap.String("tenant_id", attempt.Destination.TenantID),
+			zap.String("destination_id", attempt.Destination.ID),
+		)
+		return nil
+	}
+
+	count := res.Count
 	level, shouldAlert := m.evaluator.ShouldAlert(count)
 	if shouldAlert {
 		// At 100% threshold, disable the destination and emit disabled alert.
@@ -247,6 +261,18 @@ func (m *alertMonitor) HandleAttempt(ctx context.Context, attempt DeliveryAttemp
 				return fmt.Errorf("failed to emit exhausted retries alert: %w", err)
 			}
 		}
+	}
+
+	// Mark the attempt fully evaluated so replays skip re-emitting alerts.
+	// Non-fatal: on failure the attempt simply re-evaluates on replay, which
+	// matches the previous behavior (emit/disable are idempotent-by-design).
+	if err := m.store.MarkAttemptEvaluated(ctx, attempt.Destination.TenantID, attempt.Destination.ID, attempt.Attempt.ID); err != nil {
+		m.logger.Ctx(ctx).Warn("failed to mark attempt evaluated",
+			zap.Error(err),
+			zap.String("attempt_id", attempt.Attempt.ID),
+			zap.String("tenant_id", attempt.Destination.TenantID),
+			zap.String("destination_id", attempt.Destination.ID),
+		)
 	}
 
 	return nil

--- a/internal/alert/monitor_test.go
+++ b/internal/alert/monitor_test.go
@@ -504,6 +504,93 @@ func TestAlertMonitor_ExhaustedRetries_EmitFailureRetryClearsWindow(t *testing.T
 	require.Equal(t, 2, erCalls, "Should have 2 emit attempts (1 failed + 1 succeeded)")
 }
 
+func TestAlertMonitor_ReplayedAttempt_SkipsEvaluation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := testutil.CreateTestLogger(t)
+	redisClient := testutil.CreateTestRedisClient(t)
+	emitter := &mockAlertEmitter{}
+	emitter.On("Emit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	monitor := alert.NewAlertMonitor(
+		logger,
+		redisClient,
+		emitter,
+		10,
+		alert.WithAutoDisableFailureCount(2),
+		alert.WithAlertThresholds([]int{50, 100}),
+	)
+
+	dest := &alert.AlertDestination{ID: "dest_replay", TenantID: "tenant_replay"}
+	event := &models.Event{Topic: "test.event"}
+	attempt := alert.DeliveryAttempt{
+		Event:       event,
+		Destination: dest,
+		Attempt: &models.Attempt{
+			ID:     "att_replay_1",
+			Status: "failed",
+			Code:   "500",
+			Time:   time.Now(),
+		},
+	}
+
+	// First delivery: count=1 → 50% threshold → emits
+	require.NoError(t, monitor.HandleAttempt(ctx, attempt))
+	require.Equal(t, 1, countEmitCalls(emitter, "alert.destination.consecutive_failure"))
+
+	// Replay (MQ redelivery / producer re-publish): fully evaluated → skipped
+	require.NoError(t, monitor.HandleAttempt(ctx, attempt))
+	assert.Equal(t, 1, countEmitCalls(emitter, "alert.destination.consecutive_failure"),
+		"replayed attempt should not re-emit the alert")
+}
+
+func TestAlertMonitor_ReplayedAttempt_PartialFailureRetries(t *testing.T) {
+	// When evaluation fails after the attempt was counted (e.g. emit error),
+	// the message is nacked and redelivered — the replay must re-run the
+	// evaluation, not skip it, or alerts would be silently dropped.
+	t.Parallel()
+	ctx := context.Background()
+	logger := testutil.CreateTestLogger(t)
+	redisClient := testutil.CreateTestRedisClient(t)
+	emitter := &mockAlertEmitter{}
+	emitter.On("Emit", mock.Anything, "alert.destination.consecutive_failure", mock.Anything, mock.Anything).Return(fmt.Errorf("emit failed")).Once()
+	emitter.On("Emit", mock.Anything, "alert.destination.consecutive_failure", mock.Anything, mock.Anything).Return(nil)
+
+	monitor := alert.NewAlertMonitor(
+		logger,
+		redisClient,
+		emitter,
+		10,
+		alert.WithAutoDisableFailureCount(2),
+		alert.WithAlertThresholds([]int{50, 100}),
+	)
+
+	dest := &alert.AlertDestination{ID: "dest_partial", TenantID: "tenant_partial"}
+	event := &models.Event{Topic: "test.event"}
+	attempt := alert.DeliveryAttempt{
+		Event:       event,
+		Destination: dest,
+		Attempt: &models.Attempt{
+			ID:     "att_partial_1",
+			Status: "failed",
+			Code:   "500",
+			Time:   time.Now(),
+		},
+	}
+
+	// First delivery: counted, but emit fails → error (entry would be nacked)
+	require.Error(t, monitor.HandleAttempt(ctx, attempt))
+
+	// Replay: not marked evaluated → re-runs and emits successfully
+	require.NoError(t, monitor.HandleAttempt(ctx, attempt))
+	assert.Equal(t, 2, countEmitCalls(emitter, "alert.destination.consecutive_failure"),
+		"replay after partial failure should re-run evaluation")
+
+	// Second replay: now fully evaluated → skipped
+	require.NoError(t, monitor.HandleAttempt(ctx, attempt))
+	assert.Equal(t, 2, countEmitCalls(emitter, "alert.destination.consecutive_failure"))
+}
+
 func countEmitCalls(emitter *mockAlertEmitter, topic string) int {
 	count := 0
 	for _, call := range emitter.Calls {

--- a/internal/alert/store.go
+++ b/internal/alert/store.go
@@ -9,13 +9,27 @@ import (
 )
 
 const (
-	keyPrefixAlert = "alert" // Base prefix for all alert keys
-	keyFailures    = "cf"    // Set for consecutive failure attempt IDs
+	keyPrefixAlert = "alert"  // Base prefix for all alert keys
+	keyFailures    = "cf"     // Set for consecutive failure attempt IDs
+	keyEvaluated   = "cfeval" // Set for fully evaluated attempt IDs
+	alertKeyTTL    = 24 * time.Hour
 )
+
+// FailureCountResult reports the state of consecutive-failure tracking
+// after recording an attempt.
+type FailureCountResult struct {
+	Count            int  // current consecutive failure count
+	NewlyCounted     bool // attempt was not previously counted (first delivery of this attempt)
+	AlreadyEvaluated bool // attempt was fully evaluated before (marked via MarkAttemptEvaluated)
+}
 
 // AlertStore manages alert-related data persistence
 type AlertStore interface {
-	IncrementConsecutiveFailureCount(ctx context.Context, tenantID, destinationID, attemptID string) (int, error)
+	IncrementConsecutiveFailureCount(ctx context.Context, tenantID, destinationID, attemptID string) (FailureCountResult, error)
+	// MarkAttemptEvaluated records that an attempt's alert evaluation fully
+	// completed, so replays (MQ redelivery, producer re-publish) can skip
+	// re-evaluating it.
+	MarkAttemptEvaluated(ctx context.Context, tenantID, destinationID, attemptID string) error
 	ResetConsecutiveFailureCount(ctx context.Context, tenantID, destinationID string) error
 }
 
@@ -32,32 +46,60 @@ func NewRedisAlertStore(client redis.Cmdable, deploymentID string) AlertStore {
 	}
 }
 
-func (s *redisAlertStore) IncrementConsecutiveFailureCount(ctx context.Context, tenantID, destinationID, attemptID string) (int, error) {
+func (s *redisAlertStore) IncrementConsecutiveFailureCount(ctx context.Context, tenantID, destinationID, attemptID string) (FailureCountResult, error) {
 	key := s.getFailuresKey(destinationID)
 
 	// Use a transaction to ensure atomicity between SADD, SCARD, and EXPIRE operations.
 	// SADD is idempotent — adding the same attemptID on replay is a no-op,
 	// preventing double-counting when messages are redelivered.
 	pipe := s.client.TxPipeline()
-	pipe.SAdd(ctx, key, attemptID)
+	saddCmd := pipe.SAdd(ctx, key, attemptID)
 	scardCmd := pipe.SCard(ctx, key)
-	pipe.Expire(ctx, key, 24*time.Hour)
+	evaluatedCmd := pipe.SIsMember(ctx, s.getEvaluatedKey(destinationID), attemptID)
+	pipe.Expire(ctx, key, alertKeyTTL)
 
 	_, err := pipe.Exec(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("failed to execute consecutive failure count transaction: %w", err)
+		return FailureCountResult{}, fmt.Errorf("failed to execute consecutive failure count transaction: %w", err)
+	}
+
+	added, err := saddCmd.Result()
+	if err != nil {
+		return FailureCountResult{}, fmt.Errorf("failed to record attempt: %w", err)
 	}
 
 	count, err := scardCmd.Result()
 	if err != nil {
-		return 0, fmt.Errorf("failed to get consecutive failure count: %w", err)
+		return FailureCountResult{}, fmt.Errorf("failed to get consecutive failure count: %w", err)
 	}
 
-	return int(count), nil
+	evaluated, err := evaluatedCmd.Result()
+	if err != nil {
+		return FailureCountResult{}, fmt.Errorf("failed to check evaluated state: %w", err)
+	}
+
+	return FailureCountResult{
+		Count:            int(count),
+		NewlyCounted:     added == 1,
+		AlreadyEvaluated: evaluated,
+	}, nil
+}
+
+func (s *redisAlertStore) MarkAttemptEvaluated(ctx context.Context, tenantID, destinationID, attemptID string) error {
+	key := s.getEvaluatedKey(destinationID)
+
+	pipe := s.client.TxPipeline()
+	pipe.SAdd(ctx, key, attemptID)
+	pipe.Expire(ctx, key, alertKeyTTL)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("failed to mark attempt evaluated: %w", err)
+	}
+	return nil
 }
 
 func (s *redisAlertStore) ResetConsecutiveFailureCount(ctx context.Context, tenantID, destinationID string) error {
-	return s.client.Del(ctx, s.getFailuresKey(destinationID)).Err()
+	return s.client.Del(ctx, s.getFailuresKey(destinationID), s.getEvaluatedKey(destinationID)).Err()
 }
 
 func (s *redisAlertStore) deploymentPrefix() string {
@@ -69,4 +111,8 @@ func (s *redisAlertStore) deploymentPrefix() string {
 
 func (s *redisAlertStore) getFailuresKey(destinationID string) string {
 	return fmt.Sprintf("%s%s:%s:%s", s.deploymentPrefix(), keyPrefixAlert, destinationID, keyFailures)
+}
+
+func (s *redisAlertStore) getEvaluatedKey(destinationID string) string {
+	return fmt.Sprintf("%s%s:%s:%s", s.deploymentPrefix(), keyPrefixAlert, destinationID, keyEvaluated)
 }

--- a/internal/alert/store_test.go
+++ b/internal/alert/store_test.go
@@ -19,14 +19,16 @@ func TestRedisAlertStore(t *testing.T) {
 		store := alert.NewRedisAlertStore(redisClient, "")
 
 		// First increment
-		count, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_1")
+		res, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_1")
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Equal(t, 1, res.Count)
+		assert.True(t, res.NewlyCounted)
 
 		// Second increment (different attempt)
-		count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_2")
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_2")
 		require.NoError(t, err)
-		assert.Equal(t, 2, count)
+		assert.Equal(t, 2, res.Count)
+		assert.True(t, res.NewlyCounted)
 	})
 
 	t.Run("reset consecutive failures", func(t *testing.T) {
@@ -35,18 +37,18 @@ func TestRedisAlertStore(t *testing.T) {
 		store := alert.NewRedisAlertStore(redisClient, "")
 
 		// Set up initial failures
-		count, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_2", "dest_2", "att_1")
+		res, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_2", "dest_2", "att_1")
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Equal(t, 1, res.Count)
 
 		// Reset failures
 		err = store.ResetConsecutiveFailureCount(context.Background(), "tenant_2", "dest_2")
 		require.NoError(t, err)
 
 		// Verify counter is reset by incrementing again
-		count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_2", "dest_2", "att_2")
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_2", "dest_2", "att_2")
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Equal(t, 1, res.Count)
 	})
 
 	t.Run("idempotent on replay", func(t *testing.T) {
@@ -55,24 +57,79 @@ func TestRedisAlertStore(t *testing.T) {
 		store := alert.NewRedisAlertStore(redisClient, "")
 
 		// First call
-		count, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_1")
+		res, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_1")
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Equal(t, 1, res.Count)
+		assert.True(t, res.NewlyCounted)
 
 		// Replay same attempt — count should not change
-		count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_1")
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_1")
 		require.NoError(t, err)
-		assert.Equal(t, 1, count, "replaying the same attemptID should not increment the count")
+		assert.Equal(t, 1, res.Count, "replaying the same attemptID should not increment the count")
+		assert.False(t, res.NewlyCounted, "replayed attemptID should not be newly counted")
 
 		// Different attempt should still increment
-		count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_2")
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_2")
 		require.NoError(t, err)
-		assert.Equal(t, 2, count)
+		assert.Equal(t, 2, res.Count)
+		assert.True(t, res.NewlyCounted)
 
 		// Replay the second attempt — count should not change
-		count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_2")
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_3", "dest_3", "att_2")
 		require.NoError(t, err)
-		assert.Equal(t, 2, count, "replaying the same attemptID should not increment the count")
+		assert.Equal(t, 2, res.Count, "replaying the same attemptID should not increment the count")
+		assert.False(t, res.NewlyCounted)
+	})
+
+	t.Run("mark attempt evaluated", func(t *testing.T) {
+		t.Parallel()
+		redisClient := testutil.CreateTestRedisClient(t)
+		store := alert.NewRedisAlertStore(redisClient, "")
+
+		// Counted but not yet evaluated
+		res, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_4", "dest_4", "att_1")
+		require.NoError(t, err)
+		assert.False(t, res.AlreadyEvaluated, "attempt should not be evaluated before MarkAttemptEvaluated")
+
+		// Replay before marking — still not evaluated (partial-failure recovery path)
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_4", "dest_4", "att_1")
+		require.NoError(t, err)
+		assert.False(t, res.NewlyCounted)
+		assert.False(t, res.AlreadyEvaluated)
+
+		// Mark evaluated
+		err = store.MarkAttemptEvaluated(context.Background(), "tenant_4", "dest_4", "att_1")
+		require.NoError(t, err)
+
+		// Replay after marking — evaluated
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_4", "dest_4", "att_1")
+		require.NoError(t, err)
+		assert.False(t, res.NewlyCounted)
+		assert.True(t, res.AlreadyEvaluated, "attempt should be evaluated after MarkAttemptEvaluated")
+
+		// Other attempts unaffected
+		res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_4", "dest_4", "att_2")
+		require.NoError(t, err)
+		assert.True(t, res.NewlyCounted)
+		assert.False(t, res.AlreadyEvaluated)
+	})
+
+	t.Run("reset clears evaluated markers", func(t *testing.T) {
+		t.Parallel()
+		redisClient := testutil.CreateTestRedisClient(t)
+		store := alert.NewRedisAlertStore(redisClient, "")
+
+		_, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_5", "dest_5", "att_1")
+		require.NoError(t, err)
+		require.NoError(t, store.MarkAttemptEvaluated(context.Background(), "tenant_5", "dest_5", "att_1"))
+
+		err = store.ResetConsecutiveFailureCount(context.Background(), "tenant_5", "dest_5")
+		require.NoError(t, err)
+
+		res, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_5", "dest_5", "att_1")
+		require.NoError(t, err)
+		assert.True(t, res.NewlyCounted)
+		assert.False(t, res.AlreadyEvaluated, "reset should clear evaluated markers")
 	})
 }
 
@@ -83,23 +140,23 @@ func TestRedisAlertStore_WithDeploymentID(t *testing.T) {
 	store := alert.NewRedisAlertStore(redisClient, "dp_test_001")
 
 	// Test increment with deployment ID
-	count, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_1")
+	res, err := store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_1")
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 1, res.Count)
 
 	// Second increment
-	count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_2")
+	res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_2")
 	require.NoError(t, err)
-	assert.Equal(t, 2, count)
+	assert.Equal(t, 2, res.Count)
 
 	// Test reset with deployment ID
 	err = store.ResetConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1")
 	require.NoError(t, err)
 
 	// Verify counter is reset
-	count, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_3")
+	res, err = store.IncrementConsecutiveFailureCount(context.Background(), "tenant_1", "dest_1", "att_3")
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 1, res.Count)
 }
 
 func TestAlertStoreIsolation(t *testing.T) {
@@ -116,35 +173,41 @@ func TestAlertStoreIsolation(t *testing.T) {
 	destinationID := "dest_shared"
 
 	// Increment in store1
-	count1, err := store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_1")
+	res1, err := store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_1")
 	require.NoError(t, err)
-	assert.Equal(t, 1, count1)
+	assert.Equal(t, 1, res1.Count)
 
-	count1, err = store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_2")
+	res1, err = store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_2")
 	require.NoError(t, err)
-	assert.Equal(t, 2, count1)
+	assert.Equal(t, 2, res1.Count)
 
 	// Increment in store2 - should start at 1 (isolated from store1)
-	count2, err := store2.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_1")
+	res2, err := store2.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_1")
 	require.NoError(t, err)
-	assert.Equal(t, 1, count2, "Store 2 should have its own counter")
+	assert.Equal(t, 1, res2.Count, "Store 2 should have its own counter")
+
+	// Evaluated markers are isolated too
+	require.NoError(t, store1.MarkAttemptEvaluated(context.Background(), tenantID, destinationID, "att_1"))
+	res2, err = store2.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_1")
+	require.NoError(t, err)
+	assert.False(t, res2.AlreadyEvaluated, "Store 2 should not see store 1's evaluated marker")
 
 	// Increment store1 again - should continue from 2
-	count1, err = store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_3")
+	res1, err = store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_3")
 	require.NoError(t, err)
-	assert.Equal(t, 3, count1, "Store 1 counter should be unaffected by store 2")
+	assert.Equal(t, 3, res1.Count, "Store 1 counter should be unaffected by store 2")
 
 	// Reset store1 - should not affect store2
 	err = store1.ResetConsecutiveFailureCount(context.Background(), tenantID, destinationID)
 	require.NoError(t, err)
 
 	// Verify store1 is reset
-	count1, err = store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_4")
+	res1, err = store1.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_4")
 	require.NoError(t, err)
-	assert.Equal(t, 1, count1, "Store 1 should be reset")
+	assert.Equal(t, 1, res1.Count, "Store 1 should be reset")
 
 	// Verify store2 is unaffected
-	count2, err = store2.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_2")
+	res2, err = store2.IncrementConsecutiveFailureCount(context.Background(), tenantID, destinationID, "att_2")
 	require.NoError(t, err)
-	assert.Equal(t, 2, count2, "Store 2 should be unaffected by store 1 reset")
+	assert.Equal(t, 2, res2.Count, "Store 2 should be unaffected by store 1 reset")
 }

--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -84,6 +84,7 @@ func (bp *BatchProcessor) processBatch(_ string, msgs []*mqs.Message) {
 
 	entries := make([]*models.LogEntry, 0, len(msgs))
 	validMsgs := make([]*mqs.Message, 0, len(msgs))
+	seenAttempts := make(map[string]struct{}, len(msgs))
 
 	for _, msg := range msgs {
 		entry := &models.LogEntry{}
@@ -115,6 +116,22 @@ func (bp *BatchProcessor) processBatch(_ string, msgs []*mqs.Message) {
 			msg.Nack()
 			continue
 		}
+
+		// Dedup duplicate copies of the same attempt within the batch
+		// (at-least-once redelivery, producer re-publish — possibly under
+		// different MQ message IDs). Copies are byte-identical, so the
+		// duplicate is acked immediately; the at-least-once guarantee rides
+		// on the kept copy, which stays un-acked until persisted.
+		if _, ok := seenAttempts[entry.Attempt.ID]; ok {
+			logger.Debug("duplicate log entry in batch",
+				zap.String("message_id", msg.LoggableID),
+				zap.String("attempt_id", entry.Attempt.ID),
+				zap.String("event_id", entry.Event.ID),
+				zap.String("tenant_id", entry.Event.TenantID))
+			msg.Ack()
+			continue
+		}
+		seenAttempts[entry.Attempt.ID] = struct{}{}
 
 		logger.Debug("added to batch",
 			zap.String("message_id", msg.LoggableID),

--- a/internal/logmq/batchprocessor_test.go
+++ b/internal/logmq/batchprocessor_test.go
@@ -229,6 +229,60 @@ func TestBatchProcessor_InvalidEntry_DoesNotBlockBatch(t *testing.T) {
 	assert.Len(t, attempts, 2, "only 2 valid attempts should be inserted")
 }
 
+func TestBatchProcessor_DuplicateMessages(t *testing.T) {
+	ctx := context.Background()
+	logger := testutil.CreateTestLogger(t)
+	logStore := &mockLogStore{}
+	alertMon := &mockAlertMonitor{}
+
+	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, alertMon, logmq.BatchProcessorConfig{
+		ItemCountThreshold: 3, // Wait for 3 messages before processing
+		DelayThreshold:     1 * time.Second,
+	})
+	require.NoError(t, err)
+	defer bp.Shutdown()
+
+	// Two byte-identical copies of the same entry (redelivery / re-publish)
+	event := testutil.EventFactory.Any()
+	attempt := testutil.AttemptFactory.Any()
+	dest := testutil.DestinationFactory.Any()
+	entry := models.LogEntry{Event: &event, Attempt: &attempt, Destination: &dest}
+	mock1, msg1 := newMockMessage(entry)
+	mock2, msg2 := newMockMessage(entry)
+
+	// One distinct entry
+	otherEvent := testutil.EventFactory.Any()
+	otherAttempt := testutil.AttemptFactory.Any()
+	otherDest := testutil.DestinationFactory.Any()
+	otherEntry := models.LogEntry{Event: &otherEvent, Attempt: &otherAttempt, Destination: &otherDest}
+	mock3, msg3 := newMockMessage(otherEntry)
+
+	require.NoError(t, bp.Add(ctx, msg1))
+	require.NoError(t, bp.Add(ctx, msg2))
+	require.NoError(t, bp.Add(ctx, msg3))
+
+	// Wait for batch to process
+	time.Sleep(200 * time.Millisecond)
+
+	// All copies acked, none nacked
+	assert.True(t, mock1.acked, "kept copy should be acked")
+	assert.False(t, mock1.nacked)
+	assert.True(t, mock2.acked, "duplicate copy should be acked")
+	assert.False(t, mock2.nacked)
+	assert.True(t, mock3.acked, "distinct message should be acked")
+	assert.False(t, mock3.nacked)
+
+	// Duplicate inserted once
+	_, attempts := logStore.getInserted()
+	require.Len(t, attempts, 2, "duplicate should be inserted once")
+	attemptIDs := []string{attempts[0].ID, attempts[1].ID}
+	assert.ElementsMatch(t, []string{attempt.ID, otherAttempt.ID}, attemptIDs)
+
+	// Alert eval once per unique attempt
+	calls := alertMon.getCalls()
+	require.Len(t, calls, 2, "alert eval should run once per unique attempt")
+}
+
 func TestBatchProcessor_MalformedJSON(t *testing.T) {
 	ctx := context.Background()
 	logger := testutil.CreateTestLogger(t)

--- a/internal/logstore/chlogstore/chlogstore.go
+++ b/internal/logstore/chlogstore/chlogstore.go
@@ -766,6 +766,11 @@ func (s *logStoreImpl) InsertMany(ctx context.Context, entries []*models.LogEntr
 		return nil
 	}
 
+	// Collapse intra-batch duplicates. ReplacingMergeTree would eventually
+	// merge them away, but redundant rows cost merge overhead and surface as
+	// transient duplicate reads until compaction runs.
+	entries = driver.DedupeEntriesByAttemptID(entries)
+
 	// Extract and dedupe events by ID, skipping retry attempts.
 	// Retries (AttemptNumber > 1) carry identical event data — the event row
 	// already exists from the first attempt's batch.

--- a/internal/logstore/driver/driver.go
+++ b/internal/logstore/driver/driver.go
@@ -83,3 +83,24 @@ type AttemptRecord struct {
 	Attempt *models.Attempt
 	Event   *models.Event // optionally populated for query results
 }
+
+// DedupeEntriesByAttemptID collapses intra-batch duplicates (same Attempt.ID)
+// to a single entry. Duplicates arise from MQ redelivery and producer
+// re-publish, so they can carry different MQ message IDs; copies are
+// byte-identical, so the last occurrence wins at the first occurrence's
+// position. InsertMany implementations must tolerate intra-batch duplicates
+// regardless of caller — e.g. PostgreSQL rejects the same conflict key twice
+// in one INSERT ... ON CONFLICT DO UPDATE statement (SQLSTATE 21000).
+func DedupeEntriesByAttemptID(entries []*models.LogEntry) []*models.LogEntry {
+	deduped := make([]*models.LogEntry, 0, len(entries))
+	index := make(map[string]int, len(entries))
+	for _, entry := range entries {
+		if i, ok := index[entry.Attempt.ID]; ok {
+			deduped[i] = entry
+			continue
+		}
+		index[entry.Attempt.ID] = len(deduped)
+		deduped = append(deduped, entry)
+	}
+	return deduped
+}

--- a/internal/logstore/drivertest/crud.go
+++ b/internal/logstore/drivertest/crud.go
@@ -146,6 +146,72 @@ func testCRUD(t *testing.T, newHarness HarnessMaker) {
 			err := logStore.InsertMany(ctx, []*models.LogEntry{})
 			require.NoError(t, err)
 		})
+
+		t.Run("duplicate entries in batch", func(t *testing.T) {
+			// Duplicates arise from MQ redelivery and producer re-publish;
+			// InsertMany must tolerate intra-batch duplicates (same Attempt.ID)
+			// without error and persist a single attempt row.
+			// Isolated tenant so shared filter counts above stay intact.
+			dupTenantID := idgen.String()
+			destID := idgen.Destination()
+
+			event := testutil.EventFactory.AnyPointer(
+				testutil.EventFactory.WithID("dup_evt"),
+				testutil.EventFactory.WithTenantID(dupTenantID),
+				testutil.EventFactory.WithDestinationID(destID),
+				testutil.EventFactory.WithMatchedDestinationIDs([]string{destID}),
+				testutil.EventFactory.WithTime(baseTime.Add(-10*time.Minute)),
+			)
+			delivery := testutil.AttemptFactory.AnyPointer(
+				testutil.AttemptFactory.WithID("dup_del"),
+				testutil.AttemptFactory.WithTenantID(dupTenantID),
+				testutil.AttemptFactory.WithEventID(event.ID),
+				testutil.AttemptFactory.WithDestinationID(destID),
+				testutil.AttemptFactory.WithStatus("failed"),
+				testutil.AttemptFactory.WithTime(baseTime.Add(-10*time.Minute)),
+			)
+			otherEvent := testutil.EventFactory.AnyPointer(
+				testutil.EventFactory.WithID("dup_evt_other"),
+				testutil.EventFactory.WithTenantID(dupTenantID),
+				testutil.EventFactory.WithDestinationID(destID),
+				testutil.EventFactory.WithMatchedDestinationIDs([]string{destID}),
+				testutil.EventFactory.WithTime(baseTime.Add(-9*time.Minute)),
+			)
+			otherDelivery := testutil.AttemptFactory.AnyPointer(
+				testutil.AttemptFactory.WithID("dup_del_other"),
+				testutil.AttemptFactory.WithTenantID(dupTenantID),
+				testutil.AttemptFactory.WithEventID(otherEvent.ID),
+				testutil.AttemptFactory.WithDestinationID(destID),
+				testutil.AttemptFactory.WithStatus("success"),
+				testutil.AttemptFactory.WithTime(baseTime.Add(-9*time.Minute)),
+			)
+
+			err := logStore.InsertMany(ctx, []*models.LogEntry{
+				{Event: event, Attempt: delivery},
+				{Event: otherEvent, Attempt: otherDelivery},
+				{Event: event, Attempt: delivery}, // duplicate copy
+			})
+			require.NoError(t, err)
+			require.NoError(t, h.FlushWrites(ctx))
+
+			response, err := logStore.ListAttempt(ctx, driver.ListAttemptRequest{
+				TenantIDs:  []string{dupTenantID},
+				Limit:      10,
+				TimeFilter: driver.TimeFilter{GTE: &startTime},
+			})
+			require.NoError(t, err)
+			require.Len(t, response.Data, 2, "duplicate entry should persist a single attempt row")
+
+			dupResponse, err := logStore.ListAttempt(ctx, driver.ListAttemptRequest{
+				TenantIDs:  []string{dupTenantID},
+				EventIDs:   []string{event.ID},
+				Limit:      10,
+				TimeFilter: driver.TimeFilter{GTE: &startTime},
+			})
+			require.NoError(t, err)
+			require.Len(t, dupResponse.Data, 1)
+			assert.Equal(t, delivery.ID, dupResponse.Data[0].Attempt.ID)
+		})
 	})
 
 	t.Run("list filters", func(t *testing.T) {

--- a/internal/logstore/pglogstore/pglogstore.go
+++ b/internal/logstore/pglogstore/pglogstore.go
@@ -718,6 +718,11 @@ func (s *logStore) InsertMany(ctx context.Context, entries []*models.LogEntry) e
 		return nil
 	}
 
+	// Collapse intra-batch duplicates: the attempts INSERT below uses
+	// ON CONFLICT DO UPDATE, which Postgres rejects when the same (time, id)
+	// appears twice in one statement (SQLSTATE 21000).
+	entries = driver.DedupeEntriesByAttemptID(entries)
+
 	// Extract and dedupe events by ID, skipping retry attempts.
 	// Retries (AttemptNumber > 1) carry identical event data — the event row
 	// already exists from the first attempt's batch.


### PR DESCRIPTION
Handles at-least-once duplicates landing in the same logmq batch, which previously failed the whole batch in pglogstore (`ON CONFLICT DO UPDATE` rejects the same key twice in one statement, SQLSTATE 21000) and re-ran alert evaluation once per copy — the root cause of #946. Fixes #947.

Dedup keys on `Attempt.ID` at three layers: the batch processor drops duplicate copies while parsing, `InsertMany` tolerates intra-batch duplicates as part of the driver contract (new drivertest conformance case), and the alert monitor skips replayed attempts only once a full evaluation has succeeded — partial failures still re-run on redelivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)