### PR TITLE
fix(mqs): redial dropped RabbitMQ connections instead of wedging until restart

### DIFF
--- a/internal/mqs/export_test.go
+++ b/internal/mqs/export_test.go
@@ -1,0 +1,12 @@
+package mqs
+
+func ForceCloseRabbitMQConnection(q Queue) error {
+	rq := q.(*RabbitMQQueue)
+	rq.mu.Lock()
+	conn := rq.conn
+	rq.mu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.Close()
+}

--- a/internal/mqs/queue_rabbitmq.go
+++ b/internal/mqs/queue_rabbitmq.go
@@ -3,11 +3,14 @@ package mqs
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/rabbitmq/amqp091-go"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/rabbitpubsub"
 )
+
+const rabbitmqRedialCooldown = 5 * time.Second
 
 type RabbitMQConfig struct {
 	ServerURL string
@@ -16,11 +19,13 @@ type RabbitMQConfig struct {
 }
 
 type RabbitMQQueue struct {
-	base   *wrappedBaseQueue
-	conn   *amqp091.Connection
-	config *RabbitMQConfig
-	topic  *pubsub.Topic
-	mu     sync.Mutex
+	base            *wrappedBaseQueue
+	conn            *amqp091.Connection
+	config          *RabbitMQConfig
+	topic           *pubsub.Topic
+	mu              sync.Mutex
+	lastDialFailure time.Time
+	lastDialErr     error
 }
 
 var _ Queue = &RabbitMQQueue{}
@@ -74,10 +79,16 @@ func (q *RabbitMQQueue) ensureConnected() (*pubsub.Topic, *amqp091.Connection, e
 	if q.conn != nil && !q.conn.IsClosed() {
 		return q.topic, q.conn, nil
 	}
+	if q.lastDialErr != nil && time.Since(q.lastDialFailure) < rabbitmqRedialCooldown {
+		return nil, nil, q.lastDialErr
+	}
 	conn, err := amqp091.Dial(q.config.ServerURL)
 	if err != nil {
+		q.lastDialFailure = time.Now()
+		q.lastDialErr = err
 		return nil, nil, err
 	}
+	q.lastDialErr = nil
 	if oldTopic := q.topic; oldTopic != nil {
 		go oldTopic.Shutdown(context.Background())
 	}

--- a/internal/mqs/queue_rabbitmq.go
+++ b/internal/mqs/queue_rabbitmq.go
@@ -17,65 +17,87 @@ type RabbitMQConfig struct {
 
 type RabbitMQQueue struct {
 	base   *wrappedBaseQueue
-	once   *sync.Once
 	conn   *amqp091.Connection
 	config *RabbitMQConfig
 	topic  *pubsub.Topic
+	mu    sync.Mutex
 }
 
 var _ Queue = &RabbitMQQueue{}
 
 func (q *RabbitMQQueue) Init(ctx context.Context) (func(), error) {
-	var err error
-	q.once.Do(func() {
-		err = q.InitConn()
-	})
+	if _, _, err := q.ensureConnected(); err != nil {
+		return nil, err
+	}
+	return func() {
+		q.mu.Lock()
+		conn, topic := q.conn, q.topic
+		q.mu.Unlock()
+		if conn != nil {
+			conn.Close()
+		}
+		if topic != nil {
+			topic.Shutdown(ctx)
+		}
+	}, nil
+}
+
+func (q *RabbitMQQueue) Publish(ctx context.Context, incomingMessage IncomingMessage) error {
+	topic, _, err := q.ensureConnected()
+	if err != nil {
+		return err
+	}
+	metadata := map[string]string{"Queue": q.config.Queue}
+	err = q.base.Publish(ctx, topic, incomingMessage, metadata)
+	if err == nil || !q.connectionLost() {
+		return err
+	}
+	topic, _, rerr := q.ensureConnected()
+	if rerr != nil {
+		return err
+	}
+	return q.base.Publish(ctx, topic, incomingMessage, metadata)
+}
+
+func (q *RabbitMQQueue) Subscribe(ctx context.Context, opts ...SubscribeOption) (Subscription, error) {
+	_, conn, err := q.ensureConnected()
 	if err != nil {
 		return nil, err
 	}
+	subscription := rabbitpubsub.OpenSubscription(conn, q.config.Queue, nil)
+	return q.base.Subscribe(ctx, subscription)
+}
 
+func (q *RabbitMQQueue) ensureConnected() (*pubsub.Topic, *amqp091.Connection, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.conn != nil && !q.conn.IsClosed() {
+		return q.topic, q.conn, nil
+	}
+	conn, err := amqp091.Dial(q.config.ServerURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	if oldTopic := q.topic; oldTopic != nil {
+		go oldTopic.Shutdown(context.Background())
+	}
 	var opts *rabbitpubsub.TopicOptions
 	if q.config.Queue != "" {
 		opts = &rabbitpubsub.TopicOptions{
 			KeyName: "Queue",
 		}
 	}
-
-	q.topic = rabbitpubsub.OpenTopic(q.conn, q.config.Exchange, opts)
-	return func() {
-		q.conn.Close()
-		q.topic.Shutdown(ctx)
-	}, nil
-}
-
-func (q *RabbitMQQueue) Publish(ctx context.Context, incomingMessage IncomingMessage) error {
-	return q.base.Publish(ctx, q.topic, incomingMessage, map[string]string{
-		"Queue": q.config.Queue,
-	})
-}
-
-func (q *RabbitMQQueue) Subscribe(ctx context.Context, opts ...SubscribeOption) (Subscription, error) {
-	var err error
-	q.once.Do(func() {
-		err = q.InitConn()
-	})
-	if err != nil {
-		return nil, err
-	}
-	subscription := rabbitpubsub.OpenSubscription(q.conn, q.config.Queue, nil)
-	return q.base.Subscribe(ctx, subscription)
-}
-
-func (q *RabbitMQQueue) InitConn() error {
-	conn, err := amqp091.Dial(q.config.ServerURL)
-	if err != nil {
-		return err
-	}
 	q.conn = conn
-	return nil
+	q.topic = rabbitpubsub.OpenTopic(conn, q.config.Exchange, opts)
+	return q.topic, q.conn, nil
+}
+
+func (q *RabbitMQQueue) connectionLost() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.conn == nil || q.conn.IsClosed()
 }
 
 func NewRabbitMQQueue(config *RabbitMQConfig) *RabbitMQQueue {
-	var once sync.Once
-	return &RabbitMQQueue{config: config, once: &once, base: newWrappedBaseQueue()}
+	return &RabbitMQQueue{config: config, base: newWrappedBaseQueue()}
 }

--- a/internal/mqs/queue_rabbitmq.go
+++ b/internal/mqs/queue_rabbitmq.go
@@ -20,7 +20,7 @@ type RabbitMQQueue struct {
 	conn   *amqp091.Connection
 	config *RabbitMQConfig
 	topic  *pubsub.Topic
-	mu    sync.Mutex
+	mu     sync.Mutex
 }
 
 var _ Queue = &RabbitMQQueue{}

--- a/internal/mqs/queue_rabbitmq_test.go
+++ b/internal/mqs/queue_rabbitmq_test.go
@@ -1,0 +1,49 @@
+package mqs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hookdeck/outpost/internal/mqs"
+	"github.com/hookdeck/outpost/internal/util/testinfra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationMQ_RabbitMQPublishReconnects(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(testinfra.Start(t))
+	config := testinfra.NewMQRabbitMQConfig(t)
+
+	ctx := context.Background()
+	queue := mqs.NewQueue(&config)
+	cleanup, err := queue.Init(ctx)
+	require.NoError(t, err)
+	defer cleanup()
+
+	receive := func(t *testing.T) *Msg {
+		t.Helper()
+		subscription, err := queue.Subscribe(ctx)
+		require.NoError(t, err)
+		defer subscription.Shutdown(ctx)
+		receiveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		msg, err := subscription.Receive(receiveCtx)
+		require.NoError(t, err)
+		msg.Ack()
+		parsed := &Msg{}
+		require.NoError(t, parsed.FromMessage(msg))
+		return parsed
+	}
+
+	// Sanity check: publish and receive over the initial connection.
+	require.NoError(t, queue.Publish(ctx, &Msg{ID: "before-disconnect"}))
+	require.Equal(t, "before-disconnect", receive(t).ID)
+
+	// Simulate the broker dropping the connection.
+	require.NoError(t, mqs.ForceCloseRabbitMQConnection(queue))
+
+	// The publish must transparently redial instead of failing forever.
+	require.NoError(t, queue.Publish(ctx, &Msg{ID: "after-disconnect"}))
+	require.Equal(t, "after-disconnect", receive(t).ID)
+}

--- a/internal/mqs/queue_rabbitmq_test.go
+++ b/internal/mqs/queue_rabbitmq_test.go
@@ -10,6 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMQ_RabbitMQRedialCooldown(t *testing.T) {
+	t.Parallel()
+	queue := mqs.NewRabbitMQQueue(&mqs.RabbitMQConfig{
+		ServerURL: "amqp://guest:guest@127.0.0.1:1/",
+		Queue:     "test",
+	})
+	ctx := context.Background()
+
+	// The broker is unreachable, so the first publish dials and fails.
+	firstErr := queue.Publish(ctx, &Msg{ID: "first"})
+	require.Error(t, firstErr)
+
+	// Within the cooldown the cached dial error is returned without redialing.
+	require.ErrorIs(t, queue.Publish(ctx, &Msg{ID: "second"}), firstErr)
+}
+
 func TestIntegrationMQ_RabbitMQPublishReconnects(t *testing.T) {
 	t.Parallel()
 	t.Cleanup(testinfra.Start(t))


### PR DESCRIPTION
This fixes the issue where a dropped RabbitMQ connection permanently wedged the queue: the connection was dialed once via sync.Once, so after a broker restart or network blip every subsequent publish failed against the closed connection until the whole pod was restarted. (explained in this issue #998)

The implementation replaces the sync.Once with a mutex-guarded ensureConnected that lazily redials whenever the current connection is nil or closed, reopening the topic on the new connection (the stale topic is shut down in the background). Publish additionally retries once: if a publish fails and the connection turns out to be lost, it redials and re-attempts before surfacing the error.

If the redial itself fails, the original publish error is returned rather than the dial error, so callers see the real failure. Subscribe goes through the same path, so consumers created after a drop also get a fresh connection.