### PR TITLE
feat(opevents): attempt.success and attempt.failed operator events

### DIFF
--- a/docs/content/features/operator-events.mdoc
+++ b/docs/content/features/operator-events.mdoc
@@ -31,7 +31,11 @@ Available topics:
 | `alert.destination.consecutive_failure` | Consecutive failure count reaches 50%, 70%, 90%, or 100% of `ALERT_CONSECUTIVE_FAILURE_COUNT` |
 | `alert.destination.disabled` | Destination auto-disabled at 100% failure threshold |
 | `alert.attempt.exhausted_retries` | Delivery exhausts all retry attempts (deduplicated per event+destination) |
+| `attempt.success` | Every successful delivery attempt |
+| `attempt.failed` | Every failed delivery attempt, including retries |
 | `tenant.subscription.updated` | Destination created/updated/deleted and tenant topics or destination count changed |
+
+The `attempt.success` and `attempt.failed` topics fire once per delivery attempt, so they dominate event volume — including under `*`. Subscribe to them deliberately and size your sink for your delivery throughput.
 
 {% tabs tabGroup="deployment" %}
 {% tab label="Managed" %}
@@ -194,6 +198,25 @@ Emitted when a delivery exhausts all retry attempts. Deduplicated per event+dest
 }
 ```
 
+### `attempt.success` / `attempt.failed`
+
+Emitted once per delivery attempt, keyed by outcome. The two topics share one payload shape; `attempt.status` carries the outcome. `attempt.failed` fires on every failed attempt including retries — use `attempt.attempt_number` and `event.eligible_for_retry` to distinguish retryable failures from final ones.
+
+```json
+{
+  "tenant_id": "tenant_123",
+  "event": {},
+  "attempt": {},
+  "destination": {
+    "id": "des_456",
+    "tenant_id": "tenant_123",
+    "type": "webhook",
+    "topics": ["order.created"],
+    "disabled_at": null
+  }
+}
+```
+
 ### `tenant.subscription.updated`
 
 Emitted when destination changes affect tenant-level subscribed topics or destination count.
@@ -210,7 +233,7 @@ Emitted when destination changes affect tenant-level subscribed topics or destin
 
 ## Delivery Guarantees
 
-`alert.*` topics are delivered with an at-least-once guarantee. For other topics (e.g. `tenant.subscription.updated`), delivery is on a best-effort basis with up to 3 attempts. Consumers should deduplicate using the event `id`.
+`alert.*` and `attempt.*` topics are delivered with an at-least-once guarantee. For other topics (e.g. `tenant.subscription.updated`), delivery is on a best-effort basis with up to 3 attempts. Consumers should deduplicate using the event `id`.
 
 ## Related Configuration
 

--- a/docs/content/features/operator-events.mdoc
+++ b/docs/content/features/operator-events.mdoc
@@ -205,8 +205,35 @@ Emitted once per delivery attempt, keyed by outcome. The two topics share one pa
 ```json
 {
   "tenant_id": "tenant_123",
-  "event": {},
-  "attempt": {},
+  "event": {
+    "id": "evt_789",
+    "tenant_id": "tenant_123",
+    "destination_id": "des_456",
+    "matched_destination_ids": ["des_456"],
+    "topic": "order.created",
+    "eligible_for_retry": true,
+    "time": "2025-06-01T12:00:00Z",
+    "metadata": {},
+    "data": {
+      "order_id": "ord_123"
+    }
+  },
+  "attempt": {
+    "id": "att_abc",
+    "tenant_id": "tenant_123",
+    "event_id": "evt_789",
+    "destination_id": "des_456",
+    "destination_type": "webhook",
+    "attempt_number": 2,
+    "manual": false,
+    "status": "failed",
+    "time": "2025-06-01T12:00:05Z",
+    "code": "500",
+    "response_data": {
+      "status": 500,
+      "body": "internal server error"
+    }
+  },
   "destination": {
     "id": "des_456",
     "tenant_id": "tenant_123",
@@ -216,6 +243,10 @@ Emitted once per delivery attempt, keyed by outcome. The two topics share one pa
   }
 }
 ```
+
+An `attempt.success` payload is identical except `attempt.status` is `"success"` and `code`/`response_data` carry the destination's response (for a webhook, the HTTP status and body). For network-level failures, `code` is an error class such as `connection_refused` or `dns_error` instead of an HTTP status.
+
+The alert payloads above carry the same `event` and `attempt` objects, elided for brevity.
 
 ### `tenant.subscription.updated`
 

--- a/internal/alert/evaluator.go
+++ b/internal/alert/evaluator.go
@@ -109,6 +109,13 @@ func NewEvaluator(store AlertStore, retryMaxLimit int, opts ...Option) *Evaluato
 	return e
 }
 
+// SignalsEnabled reports whether any signal can ever fire: consecutive-failure
+// tracking, or exhausted-retries with a positive retry limit. When false,
+// Evaluate never touches the store and always returns an empty verdict.
+func (e *Evaluator) SignalsEnabled() bool {
+	return e.consecutiveFailureEnabled || (e.exhaustedRetriesEnabled && e.retryMaxLimit > 0)
+}
+
 func (e *Evaluator) Evaluate(ctx context.Context, attempt Attempt) (Evaluation, error) {
 	if attempt.Success {
 		// Nothing is tracked when consecutive-failure tracking is disabled, so

--- a/internal/idempotence/idempotence.go
+++ b/internal/idempotence/idempotence.go
@@ -140,6 +140,11 @@ func (i *IdempotenceImpl) Exec(ctx context.Context, key string, exec func(contex
 	execCtx, span := i.tracer.Start(ctx, "Idempotence.Exec")
 	err = exec(execCtx)
 	if err != nil {
+		// Known edge case: when exec failed because ctx itself was canceled,
+		// this clear fails too and the key lingers as "processing" until the
+		// claim TTL (options.Timeout) expires it — retries in that window get
+		// ErrConflict, then self-heal. Rare and bounded, so not worth the fix
+		// yet; if it bites, clear on context.WithoutCancel(ctx).
 		clearErr := i.clearIdempotency(ctx, prefixedKey)
 		if clearErr != nil {
 			finalErr := errors.Join(err, clearErr)

--- a/internal/logmq/attempt_events_test.go
+++ b/internal/logmq/attempt_events_test.go
@@ -1,0 +1,54 @@
+package logmq_test
+
+// attempt.success / attempt.failed emission. The failed side is pinned all
+// over the characterization suite (every failed attempt's expected multiset
+// carries one attempt.failed); these cover the success side, which has its own
+// path — no replay gate, no mark, send-then-ack.
+
+import (
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// A successful attempt emits exactly one attempt.success and acks.
+func TestAttemptEvents_SuccessEmits(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 1},
+		alert:   alertConfig{autoDisableCount: 2, thresholds: []int{50, 100}},
+	})
+
+	dest, tenant := "dest_ae1", "tenant_ae1"
+	cm, msg := newCountingMessage(makeEntry(dest, tenant, "att_ok", models.AttemptStatusSuccess))
+	h.add(msg)
+	h.waitTerminal([]*countingMessage{cm})
+
+	cm.requireAcked(t)
+	recs := h.sink.forDest(dest)
+	assert.Equal(t, []string{topicSuccess}, topics(recs))
+	assert.Equal(t, []string{"att_ok"}, attemptIDs(recs))
+}
+
+// A failed attempt.success send nacks the message: the success path owes its
+// event the same at-least-once treatment as the failure path (redelivery
+// re-runs the reset — idempotent — and re-sends).
+func TestAttemptEvents_SuccessEmitFailure_Nacks(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 1},
+		alert:   alertConfig{autoDisableCount: 2, thresholds: []int{50, 100}},
+		doubles: doublesConfig{
+			sinkFailOn: map[string]bool{topicSuccess: true},
+		},
+	})
+
+	dest, tenant := "dest_ae2", "tenant_ae2"
+	cm, msg := newCountingMessage(makeEntry(dest, tenant, "att_ok", models.AttemptStatusSuccess))
+	h.add(msg)
+	h.waitTerminal([]*countingMessage{cm})
+
+	cm.requireNacked(t)
+	assert.Empty(t, h.sink.forDest(dest), "the failed send recorded nothing")
+}

--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -385,7 +385,7 @@ func (bp *BatchProcessor) sendAll(ctx context.Context, events []deliveryEvent, e
 		g.Go(func() error {
 			sendCtx, cancel := context.WithTimeout(gctx, bp.emitTimeout)
 			defer cancel()
-			if err := bp.send(sendCtx, de, entry); err != nil {
+			if err := bp.send(sendCtx, de); err != nil {
 				bp.logger.Ctx(ctx).Error("opevent delivery failed",
 					zap.Error(err),
 					zap.String("topic", de.event.Topic),
@@ -458,22 +458,13 @@ func (bp *BatchProcessor) plan(ctx context.Context, eval alert.Evaluation, entry
 	return events, nil
 }
 
-// send emits one event and audits the send, inside the event's suppression
-// window when it has one. A suppressed duplicate (Exec skips the emit) counts
-// as delivered and is not audited.
-func (bp *BatchProcessor) send(ctx context.Context, de deliveryEvent, entry *models.LogEntry) error {
+// send emits one event, inside the event's suppression window when it has
+// one. A suppressed duplicate (Exec skips the emit) counts as delivered. The
+// emitter owns the delivery audit log — it fires iff an event actually went
+// out, so filtered topics and suppressed duplicates leave no line.
+func (bp *BatchProcessor) send(ctx context.Context, de deliveryEvent) error {
 	emit := func(ctx context.Context) error {
-		if err := bp.alerts.Emitter.Emit(ctx, de.event); err != nil {
-			return err
-		}
-		bp.logger.Ctx(ctx).Audit("opevent delivered",
-			zap.String("topic", de.event.Topic),
-			zap.String("attempt_id", entry.Attempt.ID),
-			zap.String("event_id", entry.Event.ID),
-			zap.String("tenant_id", de.event.TenantID),
-			zap.String("destination_id", entry.Destination.ID),
-			zap.String("destination_type", entry.Destination.Type))
-		return nil
+		return bp.alerts.Emitter.Emit(ctx, de.event)
 	}
 	if de.suppressKey == "" {
 		return emit(ctx)

--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -69,18 +69,21 @@ type SuppressionWindow interface {
 }
 
 // AlertPipeline groups the post-persist alert pipeline: evaluate the attempt,
-// act on the verdict (disable, opevents), and dedup replays.
+// act on the verdict (disable, opevents), and dedup replays. Evaluator,
+// Emitter, and ProcessedIdemp are always required — "alerting off" is
+// expressed by config (signals disabled, no topics subscribed), never by
+// absent deps.
 type AlertPipeline struct {
-	// Evaluator is the alert tracker. Nil disables the pipeline entirely.
+	// Evaluator is the alert tracker. Required.
 	Evaluator AlertEvaluator
-	// Emitter delivers the operator events. Required when Evaluator is set.
+	// Emitter delivers the operator events. Required.
 	Emitter opevents.Emitter
 	// Disabler auto-disables a destination when the 100% threshold is crossed.
 	// Nil disables auto-disable.
 	Disabler DestinationDisabler
 	// ProcessedIdemp is the per-attempt replay gate: a replay of a fully
 	// processed failed attempt is skipped instead of re-counting/re-alerting.
-	// Required when Evaluator is set.
+	// Required.
 	ProcessedIdemp ReplayGate
 	// ExhaustedIdemp is the per-(event,destination) suppression window for
 	// exhausted-retries alerts. Nil means no suppression (alert on every
@@ -127,13 +130,14 @@ type BatchProcessor struct {
 
 // NewBatchProcessor creates a new batch processor for log entries.
 func NewBatchProcessor(ctx context.Context, logger *logging.Logger, logStore LogStore, alerts AlertPipeline, cfg BatchProcessorConfig) (*BatchProcessor, error) {
-	if alerts.Evaluator != nil {
-		if alerts.Emitter == nil {
-			return nil, errors.New("logmq: AlertPipeline requires an Emitter when Evaluator is set")
-		}
-		if alerts.ProcessedIdemp == nil {
-			return nil, errors.New("logmq: AlertPipeline requires a ProcessedIdemp when Evaluator is set")
-		}
+	if alerts.Evaluator == nil {
+		return nil, errors.New("logmq: AlertPipeline requires an Evaluator")
+	}
+	if alerts.Emitter == nil {
+		return nil, errors.New("logmq: AlertPipeline requires an Emitter")
+	}
+	if alerts.ProcessedIdemp == nil {
+		return nil, errors.New("logmq: AlertPipeline requires a ProcessedIdemp")
 	}
 	bp := &BatchProcessor{
 		ctx:         ctx,
@@ -145,11 +149,9 @@ func NewBatchProcessor(ctx context.Context, logger *logging.Logger, logStore Log
 	if bp.emitTimeout <= 0 {
 		bp.emitTimeout = emitTimeout
 	}
-	if alerts.Evaluator != nil {
-		bp.alertsEnabled = alerts.Evaluator.SignalsEnabled()
-		bp.emitsAttemptEvents = alerts.Emitter.Enabled(opevents.TopicAttemptSuccess) ||
-			alerts.Emitter.Enabled(opevents.TopicAttemptFailed)
-	}
+	bp.alertsEnabled = alerts.Evaluator.SignalsEnabled()
+	bp.emitsAttemptEvents = alerts.Emitter.Enabled(opevents.TopicAttemptSuccess) ||
+		alerts.Emitter.Enabled(opevents.TopicAttemptFailed)
 
 	b, err := batcher.NewBatcher(batcher.Config[*mqs.Message]{
 		GroupCountThreshold: 2,
@@ -280,9 +282,9 @@ func (bp *BatchProcessor) processBatch(_ string, msgs []*mqs.Message) {
 	// and every fetched message reaches ack/nack well inside the broker's
 	// visibility window.
 	for i, entry := range entries {
-		// No pipeline, or one that can't produce anything (every alert signal
-		// off and no attempt topic subscribed): persisted is terminal.
-		if bp.alerts.Evaluator == nil || (!bp.alertsEnabled && !bp.emitsAttemptEvents) {
+		// A pipeline that can't produce anything (every alert signal off and
+		// no attempt topic subscribed): persisted is terminal.
+		if !bp.alertsEnabled && !bp.emitsAttemptEvents {
 			validMsgs[i].Ack()
 			continue
 		}

--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -39,6 +39,10 @@ type LogStore interface {
 // processor.
 type AlertEvaluator interface {
 	Evaluate(ctx context.Context, attempt alert.Attempt) (alert.Evaluation, error)
+	// SignalsEnabled reports whether any alert signal can ever fire. When
+	// false, Evaluate is a stateless no-op, so the pipeline skips the replay
+	// gate (there is no streak or verdict to protect from replays).
+	SignalsEnabled() bool
 }
 
 // DestinationDisabler disables destinations that hit the auto-disable
@@ -110,6 +114,11 @@ type BatchProcessor struct {
 	alerts      AlertPipeline
 	batcher     *batcher.Batcher[*mqs.Message]
 	emitTimeout time.Duration
+	// alertsEnabled and emitsAttemptEvents are derived once from the pipeline's
+	// static config. alertsEnabled=false skips the replay gate on the failed
+	// path (nothing to protect); both false skips per-entry work entirely.
+	alertsEnabled      bool
+	emitsAttemptEvents bool
 	// inflight tracks entry goroutines so Shutdown can drain them. Each is
 	// bounded by emitTimeout, so the wait is bounded too.
 	inflight     sync.WaitGroup
@@ -135,6 +144,11 @@ func NewBatchProcessor(ctx context.Context, logger *logging.Logger, logStore Log
 	}
 	if bp.emitTimeout <= 0 {
 		bp.emitTimeout = emitTimeout
+	}
+	if alerts.Evaluator != nil {
+		bp.alertsEnabled = alerts.Evaluator.SignalsEnabled()
+		bp.emitsAttemptEvents = alerts.Emitter.Enabled(opevents.TopicAttemptSuccess) ||
+			alerts.Emitter.Enabled(opevents.TopicAttemptFailed)
 	}
 
 	b, err := batcher.NewBatcher(batcher.Config[*mqs.Message]{
@@ -266,7 +280,9 @@ func (bp *BatchProcessor) processBatch(_ string, msgs []*mqs.Message) {
 	// and every fetched message reaches ack/nack well inside the broker's
 	// visibility window.
 	for i, entry := range entries {
-		if bp.alerts.Evaluator == nil {
+		// No pipeline, or one that can't produce anything (every alert signal
+		// off and no attempt topic subscribed): persisted is terminal.
+		if bp.alerts.Evaluator == nil || (!bp.alertsEnabled && !bp.emitsAttemptEvents) {
 			validMsgs[i].Ack()
 			continue
 		}
@@ -300,7 +316,9 @@ func (bp *BatchProcessor) processBatch(_ string, msgs []*mqs.Message) {
 // store is idempotent per attempt ID). A success resets the tracker and emits
 // attempt.success — both idempotent-enough to skip the gate (gating would cost
 // one Redis key per successful attempt, the dominant traffic, to dedup a rare
-// redelivery re-emit; opevents are at-least-once anyway).
+// redelivery re-emit; opevents are at-least-once anyway). The gate exists for
+// alert state and alert-event dedup only, so when every signal is disabled the
+// failed path skips it too and just emits attempt.failed.
 func (bp *BatchProcessor) processEntry(ctx context.Context, entry *models.LogEntry, msg *mqs.Message) {
 	attempt := alert.Attempt{
 		TenantID:         entry.Destination.TenantID,
@@ -320,6 +338,22 @@ func (bp *BatchProcessor) processEntry(ctx context.Context, entry *models.LogEnt
 			event: opevents.AttemptSuccessEvent(opevents.NewAlertDestination(entry.Destination), entry.Event, entry.Attempt),
 		}
 		if bp.sendAll(ctx, []deliveryEvent{success}, entry) != nil {
+			msg.Nack()
+			return
+		}
+		msg.Ack()
+		return
+	}
+
+	// With every alert signal off there is no streak to protect and no verdict
+	// to compute, so the replay gate buys nothing — skip its two Redis round
+	// trips and emit attempt.failed ungated, same at-least-once treatment as
+	// attempt.success (a redelivery may re-emit; tolerated).
+	if !bp.alertsEnabled {
+		failed := deliveryEvent{
+			event: opevents.AttemptFailedEvent(opevents.NewAlertDestination(entry.Destination), entry.Event, entry.Attempt),
+		}
+		if bp.sendAll(ctx, []deliveryEvent{failed}, entry) != nil {
 			msg.Nack()
 			return
 		}

--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -297,9 +297,10 @@ func (bp *BatchProcessor) processBatch(_ string, msgs []*mqs.Message) {
 // replay arriving after a success reset must not count toward the fresh
 // streak. The mark lands only after the attempt's events are delivered — a
 // nacked attempt re-runs in full on redelivery (counting stays correct: the
-// store is idempotent per attempt ID). A success just resets the tracker —
-// idempotent, so it needs no gate (and gating it would cost one Redis key per
-// successful attempt).
+// store is idempotent per attempt ID). A success resets the tracker and emits
+// attempt.success — both idempotent-enough to skip the gate (gating would cost
+// one Redis key per successful attempt, the dominant traffic, to dedup a rare
+// redelivery re-emit; opevents are at-least-once anyway).
 func (bp *BatchProcessor) processEntry(ctx context.Context, entry *models.LogEntry, msg *mqs.Message) {
 	attempt := alert.Attempt{
 		TenantID:         entry.Destination.TenantID,
@@ -313,6 +314,13 @@ func (bp *BatchProcessor) processEntry(ctx context.Context, entry *models.LogEnt
 	if attempt.Success {
 		if _, err := bp.alerts.Evaluator.Evaluate(ctx, attempt); err != nil {
 			bp.nackAlertFailure(ctx, err, entry, msg)
+			return
+		}
+		success := deliveryEvent{
+			event: opevents.AttemptSuccessEvent(opevents.NewAlertDestination(entry.Destination), entry.Event, entry.Attempt),
+		}
+		if bp.sendAll(ctx, []deliveryEvent{success}, entry) != nil {
+			msg.Nack()
 			return
 		}
 		msg.Ack()
@@ -342,28 +350,9 @@ func (bp *BatchProcessor) processEntry(ctx context.Context, entry *models.LogEnt
 		return
 	}
 
-	// Deliver the attempt's events concurrently; arrival order within an
-	// attempt is not guaranteed. Any failure nacks with nothing marked, so
-	// redelivery re-runs the attempt in full — events already sent may go out
-	// again (at-least-once).
-	g, gctx := errgroup.WithContext(ctx)
-	for _, de := range events {
-		g.Go(func() error {
-			sendCtx, cancel := context.WithTimeout(gctx, bp.emitTimeout)
-			defer cancel()
-			if err := bp.send(sendCtx, de, entry); err != nil {
-				bp.logger.Ctx(ctx).Error("opevent delivery failed",
-					zap.Error(err),
-					zap.String("topic", de.event.Topic),
-					zap.String("attempt_id", entry.Attempt.ID),
-					zap.String("event_id", entry.Event.ID),
-					zap.String("destination_id", entry.Destination.ID))
-				return err
-			}
-			return nil
-		})
-	}
-	if g.Wait() != nil {
+	// Any failure nacks with nothing marked, so redelivery re-runs the attempt
+	// in full — events already sent may go out again (at-least-once).
+	if bp.sendAll(ctx, events, entry) != nil {
 		msg.Nack()
 		return
 	}
@@ -387,17 +376,38 @@ type deliveryEvent struct {
 	suppressKey string
 }
 
-// plan acts on an evaluation and builds the operator events owed for this
-// attempt — disabled, consecutive_failure, exhausted_retries. They are sent
-// concurrently, so slice order carries no meaning. The disable (a DB write)
-// happens here: it's an action, not a notification, and it must precede event
-// construction so the payloads carry the destination's latest state
-// (disabled).
-func (bp *BatchProcessor) plan(ctx context.Context, eval alert.Evaluation, entry *models.LogEntry) ([]deliveryEvent, error) {
-	if eval.ConsecutiveFailure == nil && !eval.RetriesExhausted {
-		return nil, nil
+// sendAll delivers an attempt's events concurrently, each under the emit
+// timeout; arrival order within an attempt is not guaranteed. The first
+// failure is returned (the rest still run to completion or cancellation).
+func (bp *BatchProcessor) sendAll(ctx context.Context, events []deliveryEvent, entry *models.LogEntry) error {
+	g, gctx := errgroup.WithContext(ctx)
+	for _, de := range events {
+		g.Go(func() error {
+			sendCtx, cancel := context.WithTimeout(gctx, bp.emitTimeout)
+			defer cancel()
+			if err := bp.send(sendCtx, de, entry); err != nil {
+				bp.logger.Ctx(ctx).Error("opevent delivery failed",
+					zap.Error(err),
+					zap.String("topic", de.event.Topic),
+					zap.String("attempt_id", entry.Attempt.ID),
+					zap.String("event_id", entry.Event.ID),
+					zap.String("destination_id", entry.Destination.ID))
+				return err
+			}
+			return nil
+		})
 	}
+	return g.Wait()
+}
 
+// plan acts on an evaluation and builds the operator events owed for this
+// attempt — attempt.failed always, plus disabled, consecutive_failure, and
+// exhausted_retries per the verdict. They are sent concurrently, so slice
+// order carries no meaning. The disable (a DB write) happens here: it's an
+// action, not a notification, and it must precede event construction so the
+// payloads carry the destination's latest state (disabled) — attempt.failed
+// included, since they share the projection.
+func (bp *BatchProcessor) plan(ctx context.Context, eval alert.Evaluation, entry *models.LogEntry) ([]deliveryEvent, error) {
 	dest := opevents.NewAlertDestination(entry.Destination)
 	var events []deliveryEvent
 
@@ -440,6 +450,10 @@ func (bp *BatchProcessor) plan(ctx context.Context, eval alert.Evaluation, entry
 		}
 		events = append(events, de)
 	}
+
+	events = append(events, deliveryEvent{
+		event: opevents.AttemptFailedEvent(dest, entry.Event, entry.Attempt),
+	})
 
 	return events, nil
 }

--- a/internal/logmq/batchprocessor_test.go
+++ b/internal/logmq/batchprocessor_test.go
@@ -343,7 +343,7 @@ func testAlertPipeline(t *testing.T, evaluator logmq.AlertEvaluator) logmq.Alert
 	t.Helper()
 	return logmq.AlertPipeline{
 		Evaluator:      evaluator,
-		Emitter:        opevents.NewEmitter(&opevents.NoopSink{}, "test-deploy", []string{"*"}),
+		Emitter:        opevents.NewEmitter(&opevents.NoopSink{}, "test-deploy", []string{"*"}, testutil.CreateTestLogger(t)),
 		ProcessedIdemp: idempotence.New(testutil.CreateTestRedisClient(t)),
 	}
 }

--- a/internal/logmq/batchprocessor_test.go
+++ b/internal/logmq/batchprocessor_test.go
@@ -83,7 +83,7 @@ func TestBatchProcessor_ValidEntry(t *testing.T) {
 	logger := testutil.CreateTestLogger(t)
 	logStore := &mockLogStore{}
 
-	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, logmq.AlertPipeline{}, logmq.BatchProcessorConfig{
+	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, testAlertPipeline(t, &mockAlertEvaluator{}), logmq.BatchProcessorConfig{
 		ItemCountThreshold: 1,
 		DelayThreshold:     1 * time.Second,
 	})
@@ -117,7 +117,7 @@ func TestBatchProcessor_InvalidEntry_MissingEvent(t *testing.T) {
 	logger := testutil.CreateTestLogger(t)
 	logStore := &mockLogStore{}
 
-	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, logmq.AlertPipeline{}, logmq.BatchProcessorConfig{
+	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, testAlertPipeline(t, &mockAlertEvaluator{}), logmq.BatchProcessorConfig{
 		ItemCountThreshold: 1,
 		DelayThreshold:     1 * time.Second,
 	})
@@ -150,7 +150,7 @@ func TestBatchProcessor_InvalidEntry_MissingAttempt(t *testing.T) {
 	logger := testutil.CreateTestLogger(t)
 	logStore := &mockLogStore{}
 
-	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, logmq.AlertPipeline{}, logmq.BatchProcessorConfig{
+	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, testAlertPipeline(t, &mockAlertEvaluator{}), logmq.BatchProcessorConfig{
 		ItemCountThreshold: 1,
 		DelayThreshold:     1 * time.Second,
 	})
@@ -183,7 +183,7 @@ func TestBatchProcessor_InvalidEntry_DoesNotBlockBatch(t *testing.T) {
 	logger := testutil.CreateTestLogger(t)
 	logStore := &mockLogStore{}
 
-	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, logmq.AlertPipeline{}, logmq.BatchProcessorConfig{
+	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, testAlertPipeline(t, &mockAlertEvaluator{}), logmq.BatchProcessorConfig{
 		ItemCountThreshold: 3, // Wait for 3 messages before processing
 		DelayThreshold:     1 * time.Second,
 	})
@@ -292,7 +292,7 @@ func TestBatchProcessor_MalformedJSON(t *testing.T) {
 	logger := testutil.CreateTestLogger(t)
 	logStore := &mockLogStore{}
 
-	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, logmq.AlertPipeline{}, logmq.BatchProcessorConfig{
+	bp, err := logmq.NewBatchProcessor(ctx, logger, logStore, testAlertPipeline(t, &mockAlertEvaluator{}), logmq.BatchProcessorConfig{
 		ItemCountThreshold: 1,
 		DelayThreshold:     1 * time.Second,
 	})

--- a/internal/logmq/batchprocessor_test.go
+++ b/internal/logmq/batchprocessor_test.go
@@ -321,6 +321,10 @@ type mockAlertEvaluator struct {
 	returnErr error
 }
 
+// SignalsEnabled is true so the pipeline treats the mock as a live evaluator
+// (the gated path these tests exercise).
+func (m *mockAlertEvaluator) SignalsEnabled() bool { return true }
+
 func (m *mockAlertEvaluator) Evaluate(ctx context.Context, attempt alert.Attempt) (alert.Evaluation, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/logmq/characterization_acknowledgement_test.go
+++ b/internal/logmq/characterization_acknowledgement_test.go
@@ -72,15 +72,18 @@ func TestCharacterization_MixedBatchAccounting(t *testing.T) {
 	cmInvalid.requireNacked(t)
 	cmEmitFail.requireNacked(t)
 
-	// Only the alerting destination produced a (successful) record.
-	assert.Equal(t, []string{topicCF}, topics(h.sink.forDest(destAlert)))
+	// Successful records: one attempt event per processed attempt (the dup's
+	// kept copy included), plus the cf alert. The emit-fail destination
+	// recorded nothing — its sends all fail.
+	assert.ElementsMatch(t, []string{topicFailed, topicCF}, topics(h.sink.forDest(destAlert)))
+	assert.Equal(t, []string{topicSuccess}, topics(h.sink.forDest(destSuccess)))
+	assert.Equal(t, []string{topicSuccess}, topics(h.sink.forDest(destDup)), "the dup's kept copy emitted once")
 	assert.Empty(t, h.sink.forDest(destFail), "emit-fail destination produced no recorded event")
-	assert.Len(t, h.sink.snapshot(), 1, "exactly one event delivered to the sink")
+	assert.Len(t, h.sink.snapshot(), 4, "no records beyond the four accounted for")
 }
 
 // A single failed attempt below any threshold (count 1) → persisted, acked,
-// zero sink records (the "nothing to deliver" fast path: mark + ack, no
-// delivery task).
+// and only the attempt.failed event delivered — no alert topics.
 func TestCharacterization_BelowThresholdNoAlert(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t, harnessConfig{
@@ -94,6 +97,7 @@ func TestCharacterization_BelowThresholdNoAlert(t *testing.T) {
 	h.waitTerminal([]*countingMessage{cm})
 
 	cm.requireAcked(t)
-	assert.Empty(t, h.sink.snapshot(), "count 1 is below the 50%% threshold (5)")
+	assert.Equal(t, []string{topicFailed}, topics(h.sink.snapshot()),
+		"count 1 is below the 50%% threshold (5): only the attempt event, no alert")
 	require.Len(t, h.listAttempt(destA), 1, "attempt persisted")
 }

--- a/internal/logmq/characterization_decoupling_test.go
+++ b/internal/logmq/characterization_decoupling_test.go
@@ -52,7 +52,7 @@ func TestCharacterization_SlowDeliveryDoesNotBlockPersistence(t *testing.T) {
 	h.sink.release()
 	h.waitTerminal([]*countingMessage{cmSlow})
 	cmSlow.requireAcked(t)
-	assert.Equal(t, []string{topicCF}, topics(h.sink.forDest("dest_d1_slow")))
+	assert.ElementsMatch(t, []string{topicFailed, topicCF}, topics(h.sink.forDest("dest_d1_slow")))
 }
 
 // A hot destination's alerting attempts deliver in parallel — one slow send
@@ -89,7 +89,8 @@ func TestCharacterization_HotDestinationDeliversInParallel(t *testing.T) {
 		m.requireAcked(t)
 	}
 	assert.GreaterOrEqual(t, h.sink.maxInflightSends(), int32(3))
-	assert.ElementsMatch(t, []string{"att_1", "att_2", "att_3"}, attemptIDs(h.sink.forDest(destA)))
+	assert.ElementsMatch(t, []string{"att_1", "att_2", "att_3"},
+		attemptIDs(forTopic(h.sink.forDest(destA), topicCF)))
 }
 
 // Shutdown drains in-flight deliveries: every dispatched entry reaches its
@@ -118,5 +119,5 @@ func TestCharacterization_ShutdownDrainsDeliveries(t *testing.T) {
 
 	// Shutdown returned → the delivery completed and acked.
 	cm.requireAcked(t)
-	assert.Equal(t, []string{topicCF}, topics(h.sink.forDest("dest_d3")))
+	assert.ElementsMatch(t, []string{topicFailed, topicCF}, topics(h.sink.forDest("dest_d3")))
 }

--- a/internal/logmq/characterization_harness_test.go
+++ b/internal/logmq/characterization_harness_test.go
@@ -60,14 +60,15 @@ type sinkRecord struct {
 }
 
 // recordingSink implements opevents.Sink. It records each emitted event, can
-// inject Send errors keyed by attemptID or topic, and can block matching sends
-// until release() — simulating a slow sink. It also tracks how many sends run
-// concurrently. Injected-failure events are NOT recorded (so records reflect
-// only successfully delivered events).
+// inject Send errors keyed by attemptID, topic, or "attemptID/topic" (one
+// attempt's one send), and can block matching sends until release() —
+// simulating a slow sink. It also tracks how many sends run concurrently.
+// Injected-failure events are NOT recorded (so records reflect only
+// successfully delivered events).
 type recordingSink struct {
 	mu      sync.Mutex
 	records []sinkRecord
-	failOn  map[string]bool // key by attemptID or topic
+	failOn  map[string]bool // key by attemptID, topic, or attemptID+"/"+topic
 
 	blockOn     map[string]bool // block these sends (by attemptID or topic)...
 	blockCh     chan struct{}   // ...until this closes (via release)
@@ -117,7 +118,7 @@ func (s *recordingSink) Send(ctx context.Context, event *opevents.OperatorEvent)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.failOn[attemptID] || s.failOn[event.Topic] {
+	if s.failOn[attemptID] || s.failOn[event.Topic] || s.failOn[attemptID+"/"+event.Topic] {
 		return fmt.Errorf("injected send failure topic=%s attempt=%s", event.Topic, attemptID)
 	}
 	s.records = append(s.records, sinkRecord{topic: event.Topic, destID: destID, attemptID: attemptID})
@@ -500,8 +501,33 @@ func topicsForAttempt(recs []sinkRecord, attemptID string) []string {
 	return out
 }
 
+// forTopic filters a record slice down to one topic — e.g. to assert which
+// attempts carried the cf alerts without the per-attempt attempt.* noise.
+func forTopic(recs []sinkRecord, topic string) []sinkRecord {
+	out := []sinkRecord{}
+	for _, r := range recs {
+		if r.topic == topic {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// repeatTopic builds an expected-topics slice: n copies of topic, then rest.
+// Every attempt emits its attempt.success/attempt.failed event, so expected
+// multisets are mostly "one per attempt, plus the alerts".
+func repeatTopic(topic string, n int, rest ...string) []string {
+	out := make([]string, 0, n+len(rest))
+	for range n {
+		out = append(out, topic)
+	}
+	return append(out, rest...)
+}
+
 const (
 	topicCF       = opevents.TopicAlertConsecutiveFailure
 	topicDisabled = opevents.TopicAlertDestinationDisabled
 	topicExhaust  = opevents.TopicAlertExhaustedRetries
+	topicSuccess  = opevents.TopicAttemptSuccess
+	topicFailed   = opevents.TopicAttemptFailed
 )

--- a/internal/logmq/characterization_harness_test.go
+++ b/internal/logmq/characterization_harness_test.go
@@ -329,7 +329,7 @@ func newHarness(t *testing.T, cfg harnessConfig) *harness {
 
 	// NOTE: opevents.NewEmitter returns a NOOP emitter when topics is nil/empty.
 	// To accept all topics we must pass []string{"*"} (NOT nil).
-	emitter := opevents.NewEmitter(sink, "test-deploy", []string{"*"})
+	emitter := opevents.NewEmitter(sink, "test-deploy", []string{"*"}, logger)
 
 	thresholds := cfg.alert.thresholds
 	if thresholds == nil {

--- a/internal/logmq/characterization_harness_test.go
+++ b/internal/logmq/characterization_harness_test.go
@@ -163,6 +163,8 @@ type blockingEvaluator struct {
 	entered atomic.Int32 // evals that reached the inner evaluator
 }
 
+func (e *blockingEvaluator) SignalsEnabled() bool { return e.inner.SignalsEnabled() }
+
 func (e *blockingEvaluator) Evaluate(ctx context.Context, attempt alert.Attempt) (alert.Evaluation, error) {
 	if e.blockOn[attempt.AttemptID] {
 		e.blocked.Add(1)
@@ -268,13 +270,18 @@ type batcherConfig struct {
 	emitTimeout time.Duration
 }
 
-// alertConfig drives the real alert.Evaluator. Zero values fall back to defaults
-// (thresholds [50,70,90,100], autoDisableCount 10, retryMaxLimit 10).
+// alertConfig drives the real alert.Evaluator and emitter. Zero values fall
+// back to defaults (thresholds [50,70,90,100], autoDisableCount 10,
+// retryMaxLimit 10, all topics subscribed).
 type alertConfig struct {
 	thresholds       []int
 	autoDisableCount int
 	retryMaxLimit    int
 	withDisabler     bool // attach the recordingDisabler to the pipeline
+	signalsOff       bool // disable both evaluator signals (cf + exhausted)
+	// opeventTopics is the real emitter's subscription; nil = all ("*").
+	// Non-nil without attempt topics exercises the disabled-path early-outs.
+	opeventTopics []string
 }
 
 // doublesConfig controls test-double behavior. Zero values = passthrough: the
@@ -329,7 +336,11 @@ func newHarness(t *testing.T, cfg harnessConfig) *harness {
 
 	// NOTE: opevents.NewEmitter returns a NOOP emitter when topics is nil/empty.
 	// To accept all topics we must pass []string{"*"} (NOT nil).
-	emitter := opevents.NewEmitter(sink, "test-deploy", []string{"*"}, logger)
+	emitterTopics := cfg.alert.opeventTopics
+	if emitterTopics == nil {
+		emitterTopics = []string{"*"}
+	}
+	emitter := opevents.NewEmitter(sink, "test-deploy", emitterTopics, logger)
 
 	thresholds := cfg.alert.thresholds
 	if thresholds == nil {
@@ -343,10 +354,17 @@ func newHarness(t *testing.T, cfg harnessConfig) *harness {
 	if retryMaxLimit == 0 {
 		retryMaxLimit = 10
 	}
-	var evaluator logmq.AlertEvaluator = alert.NewEvaluator(alert.NewRedisAlertStore(redisClient, ""), retryMaxLimit,
+	evalOpts := []alert.Option{
 		alert.WithAutoDisableFailureCount(autoDisableCount),
 		alert.WithAlertThresholds(thresholds),
-	)
+	}
+	if cfg.alert.signalsOff {
+		evalOpts = append(evalOpts,
+			alert.WithConsecutiveFailureEnabled(false),
+			alert.WithExhaustedRetriesEnabled(false),
+		)
+	}
+	var evaluator logmq.AlertEvaluator = alert.NewEvaluator(alert.NewRedisAlertStore(redisClient, ""), retryMaxLimit, evalOpts...)
 	var evalDouble *blockingEvaluator
 	if cfg.doubles.evalBlockOn != nil {
 		evalDouble = &blockingEvaluator{

--- a/internal/logmq/characterization_idempotency_test.go
+++ b/internal/logmq/characterization_idempotency_test.go
@@ -40,7 +40,8 @@ func TestCharacterization_ReplaySameAttempt(t *testing.T) {
 	h.waitTerminal([]*countingMessage{cm2})
 
 	recs := h.sink.forDest(destA)
-	require.Equal(t, []string{topicCF}, topics(recs), "exactly one alert across both deliveries")
+	require.ElementsMatch(t, []string{topicFailed, topicCF}, topics(recs),
+		"exactly one attempt.failed and one alert across both deliveries — the replay is gated")
 
 	cm1.requireAcked(t)
 	cm2.requireAcked(t)
@@ -87,7 +88,10 @@ func TestCharacterization_StaleReplayAfterReset_Skipped(t *testing.T) {
 	h.add(msg4)
 	h.waitTerminal([]*countingMessage{cm4})
 
-	require.Empty(t, h.sink.forDest(destA), "stale replay must not count toward the fresh streak")
+	// One attempt event per processed message; the stale replay (skipped by the
+	// gate) adds nothing, and no alert topics fire — the fresh streak is at 1.
+	require.ElementsMatch(t, []string{topicFailed, topicSuccess, topicFailed}, topics(h.sink.forDest(destA)),
+		"stale replay must not count toward the fresh streak nor re-emit")
 	cm3.requireAcked(t)
 	cm4.requireAcked(t)
 }
@@ -114,7 +118,7 @@ func TestCharacterization_ExhaustedRetries(t *testing.T) {
 	h.waitTerminal([]*countingMessage{cm})
 
 	recs := h.sink.forDest(destA)
-	require.Equal(t, []string{topicExhaust}, topics(recs))
+	require.ElementsMatch(t, []string{topicExhaust, topicFailed}, topics(recs))
 
 	cm.requireAcked(t)
 }

--- a/internal/logmq/characterization_ordering_test.go
+++ b/internal/logmq/characterization_ordering_test.go
@@ -39,9 +39,10 @@ func TestCharacterization_ThresholdsThenDisable(t *testing.T) {
 	h.waitTerminal(msgs)
 
 	recs := h.sink.forDest(destA)
-	// cf at counts 5,7,9,10 (4 records) plus disabled at 10 (1 record) = 5
-	// records. Which attempts carry them is nondeterministic (concurrent eval).
-	require.ElementsMatch(t, []string{topicCF, topicCF, topicCF, topicDisabled, topicCF}, topics(recs))
+	// attempt.failed per attempt (10), plus cf at counts 5,7,9,10 and the
+	// disable at 10. Which attempts carry the alerts is nondeterministic
+	// (concurrent eval).
+	require.ElementsMatch(t, repeatTopic(topicFailed, 10, topicCF, topicCF, topicCF, topicCF, topicDisabled), topics(recs))
 
 	disabled := h.disabler.snapshot()
 	require.Len(t, disabled, 1)
@@ -81,10 +82,11 @@ func TestCharacterization_SuccessResetsConsecutiveCount(t *testing.T) {
 	}
 
 	recs := h.sink.forDest(destA)
-	// Two cf alerts, both at the 50% threshold (count 5), separated by the
-	// reset. The paced sequence makes the carrying attempts deterministic.
-	require.Equal(t, []string{topicCF, topicCF}, topics(recs))
-	require.Equal(t, []string{"fail_pre_5", "fail_post_5"}, attemptIDs(recs))
+	// One attempt event per message (10 failed, 1 success), plus two cf
+	// alerts, both at the 50% threshold (count 5), separated by the reset.
+	require.ElementsMatch(t, repeatTopic(topicFailed, 10, topicSuccess, topicCF, topicCF), topics(recs))
+	// The paced sequence makes the cf-carrying attempts deterministic.
+	require.Equal(t, []string{"fail_pre_5", "fail_post_5"}, attemptIDs(forTopic(recs, topicCF)))
 
 	// No disable: count never reached 10.
 	assert.Empty(t, h.disabler.snapshot())
@@ -118,7 +120,7 @@ func TestCharacterization_TwoDestinationsInterleaved(t *testing.T) {
 	}
 	h.waitTerminal(msgs)
 
-	wantTopics := []string{topicCF, topicCF, topicCF, topicDisabled, topicCF}
+	wantTopics := repeatTopic(topicFailed, 10, topicCF, topicCF, topicCF, topicCF, topicDisabled)
 	assert.ElementsMatch(t, wantTopics, topics(h.sink.forDest(destA)), "dest A records")
 	assert.ElementsMatch(t, wantTopics, topics(h.sink.forDest(destB)), "dest B records")
 
@@ -157,8 +159,9 @@ func TestCharacterization_CountContinuesAcrossBatches(t *testing.T) {
 	}
 	h.waitTerminal(batch1)
 
-	// Batch 1 fully terminal → exactly counts 1..6 landed: one cf (at 5).
-	require.ElementsMatch(t, []string{topicCF}, topics(h.sink.forDest(destA)))
+	// Batch 1 fully terminal → exactly counts 1..6 landed: six attempt.failed,
+	// one cf (at 5).
+	require.ElementsMatch(t, repeatTopic(topicFailed, 6, topicCF), topics(h.sink.forDest(destA)))
 
 	batch2 := make([]*countingMessage, 0, 4)
 	for i := 7; i <= 10; i++ {
@@ -170,7 +173,7 @@ func TestCharacterization_CountContinuesAcrossBatches(t *testing.T) {
 
 	// Batch 2 continues at count 7: cf at 7, 9, 10 plus the disable.
 	recs := h.sink.forDest(destA)
-	require.ElementsMatch(t, []string{topicCF, topicCF, topicCF, topicDisabled, topicCF}, topics(recs))
+	require.ElementsMatch(t, repeatTopic(topicFailed, 10, topicCF, topicCF, topicCF, topicCF, topicDisabled), topics(recs))
 
 	require.Len(t, h.disabler.snapshot(), 1)
 	for _, m := range append(batch1, batch2...) {

--- a/internal/logmq/characterization_postprocess_test.go
+++ b/internal/logmq/characterization_postprocess_test.go
@@ -49,7 +49,7 @@ func TestCharacterization_SlowEvalDoesNotBlockPersistence(t *testing.T) {
 	h.eval.release()
 	h.waitTerminal([]*countingMessage{cmSlow})
 	cmSlow.requireAcked(t)
-	assert.Equal(t, []string{topicCF}, topics(h.sink.forDest(dest)))
+	assert.ElementsMatch(t, []string{topicFailed, topicCF, topicSuccess}, topics(h.sink.forDest(dest)))
 }
 
 // One destination's attempts evaluate independently: while an attempt's eval
@@ -85,8 +85,8 @@ func TestCharacterization_SameDestEvalsRunIndependently(t *testing.T) {
 	h.waitTerminal([]*countingMessage{cm1})
 	cm1.requireAcked(t)
 	recs := h.sink.forDest(dest)
-	assert.ElementsMatch(t, []string{"att_pp3_1", "att_pp3_2"}, attemptIDs(recs))
-	assert.ElementsMatch(t, []string{topicCF, topicCF}, topics(recs))
+	assert.ElementsMatch(t, []string{"att_pp3_1", "att_pp3_2"}, attemptIDs(forTopic(recs, topicCF)))
+	assert.ElementsMatch(t, []string{topicCF, topicCF, topicFailed, topicFailed}, topics(recs))
 }
 
 // Shutdown drains the in-flight entry goroutines: every dispatched entry
@@ -115,5 +115,5 @@ func TestCharacterization_ShutdownDrainsPostprocess(t *testing.T) {
 
 	// Shutdown returned → the eval ran, the alert delivered and the msg acked.
 	cm.requireAcked(t)
-	assert.Equal(t, []string{topicCF}, topics(h.sink.forDest("dest_pp4")))
+	assert.ElementsMatch(t, []string{topicFailed, topicCF}, topics(h.sink.forDest("dest_pp4")))
 }

--- a/internal/logmq/delivery_failure_test.go
+++ b/internal/logmq/delivery_failure_test.go
@@ -55,8 +55,8 @@ func TestDelivery_MarkProcessedFailure_Nacks(t *testing.T) {
 	h.waitTerminal([]*countingMessage{cm})
 
 	cm.requireNacked(t)
-	assert.Equal(t, []string{topicCF}, topics(h.sink.forDest(dest)),
-		"the event was delivered before the mark failed")
+	assert.ElementsMatch(t, []string{topicFailed, topicCF}, topics(h.sink.forDest(dest)),
+		"the events were delivered before the mark failed")
 }
 
 // An attempt owing two events (disabled + cf at the 100% threshold) where one

--- a/internal/logmq/delivery_suppression_test.go
+++ b/internal/logmq/delivery_suppression_test.go
@@ -70,7 +70,7 @@ func TestDelivery_ExhaustedRetries_WindowSuppression(t *testing.T) {
 
 	cm1.requireAcked(t)
 	cm2.requireAcked(t)
-	assert.Equal(t, []string{topicExhaust}, topics(h.sink.forDest(dest)),
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust}, topics(h.sink.forDest(dest)),
 		"second exhaustion of the same event+destination is suppressed within the window")
 }
 
@@ -94,7 +94,7 @@ func TestDelivery_ExhaustedRetries_NoWindowEmitsEvery(t *testing.T) {
 
 	cm1.requireAcked(t)
 	cm2.requireAcked(t)
-	assert.Equal(t, []string{topicExhaust, topicExhaust}, topics(h.sink.forDest(dest)),
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust, topicExhaust}, topics(h.sink.forDest(dest)),
 		"with no window, every exhaustion of the same event+destination delivers")
 }
 
@@ -118,7 +118,7 @@ func TestDelivery_ExhaustedRetries_PerEvent(t *testing.T) {
 
 	cm1.requireAcked(t)
 	cm2.requireAcked(t)
-	assert.Equal(t, []string{topicExhaust, topicExhaust}, topics(h.sink.forDest(dest)),
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust, topicExhaust}, topics(h.sink.forDest(dest)),
 		"each distinct event exhausting retries delivers its own alert")
 }
 
@@ -132,7 +132,10 @@ func TestDelivery_ExhaustedRetries_EmitFailureClearsWindow(t *testing.T) {
 		alert:   exhaustedAlertConfig(),
 		doubles: doublesConfig{
 			idemp:      idemp,
-			sinkFailOn: map[string]bool{"att_fail": true}, // first exhausted emit fails
+			// Only the exhausted send fails — att_fail's attempt.failed must
+			// deliver, or its errgroup sibling cancels the exhausted Exec
+			// mid-flight instead of exercising the clear-on-failure path.
+			sinkFailOn: map[string]bool{"att_fail/" + topicExhaust: true},
 		},
 	})
 
@@ -149,6 +152,6 @@ func TestDelivery_ExhaustedRetries_EmitFailureClearsWindow(t *testing.T) {
 	// The failed emit nacks; the retry (key cleared on failure) delivers and acks.
 	cmFail.requireNacked(t)
 	cmOK.requireAcked(t)
-	assert.Equal(t, []string{topicExhaust}, topics(h.sink.forDest(dest)),
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust}, topics(h.sink.forDest(dest)),
 		"retry after emit failure re-delivers because the window key was cleared")
 }

--- a/internal/logmq/delivery_suppression_test.go
+++ b/internal/logmq/delivery_suppression_test.go
@@ -131,7 +131,7 @@ func TestDelivery_ExhaustedRetries_EmitFailureClearsWindow(t *testing.T) {
 		batcher: batcherConfig{itemCount: 1},
 		alert:   exhaustedAlertConfig(),
 		doubles: doublesConfig{
-			idemp:      idemp,
+			idemp: idemp,
 			// Only the exhausted send fails — att_fail's attempt.failed must
 			// deliver, or its errgroup sibling cancels the exhausted Exec
 			// mid-flight instead of exercising the clear-on-failure path.

--- a/internal/logmq/disabled_paths_test.go
+++ b/internal/logmq/disabled_paths_test.go
@@ -1,0 +1,93 @@
+package logmq_test
+
+// Early-outs when alert signals and/or attempt opevents are configured off:
+// per-entry cost should scale with what's enabled. With every signal off the
+// failed path skips the replay gate (nothing to protect — attempt.failed is
+// at-least-once like attempt.success); with attempt topics also unsubscribed
+// the per-entry pipeline is skipped entirely.
+
+import (
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// With alert signals off, a failed attempt emits attempt.failed and acks —
+// ungated, so a replay of the same attempt re-emits instead of being skipped
+// (the gated path pins the opposite in ReplaySameAttempt). No alert topics
+// fire and nothing is disabled, no matter how many failures accumulate.
+func TestDisabledSignals_FailedEmitsUngated(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 1},
+		alert:   alertConfig{autoDisableCount: 2, thresholds: []int{50, 100}, withDisabler: true, signalsOff: true},
+	})
+
+	dest, tenant := "dest_ds1", "tenant_ds1"
+	cm1, msg1 := newCountingMessage(makeEntry(dest, tenant, "att_ds_1", models.AttemptStatusFailed))
+	cm2, msg2 := newCountingMessage(makeEntry(dest, tenant, "att_ds_2", models.AttemptStatusFailed))
+	cmOK, msgOK := newCountingMessage(makeEntry(dest, tenant, "att_ds_ok", models.AttemptStatusSuccess))
+	// Paced: the replay below needs att_ds_1 terminal before its copy arrives.
+	h.add(msg1)
+	h.waitTerminal([]*countingMessage{cm1})
+	cmReplay, msgReplay := newCountingMessage(makeEntry(dest, tenant, "att_ds_1", models.AttemptStatusFailed))
+	h.add(msgReplay)
+	h.add(msg2)
+	h.add(msgOK)
+	h.waitTerminal([]*countingMessage{cm2, cmOK, cmReplay})
+
+	cm1.requireAcked(t)
+	cm2.requireAcked(t)
+	cmOK.requireAcked(t)
+	cmReplay.requireAcked(t)
+
+	recs := h.sink.forDest(dest)
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicFailed, topicSuccess}, topics(recs),
+		"every failed copy emits (no gate), success emits, no alert topics fire")
+	assert.ElementsMatch(t, []string{"att_ds_1", "att_ds_1", "att_ds_2"}, attemptIDs(forTopic(recs, topicFailed)),
+		"the replayed attempt emits twice — ungated")
+	assert.Empty(t, h.disabler.snapshot(), "signals off never disables, past any threshold")
+}
+
+// With alert signals off, a failed attempt.failed send still nacks for
+// redelivery — the early-out skips the gate, not the delivery guarantee.
+func TestDisabledSignals_FailedEmitFailure_Nacks(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 1},
+		alert:   alertConfig{signalsOff: true},
+		doubles: doublesConfig{sinkFailOn: map[string]bool{topicFailed: true}},
+	})
+
+	dest, tenant := "dest_ds2", "tenant_ds2"
+	cm, msg := newCountingMessage(makeEntry(dest, tenant, "att_ds_f", models.AttemptStatusFailed))
+	h.add(msg)
+	h.waitTerminal([]*countingMessage{cm})
+
+	cm.requireNacked(t)
+	assert.Empty(t, h.sink.forDest(dest))
+}
+
+// Signals off AND no attempt topic subscribed: the pipeline can't produce
+// anything, so entries ack straight after persistence — no goroutine, no
+// Redis, no sink traffic.
+func TestDisabledSignals_NothingEnabled_AcksAfterPersist(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 2},
+		alert:   alertConfig{signalsOff: true, opeventTopics: []string{topicCF}},
+	})
+
+	dest, tenant := "dest_ds3", "tenant_ds3"
+	cmFail, msgFail := newCountingMessage(makeEntry(dest, tenant, "att_ds_n1", models.AttemptStatusFailed))
+	cmOK, msgOK := newCountingMessage(makeEntry(dest, tenant, "att_ds_n2", models.AttemptStatusSuccess))
+	h.add(msgFail)
+	h.add(msgOK)
+	h.waitTerminal([]*countingMessage{cmFail, cmOK})
+
+	cmFail.requireAcked(t)
+	cmOK.requireAcked(t)
+	assert.Empty(t, h.sink.snapshot(), "nothing enabled, nothing emitted")
+	assert.Len(t, h.listAttempt(dest), 2, "persistence is unaffected by the early-out")
+}

--- a/internal/opevents/emitter.go
+++ b/internal/opevents/emitter.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/hookdeck/outpost/internal/idgen"
+	"github.com/hookdeck/outpost/internal/logging"
+	"go.uber.org/zap"
 )
 
 const (
@@ -21,6 +23,9 @@ type Event struct {
 	Topic    string
 	TenantID string
 	Data     any
+	// LogFields is caller context attached to the delivery audit line —
+	// typically set by the payload constructors, not at emit call sites.
+	LogFields []zap.Field
 }
 
 // Emitter is the interface for emitting operator events.
@@ -33,12 +38,15 @@ type emitter struct {
 	sink         Sink
 	deploymentID string
 	topicFilter  map[string]bool // nil means accept all ("*")
+	logger       *logging.Logger
 }
 
 // NewEmitter creates an Emitter that filters by topics, builds the envelope, and
 // delegates to the provided Sink. If topics contains "*", all topics are accepted.
-// If topics is empty, a noop emitter is returned.
-func NewEmitter(sink Sink, deploymentID string, topics []string) Emitter {
+// If topics is empty, a noop emitter is returned. The emitter owns the delivery
+// audit log: a line is written iff an event was actually sent — filtered topics
+// and the noop emitter return nil without logging.
+func NewEmitter(sink Sink, deploymentID string, topics []string, logger *logging.Logger) Emitter {
 	if len(topics) == 0 {
 		return &noopEmitter{}
 	}
@@ -59,6 +67,7 @@ func NewEmitter(sink Sink, deploymentID string, topics []string) Emitter {
 		sink:         sink,
 		deploymentID: deploymentID,
 		topicFilter:  filter,
+		logger:       logger,
 	}
 }
 
@@ -82,7 +91,17 @@ func (e *emitter) Emit(ctx context.Context, ev Event) error {
 		Data:         rawData,
 	}
 
-	return e.sendWithRetry(ctx, event)
+	if err := e.sendWithRetry(ctx, event); err != nil {
+		return err
+	}
+
+	e.logger.Ctx(ctx).Audit("opevent delivered",
+		append([]zap.Field{
+			zap.String("opevent_id", event.ID),
+			zap.String("topic", event.Topic),
+			zap.String("tenant_id", event.TenantID),
+		}, ev.LogFields...)...)
+	return nil
 }
 
 func (e *emitter) sendWithRetry(ctx context.Context, event *OperatorEvent) error {

--- a/internal/opevents/emitter.go
+++ b/internal/opevents/emitter.go
@@ -31,6 +31,10 @@ type Event struct {
 // Emitter is the interface for emitting operator events.
 type Emitter interface {
 	Emit(ctx context.Context, ev Event) error
+	// Enabled reports whether events on topic would be sent rather than
+	// discarded by the topic filter. Lets callers skip building events that
+	// would be dropped.
+	Enabled(topic string) bool
 }
 
 // emitter is the default Emitter implementation.
@@ -71,9 +75,13 @@ func NewEmitter(sink Sink, deploymentID string, topics []string, logger *logging
 	}
 }
 
+func (e *emitter) Enabled(topic string) bool {
+	// nil filter means accept all ("*")
+	return e.topicFilter == nil || e.topicFilter[topic]
+}
+
 func (e *emitter) Emit(ctx context.Context, ev Event) error {
-	// Topic filtering: nil filter means accept all ("*")
-	if e.topicFilter != nil && !e.topicFilter[ev.Topic] {
+	if !e.Enabled(ev.Topic) {
 		return nil
 	}
 
@@ -134,3 +142,5 @@ type noopEmitter struct{}
 func (e *noopEmitter) Emit(ctx context.Context, ev Event) error {
 	return nil
 }
+
+func (e *noopEmitter) Enabled(topic string) bool { return false }

--- a/internal/opevents/emitter_test.go
+++ b/internal/opevents/emitter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hookdeck/outpost/internal/opevents"
+	"github.com/hookdeck/outpost/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +50,7 @@ func TestEmitter_Emit(t *testing.T) {
 	t.Run("wildcard topic filter accepts all topics", func(t *testing.T) {
 		t.Parallel()
 		sink := &mockSink{}
-		em := opevents.NewEmitter(sink, "deploy-1", []string{"*"})
+		em := opevents.NewEmitter(sink, "deploy-1", []string{"*"}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: "any.topic", TenantID: "tenant-1", Data: map[string]string{"key": "val"}})
 		require.NoError(t, err)
@@ -67,7 +68,7 @@ func TestEmitter_Emit(t *testing.T) {
 		em := opevents.NewEmitter(sink, "", []string{
 			opevents.TopicAlertConsecutiveFailure,
 			opevents.TopicTenantSubscriptionUpdated,
-		})
+		}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: opevents.TopicAlertConsecutiveFailure, TenantID: "t1", Data: "data"})
 		require.NoError(t, err)
@@ -77,7 +78,7 @@ func TestEmitter_Emit(t *testing.T) {
 	t.Run("specific topic filter drops non-matching topics", func(t *testing.T) {
 		t.Parallel()
 		sink := &mockSink{}
-		em := opevents.NewEmitter(sink, "", []string{opevents.TopicAlertConsecutiveFailure})
+		em := opevents.NewEmitter(sink, "", []string{opevents.TopicAlertConsecutiveFailure}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: opevents.TopicTenantSubscriptionUpdated, TenantID: "t1", Data: "data"})
 		require.NoError(t, err)
@@ -87,7 +88,7 @@ func TestEmitter_Emit(t *testing.T) {
 	t.Run("envelope fields are populated", func(t *testing.T) {
 		t.Parallel()
 		sink := &mockSink{}
-		em := opevents.NewEmitter(sink, "prod", []string{"*"})
+		em := opevents.NewEmitter(sink, "prod", []string{"*"}, testutil.CreateTestLogger(t))
 
 		type payload struct {
 			Count int `json:"count"`
@@ -114,7 +115,7 @@ func TestEmitter_Emit(t *testing.T) {
 	t.Run("deployment_id omitted when empty", func(t *testing.T) {
 		t.Parallel()
 		sink := &mockSink{}
-		em := opevents.NewEmitter(sink, "", []string{"*"})
+		em := opevents.NewEmitter(sink, "", []string{"*"}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: "t", TenantID: "tenant", Data: "data"})
 		require.NoError(t, err)
@@ -132,7 +133,7 @@ func TestEmitter_Emit(t *testing.T) {
 	t.Run("empty topics returns noop emitter", func(t *testing.T) {
 		t.Parallel()
 		sink := &mockSink{}
-		em := opevents.NewEmitter(sink, "", []string{})
+		em := opevents.NewEmitter(sink, "", []string{}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: "any.topic", TenantID: "t1", Data: "data"})
 		require.NoError(t, err)
@@ -148,7 +149,7 @@ func TestEmitter_Emit(t *testing.T) {
 				nil, // third attempt succeeds
 			},
 		}
-		em := opevents.NewEmitter(sink, "", []string{"*"})
+		em := opevents.NewEmitter(sink, "", []string{"*"}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: "t", TenantID: "t1", Data: "data"})
 		require.NoError(t, err)
@@ -164,7 +165,7 @@ func TestEmitter_Emit(t *testing.T) {
 				errors.New("fail-3"),
 			},
 		}
-		em := opevents.NewEmitter(sink, "", []string{"*"})
+		em := opevents.NewEmitter(sink, "", []string{"*"}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(context.Background(), opevents.Event{Topic: "t", TenantID: "t1", Data: "data"})
 		require.Error(t, err)
@@ -180,7 +181,7 @@ func TestEmitter_Emit(t *testing.T) {
 		sink := &mockSink{
 			errs: []error{errors.New("fail")},
 		}
-		em := opevents.NewEmitter(sink, "", []string{"*"})
+		em := opevents.NewEmitter(sink, "", []string{"*"}, testutil.CreateTestLogger(t))
 
 		err := em.Emit(ctx, opevents.Event{Topic: "t", TenantID: "t1", Data: "data"})
 		require.Error(t, err)

--- a/internal/opevents/event.go
+++ b/internal/opevents/event.go
@@ -10,6 +10,8 @@ const (
 	TopicAlertConsecutiveFailure   = "alert.destination.consecutive_failure"
 	TopicAlertDestinationDisabled  = "alert.destination.disabled"
 	TopicAlertExhaustedRetries     = "alert.attempt.exhausted_retries"
+	TopicAttemptSuccess            = "attempt.success"
+	TopicAttemptFailed             = "attempt.failed"
 	TopicTenantSubscriptionUpdated = "tenant.subscription.updated"
 )
 

--- a/internal/opevents/payloads.go
+++ b/internal/opevents/payloads.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/hookdeck/outpost/internal/models"
+	"go.uber.org/zap"
 )
 
 // Operator-event payloads: the wire contract for each topic. The typed
@@ -53,6 +54,17 @@ func NewAlertDestination(d *models.Destination) *AlertDestination {
 	}
 }
 
+// attemptLogFields is the delivery-audit log context shared by the
+// per-attempt event constructors.
+func attemptLogFields(dest *AlertDestination, event *models.Event, attempt *models.Attempt) []zap.Field {
+	return []zap.Field{
+		zap.String("attempt_id", attempt.ID),
+		zap.String("event_id", event.ID),
+		zap.String("destination_id", dest.ID),
+		zap.String("destination_type", dest.Type),
+	}
+}
+
 // ConsecutiveFailures represents the nested consecutive failure state.
 type ConsecutiveFailures struct {
 	Current   int `json:"current"`
@@ -90,8 +102,9 @@ type ExhaustedRetriesData struct {
 // ConsecutiveFailureEvent builds the alert.destination.consecutive_failure event.
 func ConsecutiveFailureEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt, current, max, threshold int) Event {
 	return Event{
-		Topic:    TopicAlertConsecutiveFailure,
-		TenantID: dest.TenantID,
+		Topic:     TopicAlertConsecutiveFailure,
+		TenantID:  dest.TenantID,
+		LogFields: attemptLogFields(dest, event, attempt),
 		Data: ConsecutiveFailureData{
 			TenantID:    dest.TenantID,
 			Event:       event,
@@ -109,8 +122,9 @@ func ConsecutiveFailureEvent(dest *AlertDestination, event *models.Event, attemp
 // DestinationDisabledEvent builds the alert.destination.disabled event.
 func DestinationDisabledEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt, disabledAt time.Time) Event {
 	return Event{
-		Topic:    TopicAlertDestinationDisabled,
-		TenantID: dest.TenantID,
+		Topic:     TopicAlertDestinationDisabled,
+		TenantID:  dest.TenantID,
+		LogFields: attemptLogFields(dest, event, attempt),
 		Data: DestinationDisabledData{
 			TenantID:    dest.TenantID,
 			Destination: dest,
@@ -125,8 +139,9 @@ func DestinationDisabledEvent(dest *AlertDestination, event *models.Event, attem
 // ExhaustedRetriesEvent builds the alert.attempt.exhausted_retries event.
 func ExhaustedRetriesEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt) Event {
 	return Event{
-		Topic:    TopicAlertExhaustedRetries,
-		TenantID: dest.TenantID,
+		Topic:     TopicAlertExhaustedRetries,
+		TenantID:  dest.TenantID,
+		LogFields: attemptLogFields(dest, event, attempt),
 		Data: ExhaustedRetriesData{
 			TenantID:    dest.TenantID,
 			Event:       event,
@@ -149,8 +164,9 @@ type AttemptData struct {
 // AttemptSuccessEvent builds the attempt.success event.
 func AttemptSuccessEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt) Event {
 	return Event{
-		Topic:    TopicAttemptSuccess,
-		TenantID: dest.TenantID,
+		Topic:     TopicAttemptSuccess,
+		TenantID:  dest.TenantID,
+		LogFields: attemptLogFields(dest, event, attempt),
 		Data: AttemptData{
 			TenantID:    dest.TenantID,
 			Event:       event,
@@ -163,8 +179,9 @@ func AttemptSuccessEvent(dest *AlertDestination, event *models.Event, attempt *m
 // AttemptFailedEvent builds the attempt.failed event.
 func AttemptFailedEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt) Event {
 	return Event{
-		Topic:    TopicAttemptFailed,
-		TenantID: dest.TenantID,
+		Topic:     TopicAttemptFailed,
+		TenantID:  dest.TenantID,
+		LogFields: attemptLogFields(dest, event, attempt),
 		Data: AttemptData{
 			TenantID:    dest.TenantID,
 			Event:       event,

--- a/internal/opevents/payloads.go
+++ b/internal/opevents/payloads.go
@@ -135,3 +135,41 @@ func ExhaustedRetriesEvent(dest *AlertDestination, event *models.Event, attempt 
 		},
 	}
 }
+
+// AttemptData is the data payload for attempt.success and attempt.failed
+// events. The two topics share one shape — the split exists for subscription
+// filtering, and Attempt.Status carries the outcome.
+type AttemptData struct {
+	TenantID    string            `json:"tenant_id"`
+	Event       *models.Event     `json:"event"`
+	Attempt     *models.Attempt   `json:"attempt"`
+	Destination *AlertDestination `json:"destination"`
+}
+
+// AttemptSuccessEvent builds the attempt.success event.
+func AttemptSuccessEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt) Event {
+	return Event{
+		Topic:    TopicAttemptSuccess,
+		TenantID: dest.TenantID,
+		Data: AttemptData{
+			TenantID:    dest.TenantID,
+			Event:       event,
+			Attempt:     attempt,
+			Destination: dest,
+		},
+	}
+}
+
+// AttemptFailedEvent builds the attempt.failed event.
+func AttemptFailedEvent(dest *AlertDestination, event *models.Event, attempt *models.Attempt) Event {
+	return Event{
+		Topic:    TopicAttemptFailed,
+		TenantID: dest.TenantID,
+		Data: AttemptData{
+			TenantID:    dest.TenantID,
+			Event:       event,
+			Attempt:     attempt,
+			Destination: dest,
+		},
+	}
+}

--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -204,7 +204,7 @@ func (b *ServiceBuilder) BuildAPIWorkers(baseRouter *gin.Engine) error {
 	if err != nil {
 		return fmt.Errorf("failed to create operator events sink: %w", err)
 	}
-	subscriptionEmitter := opevents.NewEmitter(oeSink, b.cfg.DeploymentID, oeCfg.Topics)
+	subscriptionEmitter := opevents.NewEmitter(oeSink, b.cfg.DeploymentID, oeCfg.Topics, b.logger)
 
 	apiHandler := apirouter.NewRouter(
 		apirouter.RouterConfig{
@@ -357,7 +357,7 @@ func (b *ServiceBuilder) BuildLogWorker(baseRouter *gin.Engine) error {
 	if err != nil {
 		return fmt.Errorf("failed to create operator events sink: %w", err)
 	}
-	emitter := opevents.NewEmitter(sink, b.cfg.DeploymentID, oeCfg.Topics)
+	emitter := opevents.NewEmitter(sink, b.cfg.DeploymentID, oeCfg.Topics, b.logger)
 
 	alertSettings, err := b.cfg.Alert.ToConfig()
 	if err != nil {


### PR DESCRIPTION
implements #981

Adds two operator events, plus config-based optimizations along the way.

**New topics: `attempt.success` and `attempt.failed`** — one event per delivery attempt, emitted from logmq after the attempt is persisted. The payload matches the `exhausted_retries` shape. Note: existing `*` subscribers start receiving every attempt event on upgrade — worth a release-note callout.

**Skip unnecessary work when config doesn't need it** — with alerting disabled, failed attempts skip the alert logic and its Redis calls; with attempt events also unsubscribed, entries just persist and ack.