### PR TITLE
fix: return 400 when max destinations per tenant is reached

### DIFF
--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -439,6 +439,10 @@ func (h *DestinationHandlers) handleUpsertDestinationError(c *gin.Context, err e
 		AbortWithError(c, http.StatusBadRequest, NewErrBadRequest(err))
 		return
 	}
+	if errors.Is(err, tenantstore.ErrMaxDestinationsPerTenantReached) {
+		AbortWithError(c, http.StatusBadRequest, NewErrBadRequest(err))
+		return
+	}
 	AbortWithError(c, http.StatusInternalServerError, NewErrInternalServer(err))
 }
 

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hookdeck/outpost/internal/models"
 	"github.com/hookdeck/outpost/internal/opevents"
 	"github.com/hookdeck/outpost/internal/tenantstore"
+	"github.com/hookdeck/outpost/internal/tenantstore/memtenantstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +56,23 @@ func TestAPI_Destinations(t *testing.T) {
 			resp := h.do(h.withJWT(req, "t1"))
 
 			require.Equal(t, http.StatusCreated, resp.Code)
+		})
+
+		t.Run("max destinations per tenant returns 400", func(t *testing.T) {
+			h := newAPITest(t, withTenantStore(memtenantstore.New(memtenantstore.WithMaxDestinationsPerTenant(1))))
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+
+			req := h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", validDestination())
+			resp := h.do(h.withAPIKey(req))
+			require.Equal(t, http.StatusCreated, resp.Code)
+
+			req = h.jsonReq(http.MethodPost, "/api/v1/tenants/t1/destinations", validDestination())
+			resp = h.do(h.withAPIKey(req))
+
+			require.Equal(t, http.StatusBadRequest, resp.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+			assert.Equal(t, "maximum number of destinations per tenant reached", body["message"])
 		})
 
 		t.Run("missing type returns 422", func(t *testing.T) {


### PR DESCRIPTION
Creating a destination past `MAX_DESTINATIONS_PER_TENANT` fell through `handleUpsertDestinationError` to a generic 500. Maps `ErrMaxDestinationsPerTenantReached` to 400 with the sentinel's message, matching the duplicate-destination case: `{"status": 400, "message": "maximum number of destinations per tenant reached"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)