### PR TITLE
fix(deps): bump Go toolchain to 1.26.4 to patch stdlib CVEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
+          go-version: 1.26.4
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.0'
+          go-version: '1.26.4'
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hookdeck/outpost
 
-go 1.26.0
+go 1.26.4
 
 require (
 	cloud.google.com/go/pubsub v1.50.2


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` from `1.26.0` to `1.26.4`, and aligns the `setup-go` version in the release and unit-test workflows to match.

The v1.0.6 release binary is compiled with Go 1.26.0 stdlib, which a security scanner flags for stdlib vulnerabilities. Because `GOTOOLCHAIN=auto` honors the `go.mod` directive, this forces the release build to compile against the patched 1.26.4 stdlib. No code changes.

Fixes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)