### PR TITLE
fix(spec-sdk-tests): remove vestigial @hookdeck/outpost-sdk alias

### DIFF
--- a/spec-sdk-tests/package.json
+++ b/spec-sdk-tests/package.json
@@ -25,9 +25,6 @@
   ],
   "author": "Outpost Team",
   "license": "Apache-2.0",
-  "dependencies": {
-    "@hookdeck/outpost-sdk": "file:../../../sdks/outpost-typescript"
-  },
   "devDependencies": {
     "@stoplight/spectral-cli": "^6.11.0",
     "@types/chai": "^4.3.11",

--- a/spec-sdk-tests/tsconfig.json
+++ b/spec-sdk-tests/tsconfig.json
@@ -18,16 +18,13 @@
     "paths": {
       "@/*": ["./*"],
       "@utils/*": ["./utils/*"],
-      "@tests/*": ["./tests/*"],
-      "@hookdeck/outpost-sdk": ["../../../sdks/outpost-typescript/src/index.ts"],
-      "@hookdeck/outpost-sdk/*": ["../../../sdks/outpost-typescript/src/*"]
+      "@tests/*": ["./tests/*"]
     }
   },
   "include": [
     "tests/**/*",
     "utils/**/*",
-    "factories/**/*",
-    "../../../sdks/outpost-typescript/src/**/*"
+    "factories/**/*"
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes #928.

## What

Removes the `@hookdeck/outpost-sdk` package alias from `spec-sdk-tests`:
- `package.json` — the `file:../../../sdks/outpost-typescript` dependency
- `tsconfig.json` — the matching `paths` entries and the SDK `include`

## Why

The alias paths pointed `../../../` (three levels up), resolving **outside** the repo — wrong since the suite was first added. It never surfaced because the alias was **never imported anywhere**; every test, util, and factory imports the SDK via direct relative path (`../../sdks/outpost-typescript/dist/commonjs`). `npm install` didn't fail because modern npm doesn't verify `file:` targets at install time.

Chose option 2 from the issue (remove the alias) over option 1 (fix the paths): it matches how the suite actually wires the SDK today, and is a zero-risk deletion of dead config. Switching the suite to package-name imports (option 1) would be a larger change worth its own issue.

## Verification

Run against a live local Outpost stack (`make up`):
- `npm install` — clean (no longer references the bad `file:` path)
- `npm run type-check` (`tsc --noEmit`) — clean (removed alias/include weren't needed)
- `npm test` — **153 passing**, 15 pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)