### PR TITLE
fix(otel): make per-signal exporter and protocol configurable via env

### DIFF
--- a/contributing/config.md
+++ b/contributing/config.md
@@ -152,4 +152,21 @@ OTEL_METRICS_EXPORTER="otlp" # default
 OTEL_LOGS_EXPORTER="none" # disable logs
 ```
 
+Setting a per-signal endpoint also enables only that signal: with `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` set and no other endpoint or exporter variable, metrics are exported and traces and logs are off. The generic `OTEL_EXPORTER_OTLP_ENDPOINT` enables all three; a per-signal endpoint alongside it only refines where that signal sends. Setting no endpoint at all leaves every signal enabled against the SDK's default `localhost` endpoint.
+
+Exporter resolution per signal, first match wins:
+
+1. `OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER`
+2. `OTEL_EXPORTER` — Outpost-specific, applies to all three
+3. the endpoint inference above
+
+Protocol resolution per signal, first match wins:
+
+1. `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL`
+2. `OTEL_EXPORTER_OTLP_PROTOCOL`
+3. `OTEL_PROTOCOL` — Outpost-specific, applies to all three
+4. `grpc`
+
+`http` and the specification's `http/protobuf` are the same value; both are accepted.
+
 Currently, we only support `otlp` exporter. If you have specific needs for other exporter configuration (like Prometheus), you must set up your own OTEL collector and configure it accordingly.

--- a/docs/content/features/opentelemetry.mdoc
+++ b/docs/content/features/opentelemetry.mdoc
@@ -16,7 +16,7 @@ Enable OpenTelemetry in the [Hookdeck Monitoring settings](https://dashboard.hoo
 {% tab label="Self-Hosted" %}
 Outpost uses the [OpenTelemetry Go SDK](https://opentelemetry.io/docs/languages/go/) and is configured via the standard `OTEL_*` environment variables documented in the [OTel SDK configuration reference](https://opentelemetry.io/docs/languages/sdk-configuration/general/).
 
-To enable metrics export, set `OTEL_SERVICE_NAME` and configure an exporter endpoint, for example:
+To enable OpenTelemetry, set `OTEL_SERVICE_NAME` and configure an exporter endpoint, for example:
 
 ```
 OTEL_SERVICE_NAME=outpost
@@ -24,6 +24,55 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 ```
 {% /tab %}
 {% /tabs %}
+
+## Signal Configuration
+
+Setting `OTEL_SERVICE_NAME` enables all three signals: traces, metrics, and logs. Two sets of variables control them: the endpoint variables decide **which** signals are exported, and the exporter variables decide **how** an exported signal is written (or disable it with `none` — an exporter value can turn a signal off, never on).
+
+### Endpoints
+
+The endpoint variables decide which signals are enabled:
+
+- One or more per-signal endpoints (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) with no generic endpoint: only the signals with an endpoint are exported. Signals without an endpoint are disabled, regardless of any exporter setting.
+- The generic `OTEL_EXPORTER_OTLP_ENDPOINT`: all three signals are exported.
+- No endpoint at all: all three signals are exported to the SDK's default endpoint.
+
+So exporting a single signal takes nothing but its endpoint — to export only metrics:
+
+```
+OTEL_SERVICE_NAME=outpost
+OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://otel-collector:4317
+```
+
+### Exporters
+
+| Variable | Description |
+|----------|-------------|
+| `OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` | Exporter for a single signal. Takes precedence over `OTEL_EXPORTER` and the config file. |
+| `OTEL_EXPORTER` | Exporter for all three signals. |
+
+Accepted values are `otlp` (the default), `console` (alias `stdout`) to print to standard output, and `none` to disable the signal. Because a signal without its endpoint is already disabled when per-signal endpoints are in use, `console`/`stdout` only takes effect with no endpoints or with the generic endpoint. For example, to export everything except logs:
+
+```
+OTEL_SERVICE_NAME=outpost
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_LOGS_EXPORTER=none
+```
+
+### Protocol
+
+Each signal's OTLP protocol is resolved in precedence order:
+
+1. `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` / `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`
+2. `OTEL_EXPORTER_OTLP_PROTOCOL`
+3. `OTEL_PROTOCOL`
+4. `grpc` (the default)
+
+Accepted values are `grpc`, `http`, and `http/protobuf` (`http` and `http/protobuf` are equivalent).
+
+{% callout %}
+The standard OpenTelemetry variables — the per-signal exporter and protocol variables and all endpoint variables — are read from the process environment, matching how the OpenTelemetry SDK reads them. Set them as real environment variables, not in an Outpost config file. Outpost's own `OTEL_EXPORTER` and `OTEL_PROTOCOL` variables and the YAML `traces:`, `metrics:`, and `logs:` sections work in config files as usual.
+{% /callout %}
 
 ## Available Metrics
 

--- a/docs/content/self-hosting/configuration.mdoc
+++ b/docs/content/self-hosting/configuration.mdoc
@@ -134,7 +134,7 @@ The `DESTINATIONS_WEBHOOK_DISABLE_DEFAULT_EVENT_ID_HEADER`, `DESTINATIONS_WEBHOO
 
 | Variable | Description |
 |----------|-------------|
-| `OTEL_SERVICE_NAME` | Enables OpenTelemetry metrics export when set |
+| `OTEL_SERVICE_NAME` | Enables OpenTelemetry when set. All three signals (traces, metrics, and logs) are exported by default; see [OpenTelemetry](/docs/outpost/features/opentelemetry) for per-signal control |
 | `LOG_LEVEL` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` (default: `info`) |
 | `DISABLE_TELEMETRY` | Set to `true` to disable anonymous usage telemetry to Hookdeck |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -292,6 +292,7 @@ func (c *Config) parseEnvVariables(osInterface OSInterface) error {
 
 	c.captureEmptyAlertEnv(osInterface)
 	c.captureEmptyWebhookHeaderEnv(osInterface)
+	c.OpenTelemetry.resolveOTelEnv(osInterface)
 	return nil
 }
 

--- a/internal/config/otel.go
+++ b/internal/config/otel.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 
 	"github.com/hookdeck/outpost/internal/otel"
-	v "github.com/spf13/viper"
 )
 
 type OpenTelemetryTypeConfig struct {
-	Exporter string `yaml:"exporter" env:"OTEL_EXPORTER" desc:"Specifies the OTLP exporter to use for this telemetry type (e.g., 'otlp'). Typically used with environment variables like OTEL_EXPORTER_OTLP_TRACES_ENDPOINT." required:"C"`
-	Protocol string `yaml:"protocol" env:"OTEL_PROTOCOL" desc:"Specifies the OTLP protocol ('grpc' or 'http') for this telemetry type. Typically used with environment variables like OTEL_EXPORTER_OTLP_TRACES_PROTOCOL." required:"C"`
+	Exporter string `yaml:"exporter" env:"OTEL_EXPORTER" desc:"Exporter for this signal ('otlp', 'console' or 'none'). Applies to all three signals; override a single signal with OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER or OTEL_LOGS_EXPORTER. If unset, a signal is enabled when its endpoint (or the generic OTEL_EXPORTER_OTLP_ENDPOINT) is set, or when no endpoint is set at all." required:"C"`
+	Protocol string `yaml:"protocol" env:"OTEL_PROTOCOL" desc:"OTLP protocol ('grpc' or 'http') for this signal. Applies to all three signals; the standard OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL take precedence. Defaults to 'grpc'." required:"C"`
 }
 
 type OpenTelemetryConfig struct {
@@ -23,11 +22,23 @@ type OpenTelemetryConfig struct {
 const (
 	OTelProtocolGRPC = "grpc"
 	OTelProtocolHTTP = "http"
+	// OTelProtocolHTTPProtobuf is the OpenTelemetry specification's name for
+	// what Outpost calls "http". Accepted as an alias.
+	OTelProtocolHTTPProtobuf = "http/protobuf"
+
+	// OTelExporterNone disables a signal. It is the specification's value and
+	// falls through to each provider constructor's no-exporter branch.
+	OTelExporterNone = "none"
 )
 
+// otelSignals are the signal names as they appear in the specification's
+// environment variables (OTEL_<SIGNAL>_EXPORTER, OTEL_EXPORTER_OTLP_<SIGNAL>_*).
+var otelSignals = []string{"TRACES", "METRICS", "LOGS"}
+
 var validOTelProtocols = map[string]bool{
-	OTelProtocolGRPC: true,
-	OTelProtocolHTTP: true,
+	OTelProtocolGRPC:         true,
+	OTelProtocolHTTP:         true,
+	OTelProtocolHTTPProtobuf: true,
 }
 
 var ErrInvalidOTelProtocol = errors.New("config validation error: invalid OpenTelemetry protocol, must be 'grpc' or 'http'")
@@ -42,18 +53,73 @@ func validateOTelProtocol(protocol string) error {
 	return nil
 }
 
-func getProtocol(viper *v.Viper, telemetryType string) string {
-	// Check type-specific protocol first
-	protocol := viper.GetString(fmt.Sprintf("OTEL_EXPORTER_OTLP_%s_PROTOCOL", telemetryType))
-	if protocol == "" {
-		// Fall back to generic protocol
-		protocol = viper.GetString("OTEL_EXPORTER_OTLP_PROTOCOL")
-	}
-	if protocol == "" {
-		// Default to gRPC if not specified
-		protocol = "grpc"
+// normalizeOTelProtocol maps the specification's protocol name onto the value
+// the otel package switches on.
+func normalizeOTelProtocol(protocol string) string {
+	if protocol == OTelProtocolHTTPProtobuf {
+		return OTelProtocolHTTP
 	}
 	return protocol
+}
+
+// getProtocol returns the protocol for a signal from the standard OpenTelemetry
+// variables, most specific first. Empty means neither is set, and the caller
+// falls back to OTEL_PROTOCOL and then to gRPC.
+func getProtocol(osInterface OSInterface, signal string) string {
+	if protocol := osInterface.Getenv(fmt.Sprintf("OTEL_EXPORTER_OTLP_%s_PROTOCOL", signal)); protocol != "" {
+		return protocol
+	}
+	return osInterface.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+}
+
+// resolveOTelEnv applies the OpenTelemetry environment variables that
+// caarlos0/env cannot express: the per-signal exporter and protocol variables
+// (one struct tag would bind the same variable to all three signals), and the
+// endpoint variables, which decide which signals are enabled.
+//
+// It runs after env parsing, so c.<Signal>.Exporter/Protocol already hold the
+// YAML value overridden by OTEL_EXPORTER/OTEL_PROTOCOL. Anything resolved here
+// is more specific and wins.
+func (c *OpenTelemetryConfig) resolveOTelEnv(osInterface OSInterface) {
+	signals := map[string]*OpenTelemetryTypeConfig{
+		"TRACES":  &c.Traces,
+		"METRICS": &c.Metrics,
+		"LOGS":    &c.Logs,
+	}
+
+	for _, signal := range otelSignals {
+		cfg := signals[signal]
+		if exporter := osInterface.Getenv(fmt.Sprintf("OTEL_%s_EXPORTER", signal)); exporter != "" {
+			cfg.Exporter = exporter
+		}
+		if protocol := getProtocol(osInterface, signal); protocol != "" {
+			cfg.Protocol = protocol
+		}
+	}
+
+	// Endpoint inference, for signals left without an explicit exporter: a
+	// per-signal endpoint enables that signal and disables the others, while
+	// the generic endpoint enables all three. With no endpoint set at all,
+	// every signal stays enabled against the SDK's default endpoint.
+	if osInterface.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
+		return
+	}
+	endpoints := make(map[string]bool, len(otelSignals))
+	anyEndpoint := false
+	for _, signal := range otelSignals {
+		if osInterface.Getenv(fmt.Sprintf("OTEL_EXPORTER_OTLP_%s_ENDPOINT", signal)) != "" {
+			endpoints[signal] = true
+			anyEndpoint = true
+		}
+	}
+	if !anyEndpoint {
+		return
+	}
+	for _, signal := range otelSignals {
+		if cfg := signals[signal]; cfg.Exporter == "" && !endpoints[signal] {
+			cfg.Exporter = OTelExporterNone
+		}
+	}
 }
 
 func (c *OpenTelemetryConfig) Validate() error {
@@ -84,7 +150,7 @@ func (c *OpenTelemetryConfig) ToConfig() *otel.OpenTelemetryConfig {
 		if p == "" {
 			return OTelProtocolGRPC
 		}
-		return p
+		return normalizeOTelProtocol(p)
 	}
 
 	return &otel.OpenTelemetryConfig{

--- a/internal/config/otel.go
+++ b/internal/config/otel.go
@@ -8,8 +8,8 @@ import (
 )
 
 type OpenTelemetryTypeConfig struct {
-	Exporter string `yaml:"exporter" env:"OTEL_EXPORTER" desc:"Exporter for this signal ('otlp', 'console' or 'none'). Applies to all three signals; override a single signal with OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER or OTEL_LOGS_EXPORTER. If unset, a signal is enabled when its endpoint (or the generic OTEL_EXPORTER_OTLP_ENDPOINT) is set, or when no endpoint is set at all." required:"C"`
-	Protocol string `yaml:"protocol" env:"OTEL_PROTOCOL" desc:"OTLP protocol ('grpc' or 'http') for this signal. Applies to all three signals; the standard OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL take precedence. Defaults to 'grpc'." required:"C"`
+	Exporter string `yaml:"exporter" env:"OTEL_EXPORTER" desc:"How an enabled signal exports: 'otlp' (the default), 'console'/'stdout', or 'none' to disable the signal. Applies to all three signals; override a single signal with OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER or OTEL_LOGS_EXPORTER. Which signals are enabled is decided by the endpoint variables: when one or more OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT variables are set without the generic OTEL_EXPORTER_OTLP_ENDPOINT, signals without an endpoint are disabled regardless of any exporter value — an exporter can disable a signal but never enable one." required:"C"`
+	Protocol string `yaml:"protocol" env:"OTEL_PROTOCOL" desc:"OTLP protocol ('grpc', 'http' or 'http/protobuf') for this signal. Applies to all three signals; the standard OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL and OTEL_EXPORTER_OTLP_PROTOCOL take precedence. Defaults to 'grpc'." required:"C"`
 }
 
 type OpenTelemetryConfig struct {
@@ -29,6 +29,11 @@ const (
 	// OTelExporterNone disables a signal. It is the specification's value and
 	// falls through to each provider constructor's no-exporter branch.
 	OTelExporterNone = "none"
+
+	OTelExporterOTLP    = "otlp"
+	OTelExporterConsole = "console"
+	// OTelExporterStdout is an alias for "console".
+	OTelExporterStdout = "stdout"
 )
 
 // otelSignals are the signal names as they appear in the specification's
@@ -41,7 +46,7 @@ var validOTelProtocols = map[string]bool{
 	OTelProtocolHTTPProtobuf: true,
 }
 
-var ErrInvalidOTelProtocol = errors.New("config validation error: invalid OpenTelemetry protocol, must be 'grpc' or 'http'")
+var ErrInvalidOTelProtocol = errors.New("config validation error: invalid OpenTelemetry protocol, must be 'grpc', 'http' or 'http/protobuf'")
 
 func validateOTelProtocol(protocol string) error {
 	if protocol == "" {
@@ -49,6 +54,25 @@ func validateOTelProtocol(protocol string) error {
 	}
 	if !validOTelProtocols[protocol] {
 		return ErrInvalidOTelProtocol
+	}
+	return nil
+}
+
+var validOTelExporters = map[string]bool{
+	OTelExporterOTLP:    true,
+	OTelExporterConsole: true,
+	OTelExporterStdout:  true,
+	OTelExporterNone:    true,
+}
+
+var ErrInvalidOTelExporter = errors.New("config validation error: invalid OpenTelemetry exporter, must be 'otlp', 'console', 'stdout' or 'none'")
+
+func validateOTelExporter(exporter string) error {
+	if exporter == "" {
+		return nil // Empty exporter defaults to otlp
+	}
+	if !validOTelExporters[exporter] {
+		return ErrInvalidOTelExporter
 	}
 	return nil
 }
@@ -97,10 +121,13 @@ func (c *OpenTelemetryConfig) resolveOTelEnv(osInterface OSInterface) {
 		}
 	}
 
-	// Endpoint inference, for signals left without an explicit exporter: a
-	// per-signal endpoint enables that signal and disables the others, while
-	// the generic endpoint enables all three. With no endpoint set at all,
-	// every signal stays enabled against the SDK's default endpoint.
+	// Endpoints decide WHICH signals are enabled; exporter values decide HOW
+	// an enabled signal exports (an exporter can disable a signal with "none",
+	// never enable one). When per-signal endpoints are set without the generic
+	// endpoint, every signal without its own endpoint is forced to "none",
+	// regardless of any explicit exporter value. With the generic endpoint set,
+	// or with no endpoint at all (the SDK's default endpoint), no gating
+	// happens and every signal keeps its configured exporter.
 	if osInterface.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
 		return
 	}
@@ -116,8 +143,8 @@ func (c *OpenTelemetryConfig) resolveOTelEnv(osInterface OSInterface) {
 		return
 	}
 	for _, signal := range otelSignals {
-		if cfg := signals[signal]; cfg.Exporter == "" && !endpoints[signal] {
-			cfg.Exporter = OTelExporterNone
+		if !endpoints[signal] {
+			signals[signal].Exporter = OTelExporterNone
 		}
 	}
 }
@@ -134,6 +161,16 @@ func (c *OpenTelemetryConfig) Validate() error {
 		return err
 	}
 	if err := validateOTelProtocol(c.Logs.Protocol); err != nil {
+		return err
+	}
+
+	if err := validateOTelExporter(c.Traces.Exporter); err != nil {
+		return err
+	}
+	if err := validateOTelExporter(c.Metrics.Exporter); err != nil {
+		return err
+	}
+	if err := validateOTelExporter(c.Logs.Exporter); err != nil {
 		return err
 	}
 

--- a/internal/config/otel_test.go
+++ b/internal/config/otel_test.go
@@ -1,0 +1,183 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseOTelConfig(t *testing.T, envVars map[string]string) *config.OpenTelemetryConfig {
+	t.Helper()
+	if _, ok := envVars["OTEL_SERVICE_NAME"]; !ok {
+		envVars["OTEL_SERVICE_NAME"] = "outpost"
+	}
+	cfg, err := config.ParseWithoutValidation(config.Flags{}, &mockOS{
+		files:   make(map[string][]byte),
+		envVars: envVars,
+	})
+	require.NoError(t, err)
+	return &cfg.OpenTelemetry
+}
+
+func TestOTelExporterPerSignal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		envVars               map[string]string
+		traces, metrics, logs string
+	}{
+		{
+			name:    "no exporter config leaves every signal enabled",
+			envVars: map[string]string{},
+		},
+		{
+			name:    "OTEL_EXPORTER applies to every signal",
+			envVars: map[string]string{"OTEL_EXPORTER": "console"},
+			traces:  "console", metrics: "console", logs: "console",
+		},
+		{
+			name: "per-signal exporter overrides OTEL_EXPORTER",
+			envVars: map[string]string{
+				"OTEL_EXPORTER":        "otlp",
+				"OTEL_LOGS_EXPORTER":   "none",
+				"OTEL_TRACES_EXPORTER": "console",
+			},
+			traces: "console", metrics: "otlp", logs: "none",
+		},
+		{
+			name: "per-signal endpoint enables that signal and disables the rest",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector",
+			},
+			traces: "none", metrics: "", logs: "none",
+		},
+		{
+			name: "generic endpoint enables every signal",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "https://collector",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://metrics-collector",
+			},
+		},
+		{
+			name: "explicit exporter wins over endpoint inference",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector",
+				"OTEL_TRACES_EXPORTER":                "otlp",
+			},
+			traces: "otlp", metrics: "", logs: "none",
+		},
+		{
+			name: "OTEL_EXPORTER wins over endpoint inference",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector",
+				"OTEL_EXPORTER":                       "otlp",
+			},
+			traces: "otlp", metrics: "otlp", logs: "otlp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			otelCfg := parseOTelConfig(t, tt.envVars)
+			assert.Equal(t, tt.traces, otelCfg.Traces.Exporter, "traces")
+			assert.Equal(t, tt.metrics, otelCfg.Metrics.Exporter, "metrics")
+			assert.Equal(t, tt.logs, otelCfg.Logs.Exporter, "logs")
+		})
+	}
+}
+
+func TestOTelProtocolPerSignal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		envVars               map[string]string
+		traces, metrics, logs string
+	}{
+		{
+			name:    "defaults to grpc",
+			envVars: map[string]string{},
+			traces:  "grpc", metrics: "grpc", logs: "grpc",
+		},
+		{
+			name:    "OTEL_PROTOCOL applies to every signal",
+			envVars: map[string]string{"OTEL_PROTOCOL": "http"},
+			traces:  "http", metrics: "http", logs: "http",
+		},
+		{
+			name:    "standard generic protocol overrides OTEL_PROTOCOL",
+			envVars: map[string]string{"OTEL_PROTOCOL": "grpc", "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+			traces:  "http", metrics: "http", logs: "http",
+		},
+		{
+			name: "standard per-signal protocol wins",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_PROTOCOL":      "http/protobuf",
+				"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "grpc",
+			},
+			traces: "http", metrics: "http", logs: "grpc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			otelCfg := parseOTelConfig(t, tt.envVars).ToConfig()
+			require.NotNil(t, otelCfg)
+			assert.Equal(t, tt.traces, otelCfg.Traces.Protocol, "traces")
+			assert.Equal(t, tt.metrics, otelCfg.Metrics.Protocol, "metrics")
+			assert.Equal(t, tt.logs, otelCfg.Logs.Protocol, "logs")
+		})
+	}
+}
+
+func TestOTelValidateProtocol(t *testing.T) {
+	t.Parallel()
+
+	for _, protocol := range []string{"", "grpc", "http", "http/protobuf"} {
+		otelCfg := config.OpenTelemetryConfig{
+			ServiceName: "outpost",
+			Traces:      config.OpenTelemetryTypeConfig{Protocol: protocol},
+		}
+		assert.NoError(t, otelCfg.Validate(), protocol)
+	}
+
+	otelCfg := config.OpenTelemetryConfig{
+		ServiceName: "outpost",
+		Logs:        config.OpenTelemetryTypeConfig{Protocol: "http/json"},
+	}
+	assert.ErrorIs(t, otelCfg.Validate(), config.ErrInvalidOTelProtocol)
+}
+
+// Config file values stay in effect; environment variables refine them.
+func TestOTelConfigFileWithEnvOverride(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+otel:
+  service_name: outpost
+  traces:
+    exporter: console
+    protocol: http
+  metrics:
+    exporter: otlp
+  logs:
+    exporter: none
+`)
+	cfg, err := config.ParseWithoutValidation(config.Flags{Config: "config.yaml"}, &mockOS{
+		files:   map[string][]byte{"config.yaml": yaml},
+		envVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "grpc"},
+	})
+	require.NoError(t, err)
+
+	otelCfg := cfg.OpenTelemetry.ToConfig()
+	require.NotNil(t, otelCfg)
+	assert.Equal(t, "console", otelCfg.Traces.Exporter)
+	assert.Equal(t, "grpc", otelCfg.Traces.Protocol)
+	assert.Equal(t, "otlp", otelCfg.Metrics.Exporter)
+	assert.Equal(t, "none", otelCfg.Logs.Exporter)
+}

--- a/internal/config/otel_test.go
+++ b/internal/config/otel_test.go
@@ -62,20 +62,36 @@ func TestOTelExporterPerSignal(t *testing.T) {
 			},
 		},
 		{
-			name: "explicit exporter wins over endpoint inference",
+			name: "per-signal exporter cannot enable a signal gated off by endpoints",
 			envVars: map[string]string{
 				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector",
 				"OTEL_TRACES_EXPORTER":                "otlp",
 			},
-			traces: "otlp", metrics: "", logs: "none",
+			traces: "none", metrics: "", logs: "none",
 		},
 		{
-			name: "OTEL_EXPORTER wins over endpoint inference",
+			name: "OTEL_EXPORTER cannot enable signals gated off by endpoints",
 			envVars: map[string]string{
 				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector",
 				"OTEL_EXPORTER":                       "otlp",
 			},
-			traces: "otlp", metrics: "otlp", logs: "otlp",
+			traces: "none", metrics: "otlp", logs: "none",
+		},
+		{
+			name: "exporter none still disables a signal enabled by the generic endpoint",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "https://collector",
+				"OTEL_LOGS_EXPORTER":          "none",
+			},
+			traces: "", metrics: "", logs: "none",
+		},
+		{
+			name: "an endpoint never forces a signal on over exporter none",
+			envVars: map[string]string{
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector",
+				"OTEL_METRICS_EXPORTER":               "none",
+			},
+			traces: "none", metrics: "none", logs: "none",
 		},
 	}
 
@@ -153,6 +169,62 @@ func TestOTelValidateProtocol(t *testing.T) {
 	assert.ErrorIs(t, otelCfg.Validate(), config.ErrInvalidOTelProtocol)
 }
 
+func TestOTelValidateExporter(t *testing.T) {
+	t.Parallel()
+
+	for _, exporter := range []string{"", "otlp", "console", "stdout", "none"} {
+		otelCfg := config.OpenTelemetryConfig{
+			ServiceName: "outpost",
+			Traces:      config.OpenTelemetryTypeConfig{Exporter: exporter},
+		}
+		assert.NoError(t, otelCfg.Validate(), exporter)
+	}
+
+	tests := []struct {
+		name string
+		cfg  config.OpenTelemetryConfig
+	}{
+		{
+			name: "typoed traces exporter",
+			cfg: config.OpenTelemetryConfig{
+				ServiceName: "outpost",
+				Traces:      config.OpenTelemetryTypeConfig{Exporter: "otpl"},
+			},
+		},
+		{
+			name: "invalid metrics exporter",
+			cfg: config.OpenTelemetryConfig{
+				ServiceName: "outpost",
+				Metrics:     config.OpenTelemetryTypeConfig{Exporter: "prometheus"},
+			},
+		},
+		{
+			name: "invalid logs exporter",
+			cfg: config.OpenTelemetryConfig{
+				ServiceName: "outpost",
+				Logs:        config.OpenTelemetryTypeConfig{Exporter: "invalid"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			assert.ErrorIs(t, err, config.ErrInvalidOTelExporter)
+			assert.ErrorContains(t, err, "'otlp', 'console', 'stdout' or 'none'")
+		})
+	}
+
+	t.Run("empty service name skips exporter validation", func(t *testing.T) {
+		t.Parallel()
+		otelCfg := config.OpenTelemetryConfig{
+			Traces: config.OpenTelemetryTypeConfig{Exporter: "otpl"},
+		}
+		assert.NoError(t, otelCfg.Validate())
+	})
+}
+
 // Config file values stay in effect; environment variables refine them.
 func TestOTelConfigFileWithEnvOverride(t *testing.T) {
 	t.Parallel()
@@ -180,4 +252,27 @@ otel:
 	assert.Equal(t, "grpc", otelCfg.Traces.Protocol)
 	assert.Equal(t, "otlp", otelCfg.Metrics.Exporter)
 	assert.Equal(t, "none", otelCfg.Logs.Exporter)
+}
+
+// Endpoint gating applies to YAML-configured exporters too: a per-signal
+// endpoint in the environment disables the signals without one, regardless of
+// what the config file asks for.
+func TestOTelEndpointGatingOverridesConfigFile(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+otel:
+  service_name: outpost
+  traces:
+    exporter: otlp
+`)
+	cfg, err := config.ParseWithoutValidation(config.Flags{Config: "config.yaml"}, &mockOS{
+		files:   map[string][]byte{"config.yaml": yaml},
+		envVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://collector"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", cfg.OpenTelemetry.Traces.Exporter)
+	assert.Equal(t, "", cfg.OpenTelemetry.Metrics.Exporter)
+	assert.Equal(t, "none", cfg.OpenTelemetry.Logs.Exporter)
 }


### PR DESCRIPTION
Closes #1015.

`OpenTelemetryConfig` already had separate `Traces`/`Metrics`/`Logs` sections, but all three carried the same `OTEL_EXPORTER` / `OTEL_PROTOCOL` env tags, so one value populated all three. Enabling OTel for one signal enabled the other two with no endpoint — they retried against `localhost:4317` for the life of the process, with no env var to turn them off.

## What changed

`resolveOTelEnv` runs after env parsing and applies what struct tags can't express. Two orthogonal roles:

**Endpoints decide which signals export.** Per-signal `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT` (with no generic endpoint) enables exactly those signals — the rest are disabled regardless of any exporter value. The generic `OTEL_EXPORTER_OTLP_ENDPOINT` enables all three, with per-signal endpoints refining destinations. No endpoints at all keeps today's behavior: all three against the SDK default. Endpoint values themselves stay the SDK's job — Outpost reads them only for gating, and headers, compression and timeout remain untouched.

**Exporter variables decide how an enabled signal exports, never whether.** `OTEL_{TRACES,METRICS,LOGS}_EXPORTER` (spec names) select `otlp` or `console`/`stdout`, and `none` disables a signal in any configuration — an exporter can turn a signal off, never on. `OTEL_EXPORTER` applies to all three, unchanged. Precedence among exporter sources: per-signal env > `OTEL_EXPORTER` > config file. Values are validated at startup; a typo fails config validation instead of silently disabling a signal.

**Protocol**, per signal, first match wins:
1. `OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL`
2. `OTEL_EXPORTER_OTLP_PROTOCOL`
3. `OTEL_PROTOCOL`
4. `grpc`

1 and 2 are what `getProtocol` already implemented — it had no callers and read from a viper instance the config package never constructs. It now takes `OSInterface` and is wired in. `http/protobuf` validates as an alias for `http`.

The OTel spec variables (per-signal exporters, protocols, and all endpoints) are read from the process environment, matching how the SDK reads them — they have no effect in an Outpost `.env`/YAML config file. Outpost's own `OTEL_EXPORTER` / `OTEL_PROTOCOL` and the YAML `traces:`/`metrics:`/`logs:` sections work in config files as usual.

Also: `desc` tags rewritten to describe the variables that exist, the OpenTelemetry section of `contributing/config.md` documents both chains, and `docs/content/features/opentelemetry.mdoc` gains a Signal Configuration section.

## Compatibility

- No change for a deployment setting only `OTEL_SERVICE_NAME`, or that plus a generic endpoint. `OTEL_EXPORTER` / `OTEL_PROTOCOL` keep their meaning.
- A deployment with per-signal endpoints only: the signals without endpoints stop exporting into a dead localhost socket — the bug this fixes.
- An unrecognized exporter value (previously a silent no-op that disabled the signal) now fails startup; disabling is spelled `none`.

## Tests

`internal/config/otel_test.go` covers endpoint gating (including over explicit exporters and the YAML config file), exporter and protocol validation, both precedence chains, and YAML-plus-env override. `go test -short ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
