### PR TITLE
fix(agent-eval): bump LLM-judge default model off EOL claude-sonnet-4

### DIFF
--- a/docs/agent-evaluation/.env.example
+++ b/docs/agent-evaluation/.env.example
@@ -36,4 +36,4 @@ EVAL_TEST_DESTINATION_URL=
 # Scoring is ON by default after each scenario (heuristic + LLM). Opt out:
 # EVAL_NO_SCORE_HEURISTIC=1
 # EVAL_NO_SCORE_LLM=1
-# EVAL_SCORE_MODEL=claude-sonnet-4-20250514
+# EVAL_SCORE_MODEL=claude-sonnet-4-6

--- a/docs/agent-evaluation/src/llm-judge.ts
+++ b/docs/agent-evaluation/src/llm-judge.ts
@@ -8,7 +8,7 @@ import { basename, dirname, join } from "node:path";
 import { extractTranscriptScoringText } from "./score-transcript.js";
 
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
-const DEFAULT_SCORE_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_SCORE_MODEL = "claude-sonnet-4-6";
 const MAX_TRANSCRIPT_CHARS = 180_000;
 
 export interface LlmCriterionJudgment {

--- a/docs/agent-evaluation/src/score-eval.ts
+++ b/docs/agent-evaluation/src/score-eval.ts
@@ -60,7 +60,7 @@ Score an eval transcript.
   npm run score -- --llm [--write]      # Anthropic judge (needs ANTHROPIC_API_KEY)
   npm run score -- --llm --no-heuristic # LLM only (no regex heuristic)
 
-Heuristic: src/score-transcript.ts. LLM: reads scenarios/*.md Success criteria + assistant text; model from EVAL_SCORE_MODEL (default claude-sonnet-4-20250514).
+Heuristic: src/score-transcript.ts. LLM: reads scenarios/*.md Success criteria + assistant text; model from EVAL_SCORE_MODEL (default claude-sonnet-4-6).
 
 Options:
   --run <path>      transcript.json, a run directory, or legacy flat *-scenario-NN.json


### PR DESCRIPTION
## What

The agent-evaluation LLM-judge defaulted to `claude-sonnet-4-20250514`, which is deprecated and now returns `404 not_found_error`. CI doesn't set `EVAL_SCORE_MODEL`, so it fell back to the dead default and every scenario failed:

```
Eval scenario failed (01-basics-curl.md): Error: Anthropic API 404: {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

## Change

Bump the default to `claude-sonnet-4-6` in:
- `src/llm-judge.ts` — the actual `DEFAULT_SCORE_MODEL`
- `.env.example` — commented example
- `src/score-eval.ts` — help text

Still overridable via `EVAL_SCORE_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)