### PR TITLE
docs: v1.1 upgrade guide and release doc updates

### DIFF
--- a/cmd/redis-debug/main.go
+++ b/cmd/redis-debug/main.go
@@ -147,6 +147,8 @@ func testRedisOperations(client RedisClientInterface) {
 	rsmqKeys := []string{
 		"rsmq:deliverymq-retry:Q",
 		"rsmq:deliverymq-retry",
+		"rsmq:deliverymq-retry-dlq:Q",
+		"rsmq:deliverymq-retry-dlq",
 		"rsmq:QUEUES",
 	}
 

--- a/docs/content/features/event-delivery.mdoc
+++ b/docs/content/features/event-delivery.mdoc
@@ -63,3 +63,5 @@ Each delivery attempt records:
 - Whether automatic retries are exhausted
 
 Access delivery attempts via the [API Reference](/docs/outpost/api#attempts), the tenant portal, or Admin UI.
+
+To receive attempts as they happen, subscribe to the `attempt.success` and `attempt.failed` [operator events](/docs/outpost/features/operator-events). They fire once per delivery attempt.

--- a/docs/content/features/operator-events.mdoc
+++ b/docs/content/features/operator-events.mdoc
@@ -16,11 +16,13 @@ Enable operator events by specifying topics and configuring a sink.
 Configure operator event topic subscriptions through [Hookdeck Monitoring settings](https://dashboard.hookdeck.com/settings/project/monitoring) or Config API.
 {% /tab %}
 {% tab label="Self-Hosted" %}
-Set `OPERATION_EVENTS_TOPICS` to a comma-separated list of topics, or `*` for all topics:
+Set `OPERATION_EVENTS_TOPICS` to a comma-separated list of topics:
 
 ```
-OPERATION_EVENTS_TOPICS=*
+OPERATION_EVENTS_TOPICS=alert.destination.disabled,alert.attempt.exhausted_retries
 ```
+
+Use `*` to subscribe to all topics. A wildcard subscription also includes topics added in future versions, so upgrading Outpost can change what your sink receives. Prefer an explicit topic list unless your sink is sized for per-attempt volume.
 {% /tab %}
 {% /tabs %}
 
@@ -35,7 +37,9 @@ Available topics:
 | `attempt.failed` | Every failed delivery attempt, including retries |
 | `tenant.subscription.updated` | Destination created/updated/deleted and tenant topics or destination count changed |
 
-The `attempt.success` and `attempt.failed` topics fire once per delivery attempt, so they dominate event volume — including under `*`. Subscribe to them deliberately and size your sink for your delivery throughput.
+{% callout type="warning" %}
+The `attempt.success` and `attempt.failed` topics fire once per delivery attempt, so they dominate event volume — including under `*`. A wildcard subscriber receives operator events at the deployment's full delivery throughput. Subscribe to these topics deliberately and size your sink accordingly.
+{% /callout %}
 
 {% tabs tabGroup="deployment" %}
 {% tab label="Managed" %}

--- a/docs/content/nav.json
+++ b/docs/content/nav.json
@@ -251,6 +251,10 @@
             {
               "slug": "self-hosting/changelog/upgrade-v0.17",
               "title": "Upgrade to v0.17"
+            },
+            {
+              "slug": "self-hosting/changelog/upgrade-v1.1",
+              "title": "Upgrade to v1.1"
             }
           ]
         ]

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -24,7 +24,11 @@ Unset keeps the default `<prefix><key>` behavior, an explicit value pins that ex
 
 ### Delivery attempt operator events
 
-Two new [operator events](/docs/outpost/features/operator-events) are published: `attempt.success` and `attempt.failed`, emitted per delivery attempt. Existing operator events are unchanged.
+Two new [operator events](/docs/outpost/features/operator-events) are published: `attempt.success` and `attempt.failed`, emitted once per delivery attempt. Existing operator event topics are unchanged.
+
+{% callout type="warning" %}
+If `OPERATION_EVENTS_TOPICS=*`, you start receiving `attempt.success` and `attempt.failed` immediately after upgrading. These fire once per delivery attempt, so your sink receives operator events at the deployment's full delivery throughput. This can be orders of magnitude more volume than the alert and subscription topics alone. If your sink is not sized for that, replace `*` with an explicit topic list before upgrading.
+{% /callout %}
 
 ### Faster log processing
 
@@ -87,6 +91,7 @@ The deprecated fields are also removed from the OpenAPI spec and generated SDKs;
 1. **Before upgrading:**
    - [ ] If you use any `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_*_HEADER` flag, switch to the `*_HEADER_NAME=""` replacement
    - [ ] If your destinations return response bodies larger than 128 KiB and you rely on them being stored, set `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES` accordingly (or `0` for no cap)
+   - [ ] If `OPERATION_EVENTS_TOPICS=*`, decide whether your sink can handle per-attempt volume; otherwise replace `*` with an explicit topic list
 
 2. **Upgrade:**
    - [ ] Update Outpost to v1.1 (no new migrations in this release)

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -1,0 +1,96 @@
+---
+title: "Upgrade to v1.1"
+description: "New features, behavior changes, and deprecations when upgrading Outpost from v1.0 to v1.1."
+---
+
+This guide covers what changes when upgrading from v1.0 to v1.1. There are no breaking changes and no new migrations, but there are behavior changes and deprecations to review before upgrading.
+
+## What's New
+
+### Configurable webhook system header names
+
+You can now pin the exact name of each system header the webhook destination sends, instead of only controlling the shared prefix:
+
+- `DESTINATIONS_WEBHOOK_EVENT_ID_HEADER_NAME`
+- `DESTINATIONS_WEBHOOK_TIMESTAMP_HEADER_NAME`
+- `DESTINATIONS_WEBHOOK_TOPIC_HEADER_NAME`
+- `DESTINATIONS_WEBHOOK_SIGNATURE_HEADER_NAME`
+
+Unset keeps the default `<prefix><key>` behavior, an explicit value pins that exact name, and an empty string disables the header. See [Webhook destination](/docs/outpost/destinations/webhook) for details, including the duplicate-name validation rules.
+
+### IAM role authentication for AWS SQS
+
+`AWS_SQS_ACCESS_KEY_ID` and `AWS_SQS_SECRET_ACCESS_KEY` are now optional. When omitted, Outpost uses the AWS SDK default credential chain, so you can authenticate with an IAM role (for example EKS Pod Identity, IRSA, or an instance profile) instead of static credentials. Setting only one of the two is rejected at startup. See [Configuration](/docs/outpost/self-hosting/configuration).
+
+### Delivery attempt operator events
+
+Two new [operator events](/docs/outpost/features/operator-events) are published: `attempt.success` and `attempt.failed`, emitted per delivery attempt. Existing operator events are unchanged.
+
+### Faster log processing
+
+Alert evaluation and operator event delivery during log processing now run in parallel per destination instead of serially. This is an internal throughput improvement with no configuration changes.
+
+## Behavior Changes
+
+### Retry tasks now dead-letter instead of retrying forever
+
+Before v1.1, a delivery retry task that repeatedly failed to process (for example, a malformed task payload) was redelivered indefinitely and could occupy a delivery worker forever.
+
+Starting in v1.1, the retry scheduler:
+
+1. Applies exponential backoff between receives of a failing task (doubling per receive, capped at 15 minutes).
+2. After 5 receives, moves the task to a dead-letter queue named `deliverymq-retry-dlq`, stored in Redis alongside the retry queue itself.
+
+Each dead-lettered task logs an error, `task exceeded max receive count, moved to dead-letter queue`, that includes the queue name, message ID, receive count, and the full task payload. Alert on this log line to catch dead-lettered tasks.
+
+{% callout type="info" %}
+If your deployment had tasks stuck in a retry loop before the upgrade, they drain into the dead-letter queue shortly after upgrading. Entries appearing in `deliverymq-retry-dlq` right after the upgrade are expected and indicate previously invisible failures, not a new problem.
+{% /callout %}
+
+There is no automatic redrive. Dead-lettered tasks stay in Redis under the `rsmq:deliverymq-retry-dlq` keys (prefixed with your `DEPLOYMENT_ID` if set) for manual inspection.
+
+### Stored response body size cap
+
+Outpost stores each destination response body on the delivery attempt. Starting in v1.1, bodies larger than `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES` (default `131072`, 128 KiB) are replaced with a placeholder instead of stored. This prevents oversized attempt logs from exceeding the message queue's per-message size limit, which previously caused those deliveries to be retried indefinitely.
+
+To restore the previous unbounded behavior, set `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES=0`. See [Webhook destination](/docs/outpost/destinations/webhook) for sizing guidance.
+
+### Alert suppression is now per destination
+
+`ALERT_EXHAUSTED_RETRIES_WINDOW_SECONDS` documents that the first exhaustion per destination emits an alert and subsequent ones within the window are suppressed. Before v1.1, the suppression key included the event ID, so every distinct event that exhausted retries on a destination triggered an alert regardless of the window. The suppression now works as documented: one alert per destination per window.
+
+The suppression key format changed, so live suppression windows reset once on deploy. Worst case, you receive one extra alert per destination during the upgrade.
+
+### Destination topics are normalized on write
+
+Creating or updating a destination now normalizes its `topics` list: exact duplicates are removed, and an entry that a sibling wildcard pattern strictly covers is folded into the wildcard (`["user.*", "user.created"]` becomes `["user.*"]`). First-seen order is preserved, and delivery matching is unchanged — normalization only removes entries already covered by a retained entry.
+
+### RabbitMQ connections redial automatically
+
+When using RabbitMQ as the message queue, a dropped connection previously wedged publishing until the process restarted. Outpost now redials dropped connections transparently. During a broker outage, publishes fail fast with a 5-second cooldown between redial attempts instead of hanging.
+
+## Deprecations
+
+The `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_*_HEADER` flags are deprecated and will be removed in a future version. They still work in v1.1, but a set `*_HEADER_NAME` variable takes precedence over the matching flag.
+
+| Deprecated | Replacement |
+| --- | --- |
+| `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_EVENT_ID_HEADER=true` | `DESTINATIONS_WEBHOOK_EVENT_ID_HEADER_NAME=""` |
+| `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_TIMESTAMP_HEADER=true` | `DESTINATIONS_WEBHOOK_TIMESTAMP_HEADER_NAME=""` |
+| `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_TOPIC_HEADER=true` | `DESTINATIONS_WEBHOOK_TOPIC_HEADER_NAME=""` |
+| `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_SIGNATURE_HEADER=true` | `DESTINATIONS_WEBHOOK_SIGNATURE_HEADER_NAME=""` |
+
+The deprecated fields are also removed from the OpenAPI spec and generated SDKs; the environment variables and Config API keys continue to work until removal.
+
+## Upgrade Checklist
+
+1. **Before upgrading:**
+   - [ ] If you use any `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_*_HEADER` flag, switch to the `*_HEADER_NAME=""` replacement
+   - [ ] If your destinations return response bodies larger than 128 KiB and you rely on them being stored, set `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES` accordingly (or `0` for no cap)
+
+2. **Upgrade:**
+   - [ ] Update Outpost to v1.1 (no new migrations in this release)
+
+3. **After upgrading:**
+   - [ ] Add an alert on the `task exceeded max receive count, moved to dead-letter queue` error log
+   - [ ] Check `deliverymq-retry-dlq` for tasks that were previously stuck in a retry loop

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -59,12 +59,6 @@ Outpost stores each destination response body on the delivery attempt. Starting 
 
 To restore the previous unbounded behavior, set `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES=0`. See [Webhook destination](/docs/outpost/destinations/webhook) for sizing guidance.
 
-### Alert suppression is now per destination
-
-`ALERT_EXHAUSTED_RETRIES_WINDOW_SECONDS` documents that the first exhaustion per destination emits an alert and subsequent ones within the window are suppressed. Before v1.1, the suppression key included the event ID, so every distinct event that exhausted retries on a destination triggered an alert regardless of the window. The suppression now works as documented: one alert per destination per window.
-
-The suppression key format changed, so live suppression windows reset once on deploy. Worst case, you receive one extra alert per destination during the upgrade.
-
 ### Destination topics are normalized on write
 
 Creating or updating a destination now normalizes its `topics` list: exact duplicates are removed, and an entry that a sibling wildcard pattern strictly covers is folded into the wildcard (`["user.*", "user.created"]` becomes `["user.*"]`). First-seen order is preserved, and delivery matching is unchanged — normalization only removes entries already covered by a retained entry.

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -96,4 +96,4 @@ The deprecated fields are also removed from the OpenAPI spec and generated SDKs;
 
 ## Thanks
 
-This release cycle includes first-time contributions from [@LendritIbrahimi](https://github.com/LendritIbrahimi), [@ambroziepaval](https://github.com/ambroziepaval), [@mvanhorn](https://github.com/mvanhorn), [@lovlyx](https://github.com/lovlyx), [@distroaryan](https://github.com/distroaryan), and [@Abdulmumin1](https://github.com/Abdulmumin1). Thank you!
+This release cycle includes first-time contributions from [@LendritIbrahimi](https://github.com/LendritIbrahimi), [@ambroziepaval](https://github.com/ambroziepaval), [@mvanhorn](https://github.com/mvanhorn), [@lovlyx](https://github.com/lovlyx), [@distroaryan](https://github.com/distroaryan), and [@Abdulmumin1](https://github.com/Abdulmumin1). Thank you for your contributions!

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -59,10 +59,6 @@ Outpost stores each destination response body on the delivery attempt. Starting 
 
 To restore the previous unbounded behavior, set `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES=0`. See [Webhook destination](/docs/outpost/destinations/webhook) for sizing guidance.
 
-### Destination topics are normalized on write
-
-Creating or updating a destination now normalizes its `topics` list: exact duplicates are removed, and an entry that a sibling wildcard pattern strictly covers is folded into the wildcard (`["user.*", "user.created"]` becomes `["user.*"]`). First-seen order is preserved, and delivery matching is unchanged — normalization only removes entries already covered by a retained entry.
-
 ### RabbitMQ connections redial automatically
 
 When using RabbitMQ as the message queue, a dropped connection previously wedged publishing until the process restarted. Outpost now redials dropped connections transparently. During a broker outage, publishes fail fast with a 5-second cooldown between redial attempts instead of hanging.

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -20,7 +20,7 @@ Unset keeps the default `<prefix><key>` behavior, an explicit value pins that ex
 
 ### IAM role authentication for AWS SQS
 
-`AWS_SQS_ACCESS_KEY_ID` and `AWS_SQS_SECRET_ACCESS_KEY` are now optional. When omitted, Outpost uses the AWS SDK default credential chain, so you can authenticate with an IAM role (for example EKS Pod Identity, IRSA, or an instance profile) instead of static credentials. Setting only one of the two is rejected at startup. See [Configuration](/docs/outpost/self-hosting/configuration).
+`AWS_SQS_ACCESS_KEY_ID` and `AWS_SQS_SECRET_ACCESS_KEY` are now optional. When omitted, Outpost uses the AWS SDK default credential chain, so you can authenticate with an IAM role (for example EKS Pod Identity, IRSA, or an instance profile) instead of static credentials. See [Configuration](/docs/outpost/self-hosting/configuration).
 
 ### Delivery attempt operator events
 
@@ -99,3 +99,7 @@ The deprecated fields are also removed from the OpenAPI spec and generated SDKs;
 3. **After upgrading:**
    - [ ] Add an alert on the `task exceeded max receive count, moved to dead-letter queue` error log
    - [ ] Check `deliverymq-retry-dlq` for tasks that were previously stuck in a retry loop
+
+## Thanks
+
+This release cycle includes first-time contributions from [@LendritIbrahimi](https://github.com/LendritIbrahimi), [@ambroziepaval](https://github.com/ambroziepaval), [@mvanhorn](https://github.com/mvanhorn), [@lovlyx](https://github.com/lovlyx), [@distroaryan](https://github.com/distroaryan), and [@Abdulmumin1](https://github.com/Abdulmumin1). Thank you!

--- a/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
+++ b/docs/content/self-hosting/changelog/upgrade-v1.1.mdoc
@@ -59,10 +59,6 @@ Outpost stores each destination response body on the delivery attempt. Starting 
 
 To restore the previous unbounded behavior, set `DESTINATIONS_WEBHOOK_MAX_RESPONSE_BODY_BYTES=0`. See [Webhook destination](/docs/outpost/destinations/webhook) for sizing guidance.
 
-### RabbitMQ connections redial automatically
-
-When using RabbitMQ as the message queue, a dropped connection previously wedged publishing until the process restarted. Outpost now redials dropped connections transparently. During a broker outage, publishes fail fast with a 5-second cooldown between redial attempts instead of hanging.
-
 ## Deprecations
 
 The `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_*_HEADER` flags are deprecated and will be removed in a future version. They still work in v1.1, but a set `*_HEADER_NAME` variable takes precedence over the matching flag.

--- a/docs/content/self-hosting/configuration.mdoc
+++ b/docs/content/self-hosting/configuration.mdoc
@@ -37,6 +37,8 @@ Choose one message queue provider. The selected provider is used for both event 
 | `AWS_SQS_SECRET_ACCESS_KEY` | AWS Secret Access Key (optional; omit to use the AWS SDK default credential chain, e.g. an IAM role) |
 | `AWS_SQS_REGION` | AWS Region |
 
+Whichever way you authenticate, the principal needs these actions on the Outpost queues: `sqs:GetQueueUrl`, `sqs:SendMessage`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`, and `sqs:ChangeMessageVisibility` (the batch API variants are covered by the same actions). With auto-provisioning enabled (the default, `MQS_AUTO_PROVISION=true`), it also needs `sqs:CreateQueue` and `sqs:GetQueueAttributes`. If you [manage the queues yourself](/docs/outpost/self-hosting/guides/byo-mqs), the first list is sufficient.
+
 **GCP Pub/Sub:**
 
 | Variable | Description |

--- a/docs/content/self-hosting/guides/byo-mqs.mdoc
+++ b/docs/content/self-hosting/guides/byo-mqs.mdoc
@@ -90,6 +90,7 @@ The following table shows the resources, default names, and configuration variab
 - Configure `RedrivePolicy` on main queue pointing to DLQ
 - Set appropriate `VisibilityTimeout` (SQS default: 30 seconds)
 - Set `maxReceiveCount` in RedrivePolicy for retry limit
+- Grant the Outpost principal `sqs:GetQueueUrl`, `sqs:SendMessage`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`, and `sqs:ChangeMessageVisibility` on the queues. No create or delete permissions are needed when you manage the queues yourself.
 
 ### GCP Pub/Sub
 

--- a/docs/content/self-hosting/guides/troubleshooting-redis.mdoc
+++ b/docs/content/self-hosting/guides/troubleshooting-redis.mdoc
@@ -111,7 +111,9 @@ go build -o redis-debug cmd/redis-debug/main.go
 
 === RSMQ Key Analysis ===
 ℹ️  rsmq:deliverymq-retry:Q: Does not exist
-ℹ️  rsmq:deliverymq-retry: Does not exist  
+ℹ️  rsmq:deliverymq-retry: Does not exist
+ℹ️  rsmq:deliverymq-retry-dlq:Q: Does not exist
+ℹ️  rsmq:deliverymq-retry-dlq: Does not exist
 ℹ️  rsmq:QUEUES: Does not exist
 
 === HSETNX Test ===


### PR DESCRIPTION
Docs for the v1.1 release:

- New upgrade guide at `self-hosting/changelog/upgrade-v1.1`: new features, behavior changes (retry-task DLQ, response body cap, per-destination alert suppression), and the `DISABLE_DEFAULT_*_HEADER` deprecations. No breaking changes, no migrations.
- Operator events: `OPERATION_EVENTS_TOPICS=*` subscribers start receiving per-attempt `attempt.success`/`attempt.failed` volume on upgrade — drop `*` as the suggested example and warn that wildcard subscriptions pick up future topics.
- SQS: list the IAM actions the Outpost principal needs, for both auto-provisioned and self-managed queues (`sqs:DeleteQueue` deliberately omitted — teardown is only called from e2e).
- `redis-debug`: check the new `deliverymq-retry-dlq` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)