### PR TITLE
fix(destregistry): record the cause of a transport-level delivery failure

### DIFF
--- a/internal/destregistry/providers/destwebhook/httphelper.go
+++ b/internal/destregistry/providers/destwebhook/httphelper.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/hookdeck/outpost/internal/destregistry"
 )
@@ -76,10 +77,26 @@ func ExecuteHTTPRequest(ctx context.Context, client *http.Client, req *http.Requ
 			}
 		}
 
+		// The transport branch is the only one that doesn't fill Response, which
+		// would store response_data NULL and lose the cause entirely.
+		//
+		// A plain transport error is a *url.Error naming the customer's own
+		// destination, safe to store. ErrProxyDestination.Error() appends proxy
+		// diagnostics, which are operator-side — that branch stores the
+		// classification instead, matching the block above.
+		message := err.Error()
+		if destErr != nil {
+			message = code
+			if destErr.DestHost != "" {
+				message = fmt.Sprintf("%s connecting to %s", code, destErr.DestHost)
+			}
+		}
+
 		return &HTTPRequestResult{
 			Delivery: &destregistry.Delivery{
-				Status: "failed",
-				Code:   code,
+				Status:   "failed",
+				Code:     code,
+				Response: map[string]interface{}{"error": message},
 			},
 			Error:    destregistry.NewErrDestinationPublishAttempt(err, provider, data),
 			Response: nil,
@@ -146,6 +163,15 @@ func ClassifyNetworkError(err error) string {
 		return "unknown"
 	}
 
+	// Source-side ephemeral port exhaustion. Ours, not the destination's, and the
+	// fix is connection reuse rather than a retry — so it must not disappear into
+	// the network_error catch-all among genuinely remote failures. Matched on the
+	// errno because the message is not portable: Linux renders EADDRNOTAVAIL as
+	// "cannot assign requested address", darwin as "can't".
+	if errors.Is(err, syscall.EADDRNOTAVAIL) {
+		return "address_unavailable"
+	}
+
 	errStr := err.Error()
 
 	switch {
@@ -157,6 +183,10 @@ func ClassifyNetworkError(err error) string {
 		return "connection_reset"
 	case strings.Contains(errStr, "network is unreachable"):
 		return "network_unreachable"
+	// Same condition arriving as an opaque string (e.g. synthesized from a proxy
+	// report), where the errno is not available to match on.
+	case strings.Contains(errStr, "assign requested address"):
+		return "address_unavailable"
 	case strings.Contains(errStr, "i/o timeout"):
 		return "timeout"
 	case strings.Contains(errStr, "context deadline exceeded"):

--- a/internal/destregistry/providers/destwebhook/httphelper_test.go
+++ b/internal/destregistry/providers/destwebhook/httphelper_test.go
@@ -1,14 +1,21 @@
 package destwebhook_test
 
 import (
+	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/hookdeck/outpost/internal/destregistry"
 	"github.com/hookdeck/outpost/internal/destregistry/providers/destwebhook"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseHTTPResponse_MaxBytes(t *testing.T) {
@@ -62,4 +69,68 @@ func TestParseHTTPResponse_MaxBytes(t *testing.T) {
 			assert.Equal(t, tt.wantBody, delivery.Response["body"])
 		})
 	}
+}
+
+// Ephemeral port exhaustion is a source-side failure: the fix is connection
+// reuse, not a retry against the destination. Folding it into the
+// network_error catch-all alongside genuinely remote failures is what made a
+// 7,604-failure episode in the 2026-07-30 benchmark unattributable.
+func TestClassifyNetworkError_AddressUnavailable(t *testing.T) {
+	t.Parallel()
+
+	err := &url.Error{
+		Op:  "Post",
+		URL: "https://example.com/hook",
+		Err: &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: &os.SyscallError{Syscall: "connect", Err: syscall.EADDRNOTAVAIL},
+		},
+	}
+	assert.Equal(t, "address_unavailable", destwebhook.ClassifyNetworkError(err))
+}
+
+func TestClassifyNetworkError_Codes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"dns", errors.New(`dial tcp: lookup nope.invalid: no such host`), "dns_error"},
+		{"refused", errors.New(`dial tcp 1.2.3.4:443: connect: connection refused`), "connection_refused"},
+		{"timeout", errors.New(`context deadline exceeded`), "timeout"},
+		{"unknown", errors.New(`something else entirely`), "network_error"},
+		{"nil", nil, "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, destwebhook.ClassifyNetworkError(tt.err))
+		})
+	}
+}
+
+// A transport failure must record why it failed. This was the only one of the
+// package's four failure paths leaving Delivery.Response nil, so every
+// connection-level failure stored response_data NULL.
+func TestExecuteHTTPRequest_TransportErrorRecordsCause(t *testing.T) {
+	t.Parallel()
+
+	// Port 1 on loopback: nothing listens, so client.Do fails at the transport
+	// layer without involving a server.
+	req, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:1/hook", strings.NewReader("{}"))
+	require.NoError(t, err)
+
+	res := destwebhook.ExecuteHTTPRequest(context.Background(), http.DefaultClient, req, "webhook", 0)
+
+	require.NotNil(t, res.Delivery, "transport error must still record a customer-visible attempt")
+	assert.Equal(t, "failed", res.Delivery.Status)
+	require.NotNil(t, res.Delivery.Response, "response_data was nil — the cause is unrecoverable after the fact")
+
+	msg, ok := res.Delivery.Response["error"].(string)
+	require.True(t, ok, "response_data.error missing or not a string: %#v", res.Delivery.Response)
+	assert.Contains(t, msg, "connection refused")
+	assert.Contains(t, msg, "127.0.0.1:1", "the destination the customer configured should be identifiable")
 }


### PR DESCRIPTION
## Problem

When a webhook delivery fails **before receiving an HTTP response** — DNS failure, connection refused, TLS error, dial timeout — the attempt records that it failed and nothing about why. `response_data` is written NULL.

To be precise about which failures these are: a destination that *replies* `503` is not this path — that's an HTTP response, it goes down the 4xx/5xx branch, and its body is already recorded. This path is the case where no response ever arrives.

It's the only delivery failure path through `destwebhook` that behaves this way:

| failure | `code` | `response_data` |
|---|---|---|
| destination returns 4xx/5xx | `"503"` | status, body |
| payload format failure | `"ERR"` | the error message |
| publisher resolution failure | `"ERR"` | the error message |
| **connection-level failure** | `connection_refused` | **absent** |

A destination that returns a 500 with an empty body leaves more diagnostic trace than a destination we could not reach at all.

## What the end user sees

`GET /destinations/:id/attempts?include=response_data`, for a delivery to a host that isn't accepting connections.

Before:

```json
{
  "id": "att_...",
  "status": "failed",
  "code": "connection_refused",
  "attempt_number": 1
}
```

`response_data` is omitted entirely — it was NULL, and the field is `omitempty`. The user knows the category and nothing else: which host, which port, whether it was one endpoint or all of them.

After:

```json
{
  "id": "att_...",
  "status": "failed",
  "code": "connection_refused",
  "response_data": {
    "error": "Post \"https://api.example.com/hooks/abc\": dial tcp 203.0.113.10:443: connect: connection refused"
  },
  "attempt_number": 1
}
```

The `code` is unchanged. What's new is the `response_data.error` string, which names the URL, the resolved address, and the failing syscall — enough to tell "my DNS points at a stale IP" from "my service is down" from "my TLS cert expired" without contacting support.

Worth noting the string is Go's raw transport error, so it reads like a Go error rather than a written message. It's the same trade the 4xx/5xx path already makes by storing the destination's response body verbatim. Normalizing it is a reasonable follow-up; recording it at all is the change here.

The catch-all case is where this matters most. `dns_error` and `connection_refused` at least name a category; `network_error` is everything unrecognized, and before this change an attempt with that code carried no information whatsoever.

Both webhook providers get this — `destwebhook` and `destwebhookstandard` share the same helper. `desthookdeck` already records the cause on its own error path and is unaffected.

## Open question: is `response_data` the right field for this?

There's a reasonable objection to the change above: the connection failed, so there *is* no response — leaving `response_data` empty is arguably correct, and putting an error string there is a misuse of the field.

Raising it because the answer isn't obvious, and because the field already has this problem independently of this PR.

`response_data` is not "the HTTP response" today. `NewFormatError` fires when an event can't be turned into a request at all — an unparseable payload, an invalid partition-key or object-key template. Nothing is sent, no connection is opened, and it still fills the field:

```go
func NewFormatError(provider, message string, err error) (*Delivery, error) {
	if message == "" {
		message = "could not format event for delivery"
	}
	return &Delivery{
		Status:   "failed",
		Code:     "ERR",
		Response: map[string]interface{}{"error": message},
	}, ...
}
```

Eight providers call it — `destwebhook`, `destwebhookstandard`, `destkafka`, `destawss3`, `destawssqs`, `destawskinesis`, `destgcppubsub`, `destazureservicebus`. Every one passes an empty message, so what the customer actually receives is the literal default:

```json
{
  "id": "att_...",
  "status": "failed",
  "code": "ERR",
  "response_data": {
    "error": "could not format event for delivery"
  },
  "attempt_number": 1
}
```

A `response_data` for an attempt where no request ever left the process. Validation and publisher-resolution failures do the same, storing `{"error": err.Error()}` under `Code: "ERR"`.

So the field carries three distinct shapes:

| when | shape |
|---|---|
| response received (2xx, 4xx, 5xx) | `{"status": 503, "body": "..."}` |
| never sent — format failure | `{"error": "could not format event for delivery"}` |
| never sent — validation / resolution failure | `{"error": "<err.Error()>"}` |

And the doc comment on `NewFormatError` states the intent outright: *"message is the customer-facing string persisted on the attempt (ResponseData)."* Not "the response" — the customer-facing string.

That leaves two positions:

1. **`response_data` is the attempt's explanation field**, and the name is historical. This PR follows that, making the transport path consistent with the two other no-response failures that already populate it.
2. **`response_data` should strictly mean a response**, and the explanation belongs in a separate `error` / `failure_reason` field. Cleaner, but it touches `models.Attempt`, both log store schemas, the API type, and the SDKs — plus the `{"error": ...}` values already sitting in customers' attempt history.

This PR takes the first, since it's what the surrounding code does. If we'd rather have the second, this becomes one more call site to migrate rather than an obstacle — but worth deciding, because the inconsistency is customer-visible either way.

## Also: source-side failures are no longer charged to the destination

Ephemeral port exhaustion on the sending host previously fell into the `network_error` catch-all, beside genuinely remote failures. It now records `address_unavailable`.

This matters to the user because the two need different responses: a destination that's unreachable is theirs to fix, while running out of local ports is ours, and retrying against the destination won't help. Under the old classification the two were indistinguishable on the attempt.

It does change a customer-visible value — an attempt that would have recorded `network_error` now records `address_unavailable`, so anything matching on that string sees new behavior. Happy to split this out if you'd rather it land separately.

## Testing

`go test -short ./...` passes. Adds coverage asserting a connection-level failure records a non-empty cause, plus the errno classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
