### PR TITLE
fix: normalize nil event metadata to an empty map

### DIFF
--- a/internal/apirouter/publish_handlers.go
+++ b/internal/apirouter/publish_handlers.go
@@ -102,6 +102,12 @@ func (p *PublishedEvent) toEvent() models.Event {
 	if p.EligibleForRetry != nil {
 		eligibleForRetry = *p.EligibleForRetry
 	}
+	metadata := p.Metadata
+	if metadata == nil {
+		// metadata is jsonb NOT NULL in the log store; a missing metadata
+		// field must become an empty map, never a nil one.
+		metadata = map[string]string{}
+	}
 	return models.Event{
 		ID:               id,
 		TenantID:         p.TenantID,
@@ -109,7 +115,7 @@ func (p *PublishedEvent) toEvent() models.Event {
 		Topic:            p.Topic,
 		EligibleForRetry: eligibleForRetry,
 		Time:             eventTime,
-		Metadata:         p.Metadata,
+		Metadata:         metadata,
 		Data:             p.Data,
 	}
 }

--- a/internal/apirouter/publish_handlers_test.go
+++ b/internal/apirouter/publish_handlers_test.go
@@ -404,6 +404,23 @@ func TestAPI_Publish(t *testing.T) {
 			assert.Equal(t, models.Metadata{"env": "prod"}, h.eventHandler.calls[0].Metadata)
 		})
 
+		t.Run("defaults missing metadata to non-nil empty map", func(t *testing.T) {
+			// metadata is jsonb NOT NULL downstream; the event built from a
+			// request without metadata must never carry a nil map.
+			h := newAPITest(t)
+
+			req := h.jsonReq(http.MethodPost, "/api/v1/publish", map[string]any{
+				"tenant_id": "t1",
+				"data":      map[string]any{"key": "value"},
+			})
+			resp := h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusAccepted, resp.Code)
+			require.Len(t, h.eventHandler.calls, 1)
+			assert.NotNil(t, h.eventHandler.calls[0].Metadata, "metadata should be normalized to a non-nil map")
+			assert.Empty(t, h.eventHandler.calls[0].Metadata)
+		})
+
 		t.Run("metadata with non-string values returns 422", func(t *testing.T) {
 			h := newAPITest(t)
 

--- a/internal/logstore/chlogstore/chlogstore.go
+++ b/internal/logstore/chlogstore/chlogstore.go
@@ -792,7 +792,13 @@ func (s *logStoreImpl) InsertMany(ctx context.Context, entries []*models.LogEntr
 		}
 
 		for _, e := range eventMap {
-			metadataJSON, err := json.Marshal(e.Metadata)
+			// Normalize nil metadata to an empty object so it round-trips as
+			// a non-nil empty map, consistent with the Postgres backend.
+			metadata := e.Metadata
+			if metadata == nil {
+				metadata = map[string]string{}
+			}
+			metadataJSON, err := json.Marshal(metadata)
 			if err != nil {
 				return fmt.Errorf("failed to marshal metadata: %w", err)
 			}
@@ -834,7 +840,12 @@ func (s *logStoreImpl) InsertMany(ctx context.Context, entries []*models.LogEntr
 		event := entry.Event
 		a := entry.Attempt
 
-		metadataJSON, err := json.Marshal(event.Metadata)
+		// See event insert above: keep nil metadata as an empty object.
+		eventMetadata := event.Metadata
+		if eventMetadata == nil {
+			eventMetadata = map[string]string{}
+		}
+		metadataJSON, err := json.Marshal(eventMetadata)
 		if err != nil {
 			return fmt.Errorf("failed to marshal metadata: %w", err)
 		}

--- a/internal/logstore/drivertest/crud.go
+++ b/internal/logstore/drivertest/crud.go
@@ -147,6 +147,46 @@ func testCRUD(t *testing.T, newHarness HarnessMaker) {
 			require.NoError(t, err)
 		})
 
+		t.Run("nil metadata persists as empty", func(t *testing.T) {
+			// An event published without metadata has a nil Metadata map.
+			// Stores must persist it without error and round-trip it as an
+			// empty (non-nil) map, regardless of backend. Postgres in
+			// particular has `metadata jsonb NOT NULL`, so a nil map that
+			// encodes to SQL NULL is rejected at insert time.
+			nilTenantID := idgen.String()
+			destID := idgen.Destination()
+
+			event := testutil.EventFactory.AnyPointer(
+				testutil.EventFactory.WithID("nil_meta_evt"),
+				testutil.EventFactory.WithTenantID(nilTenantID),
+				testutil.EventFactory.WithDestinationID(destID),
+				testutil.EventFactory.WithMatchedDestinationIDs([]string{destID}),
+				testutil.EventFactory.WithMetadata(nil),
+				testutil.EventFactory.WithTime(baseTime.Add(-8*time.Minute)),
+			)
+			delivery := testutil.AttemptFactory.AnyPointer(
+				testutil.AttemptFactory.WithID("nil_meta_del"),
+				testutil.AttemptFactory.WithTenantID(nilTenantID),
+				testutil.AttemptFactory.WithEventID(event.ID),
+				testutil.AttemptFactory.WithDestinationID(destID),
+				testutil.AttemptFactory.WithStatus("success"),
+				testutil.AttemptFactory.WithTime(baseTime.Add(-8*time.Minute)),
+			)
+
+			err := logStore.InsertMany(ctx, []*models.LogEntry{{Event: event, Attempt: delivery}})
+			require.NoError(t, err, "inserting an event with nil metadata must not error")
+			require.NoError(t, h.FlushWrites(ctx))
+
+			retrieved, err := logStore.RetrieveEvent(ctx, driver.RetrieveEventRequest{
+				TenantID: nilTenantID,
+				EventID:  event.ID,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, retrieved)
+			assert.NotNil(t, retrieved.Metadata, "nil metadata should round-trip as a non-nil empty map")
+			assert.Empty(t, retrieved.Metadata)
+		})
+
 		t.Run("duplicate entries in batch", func(t *testing.T) {
 			// Duplicates arise from MQ redelivery and producer re-publish;
 			// InsertMany must tolerate intra-batch duplicates (same Attempt.ID)

--- a/internal/logstore/memlogstore/memlogstore.go
+++ b/internal/logstore/memlogstore/memlogstore.go
@@ -452,6 +452,8 @@ func copyEvent(e *models.Event) *models.Event {
 		for k, v := range e.Metadata {
 			copied.Metadata[k] = v
 		}
+	} else {
+		copied.Metadata = map[string]string{}
 	}
 	if e.Data != nil {
 		copied.Data = make([]byte, len(e.Data))

--- a/internal/logstore/pglogstore/pglogstore.go
+++ b/internal/logstore/pglogstore/pglogstore.go
@@ -813,7 +813,13 @@ func eventArrays(events []*models.Event) []any {
 		topics[i] = e.Topic
 		eligibleForRetries[i] = e.EligibleForRetry
 		datas[i] = string(e.Data)
-		metadatas[i] = e.Metadata
+		// metadata is jsonb NOT NULL; a nil map encodes to SQL NULL under
+		// pgx and is rejected. Persist an empty object instead.
+		metadata := e.Metadata
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		metadatas[i] = metadata
 	}
 
 	return []any{
@@ -869,7 +875,12 @@ func attemptArrays(entries []*models.LogEntry) []any {
 		eventTimes[i] = e.Time
 		eligibleForRetries[i] = e.EligibleForRetry
 		eventDatas[i] = string(e.Data)
-		eventMetadatas[i] = e.Metadata
+		// event_metadata is jsonb NOT NULL; see eventArrays.
+		eventMetadata := e.Metadata
+		if eventMetadata == nil {
+			eventMetadata = map[string]string{}
+		}
+		eventMetadatas[i] = eventMetadata
 	}
 
 	return []any{


### PR DESCRIPTION
Closes #972.

## Problem

An event published without `metadata` carries a nil `map[string]string`. `events.metadata` and `attempts.event_metadata` are `jsonb NOT NULL`, and under **pgx v5.10** (bumped in #940) a nil map encodes to SQL `NULL` — so the Postgres log store rejects the insert:

```
null value in column "metadata" of relation "events_default" violates not-null constraint
```

The event is never persisted; the log worker retries forever. ClickHouse accepted the insert but read metadata back as `nil` — a silent inconsistency with Postgres.

## Why it wasn't caught

- The logstore conformance suite only ever inserted events from `EventFactory.Any()`, which **always** sets a populated metadata map — the nil path was never exercised.
- Those conformance tests are integration-gated (`testing.Short()`), and CI's Go job runs `-short`, so they don't run on PRs. Only the `spec-sdk-tests` e2e job hit it, surfacing late as a confusing timeout.
- An apirouter test couldn't have caught it either: those tests use the in-memory store, and publish is async (the insert happens downstream of the HTTP response).

## Change

Treat nil and empty metadata as equivalent ("no metadata") and enforce a non-nil map at every boundary:

- **apirouter** — default missing metadata to `{}` when building the event (the canonical, earliest boundary; runs in CI).
- **pglogstore** — default nil to `{}` in the event and attempt insert arrays (correctness; `NOT NULL`).
- **chlogstore** — default nil to `{}` before marshaling, so it round-trips as an empty map like Postgres (consistency).

## Commits

1. `test:` — failing coverage at both layers. Red on current code: Postgres rejects the insert, ClickHouse reads back nil, the router passes nil through.
2. `fix:` — the normalization above. All green.

## Verification

Local, both backends (`make up/test`, `TESTINFRA=1`):
- `apirouter` publish tests — pass (runs in CI `-short`).
- `pglogstore` + `chlogstore` conformance — pass.
- gofmt / go vet clean.

## Note

The conformance tests guard the real backends but only run in the non-`-short` integration runs, not on PRs. The new apirouter test does run in CI. Wiring the logstore integration tests into CI is a worthwhile follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)