### PR TITLE
fix(alert): tenant-scope alert keys to prevent cross-tenant collisions

### DIFF
--- a/internal/alert/store.go
+++ b/internal/alert/store.go
@@ -47,7 +47,7 @@ func NewRedisAlertStore(client redis.Cmdable, deploymentID string) AlertStore {
 }
 
 func (s *redisAlertStore) IncrementConsecutiveFailureCount(ctx context.Context, tenantID, destinationID, attemptID string) (FailureCountResult, error) {
-	key := s.getFailuresKey(destinationID)
+	key := s.getFailuresKey(tenantID, destinationID)
 
 	// Use a transaction to ensure atomicity between SADD, SCARD, and EXPIRE operations.
 	// SADD is idempotent — adding the same attemptID on replay is a no-op,
@@ -55,7 +55,7 @@ func (s *redisAlertStore) IncrementConsecutiveFailureCount(ctx context.Context, 
 	pipe := s.client.TxPipeline()
 	saddCmd := pipe.SAdd(ctx, key, attemptID)
 	scardCmd := pipe.SCard(ctx, key)
-	evaluatedCmd := pipe.SIsMember(ctx, s.getEvaluatedKey(destinationID), attemptID)
+	evaluatedCmd := pipe.SIsMember(ctx, s.getEvaluatedKey(tenantID, destinationID), attemptID)
 	pipe.Expire(ctx, key, alertKeyTTL)
 
 	_, err := pipe.Exec(ctx)
@@ -86,7 +86,7 @@ func (s *redisAlertStore) IncrementConsecutiveFailureCount(ctx context.Context, 
 }
 
 func (s *redisAlertStore) MarkAttemptEvaluated(ctx context.Context, tenantID, destinationID, attemptID string) error {
-	key := s.getEvaluatedKey(destinationID)
+	key := s.getEvaluatedKey(tenantID, destinationID)
 
 	pipe := s.client.TxPipeline()
 	pipe.SAdd(ctx, key, attemptID)
@@ -99,7 +99,7 @@ func (s *redisAlertStore) MarkAttemptEvaluated(ctx context.Context, tenantID, de
 }
 
 func (s *redisAlertStore) ResetConsecutiveFailureCount(ctx context.Context, tenantID, destinationID string) error {
-	return s.client.Del(ctx, s.getFailuresKey(destinationID), s.getEvaluatedKey(destinationID)).Err()
+	return s.client.Del(ctx, s.getFailuresKey(tenantID, destinationID), s.getEvaluatedKey(tenantID, destinationID)).Err()
 }
 
 func (s *redisAlertStore) deploymentPrefix() string {
@@ -109,10 +109,10 @@ func (s *redisAlertStore) deploymentPrefix() string {
 	return fmt.Sprintf("%s:", s.deploymentID)
 }
 
-func (s *redisAlertStore) getFailuresKey(destinationID string) string {
-	return fmt.Sprintf("%s%s:%s:%s", s.deploymentPrefix(), keyPrefixAlert, destinationID, keyFailures)
+func (s *redisAlertStore) getFailuresKey(tenantID, destinationID string) string {
+	return fmt.Sprintf("%s%s:%s:%s:%s", s.deploymentPrefix(), keyPrefixAlert, tenantID, destinationID, keyFailures)
 }
 
-func (s *redisAlertStore) getEvaluatedKey(destinationID string) string {
-	return fmt.Sprintf("%s%s:%s:%s", s.deploymentPrefix(), keyPrefixAlert, destinationID, keyEvaluated)
+func (s *redisAlertStore) getEvaluatedKey(tenantID, destinationID string) string {
+	return fmt.Sprintf("%s%s:%s:%s:%s", s.deploymentPrefix(), keyPrefixAlert, tenantID, destinationID, keyEvaluated)
 }

--- a/internal/alert/store_test.go
+++ b/internal/alert/store_test.go
@@ -159,6 +159,52 @@ func TestRedisAlertStore_WithDeploymentID(t *testing.T) {
 	assert.Equal(t, 1, res.Count)
 }
 
+func TestAlertStoreTenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	redisClient := testutil.CreateTestRedisClient(t)
+
+	// A single store (same deployment) shared by two tenants that happen to
+	// use the same destination id. The create API accepts a caller-supplied
+	// id, so distinct tenants can collide on a destination id like "prod".
+	store := alert.NewRedisAlertStore(redisClient, "")
+
+	destinationID := "dest_shared"
+	tenantA := "tenant_a"
+	tenantB := "tenant_b"
+
+	// Increment for tenant A.
+	resA, err := store.IncrementConsecutiveFailureCount(context.Background(), tenantA, destinationID, "att_1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, resA.Count)
+
+	resA, err = store.IncrementConsecutiveFailureCount(context.Background(), tenantA, destinationID, "att_2")
+	require.NoError(t, err)
+	assert.Equal(t, 2, resA.Count)
+
+	// Tenant B uses the same destination id but must have its own counter.
+	resB, err := store.IncrementConsecutiveFailureCount(context.Background(), tenantB, destinationID, "att_1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, resB.Count, "tenant B should not inherit tenant A's failure count")
+
+	// Evaluated markers are tenant-scoped too.
+	require.NoError(t, store.MarkAttemptEvaluated(context.Background(), tenantA, destinationID, "att_1"))
+	resB, err = store.IncrementConsecutiveFailureCount(context.Background(), tenantB, destinationID, "att_1")
+	require.NoError(t, err)
+	assert.False(t, resB.AlreadyEvaluated, "tenant B should not see tenant A's evaluated marker")
+
+	// Resetting tenant A must not clear tenant B's counter.
+	require.NoError(t, store.ResetConsecutiveFailureCount(context.Background(), tenantA, destinationID))
+
+	resA, err = store.IncrementConsecutiveFailureCount(context.Background(), tenantA, destinationID, "att_3")
+	require.NoError(t, err)
+	assert.Equal(t, 1, resA.Count, "tenant A should be reset")
+
+	resB, err = store.IncrementConsecutiveFailureCount(context.Background(), tenantB, destinationID, "att_2")
+	require.NoError(t, err)
+	assert.Equal(t, 2, resB.Count, "tenant B should be unaffected by tenant A reset")
+}
+
 func TestAlertStoreIsolation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Tenant-scope the consecutive-failure alert keys in the Redis alert store. The key format changes from `{deployment}alert:{destinationID}:cf` (and the `cfeval` companion) to `{deployment}alert:{tenantID}:{destinationID}:cf` / `:cfeval`.

`getFailuresKey` and `getEvaluatedKey` now take the `tenantID` that `IncrementConsecutiveFailureCount`, `MarkAttemptEvaluated`, and `ResetConsecutiveFailureCount` already receive. No other behavior changes: the deployment prefix and the 24h TTL are preserved.

## Why this matters

Destination IDs are only unique within a tenant, and the create API accepts a caller-supplied `id`. Two tenants that both use a destination id like `prod` previously collided on a single shared key, corrupting consecutive-failure counts and auto-disable behavior across tenants (#955).

No migration code is needed: existing `cf`/`cfeval` keys carry a 24h TTL and are reset on success, so any orphaned old-format keys age out on their own. This is the lazy in-place migration alexbouchardd greenlit on the issue.

## Testing

- `gofmt -l`, `go vet ./internal/alert/...`, and `go build ./...` all pass.
- Added `TestAlertStoreTenantIsolation`: two tenants sharing the same destination id increment independently, evaluated markers stay tenant-scoped, and resetting one tenant leaves the other's counter intact (the regression #955 reports).
- The existing deployment-isolation, idempotency, reset, and mark-evaluated tests continue to cover the rest of the surface. The alert store tests require a Redis instance (`testutil.CreateTestRedisClient`); they run in CI.

Fixes #955
