### PR TITLE
chore(logging): correct wide-event comments, document the sink split

### DIFF
--- a/internal/deliverymq/messagehandler.go
+++ b/internal/deliverymq/messagehandler.go
@@ -174,9 +174,9 @@ func (h *messageHandler) handleError(msg *mqs.Message, err error) error {
 	}
 	// Attempt errors from a destination's publish call (webhook 5xx, timeout,
 	// refused, etc.) are expected operational outcomes. Ack semantics are
-	// already decided above; the failure is captured in the audit log, the
-	// ClickHouse log entry, and the scheduled retry. Suppress propagation so
-	// the consumer doesn't log them as unexpected handler errors.
+	// already decided above; the failure is captured in the delivery.attempted
+	// line, the ClickHouse log entry, and the scheduled retry. Suppress
+	// propagation so the consumer doesn't log them as unexpected handler errors.
 	if atmErr, ok := err.(*AttemptError); ok {
 		var pubErr *destregistry.ErrDestinationPublishAttempt
 		if errors.As(atmErr.err, &pubErr) {
@@ -186,8 +186,8 @@ func (h *messageHandler) handleError(msg *mqs.Message, err error) error {
 	return err
 }
 
-// retryOutcome captures the retry-scheduling decisions made during a delivery
-// attempt so they can be folded into the single delivery.attempted audit event.
+// retryOutcome defers the retry-scheduling decisions taken during an attempt
+// so logDeliveryResult can fold them into the one delivery.attempted line.
 type retryOutcome struct {
 	scheduled      bool
 	backoff        time.Duration
@@ -278,10 +278,6 @@ func (h *messageHandler) logDeliveryResult(ctx context.Context, task *models.Del
 	attempt.AttemptNumber = task.Attempt
 	attempt.Manual = task.Manual
 
-	// Wide event: one audit per delivery attempt carrying the full outcome
-	// (attempt result, timing, retry decision). Replaces the separate
-	// "retry scheduled" and "scheduled retry canceled" audits so consumers
-	// don't have to join across lines to reconstruct what happened.
 	fields := []zap.Field{
 		zap.String("attempt_id", attempt.ID),
 		zap.String("event_id", task.Event.ID),

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -14,6 +14,12 @@ import (
 // operator logs (stdout, no OTel export) while auditLogger is otelzap-wrapped
 // so Audit() lines flow to both stdout and the OTel logs SDK. This keeps
 // infrastructure errors and debug noise out of customer-visible OTel sinks.
+//
+// Audit() is for control-plane changes — tenant and destination lifecycle,
+// manual retry, auto-disable — one line per user-visible decision. The hot
+// path uses Info even for its wide events (delivery.attempted,
+// event.received): they scale with throughput, and tenants read delivery
+// history through the events and attempts APIs, not this sink.
 type Logger struct {
 	*zap.Logger
 	auditLogger *otelzap.Logger

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -14,12 +14,6 @@ import (
 // operator logs (stdout, no OTel export) while auditLogger is otelzap-wrapped
 // so Audit() lines flow to both stdout and the OTel logs SDK. This keeps
 // infrastructure errors and debug noise out of customer-visible OTel sinks.
-//
-// Audit() is for control-plane changes — tenant and destination lifecycle,
-// manual retry, auto-disable — one line per user-visible decision. The hot
-// path uses Info even for its wide events (delivery.attempted,
-// event.received): they scale with throughput, and tenants read delivery
-// history through the events and attempts APIs, not this sink.
 type Logger struct {
 	*zap.Logger
 	auditLogger *otelzap.Logger
@@ -92,6 +86,11 @@ func (l *Logger) Ctx(ctx context.Context) LoggerWithCtx {
 	}
 }
 
+// Audit records control-plane decisions: lifecycle changes a tenant or
+// operator needs a durable record of.
+//
+// Per-unit-of-work outcomes on the hot path stay on Info however significant
+// they are — this sink isn't sized for per-event volume.
 func (l *Logger) Audit(msg string, fields ...zap.Field) {
 	l.auditLogger.Info(msg, fields...)
 }

--- a/internal/publishmq/eventhandler.go
+++ b/internal/publishmq/eventhandler.go
@@ -78,9 +78,8 @@ func (h *eventHandler) Handle(ctx context.Context, event *models.Event) (*Handle
 	logger := h.logger.Ctx(ctx)
 	receivedAt := time.Now()
 
-	// Wide event state: populated by the rest of Handle and emitted as a single
-	// audit at the end. Replaces the separate "processing event" and per-
-	// destination "delivery task enqueued" audits.
+	// Wide event state: accumulated through Handle, emitted as a single
+	// event.received line by the defer below.
 	var enqueuedMu sync.Mutex
 	var enqueued []string
 	var matched []string


### PR DESCRIPTION
`delivery.attempted` and `event.received` are emitted with `Info`, but the comments around them called them audit events. That wording is left over from the multi-line `Audit()` calls they replaced in #913 — the same commit introduced both the wide events and the Audit→OTel split, and deliberately put per-unit-of-work lines on the operator sink. Nothing routes them to the OTel logs SDK, so the comments described behavior that doesn't exist.

- `logging.Logger` — say which sink a line belongs on, once, next to the split it describes
- `messagehandler.go`, `eventhandler.go` — drop the "replaces X and Y" history and the re-explanation of the wide-event pattern; keep only what the code can't say (why `retryOutcome` exists, why swallowing an attempt error is safe)

Comments only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)