### PR TITLE
fix(test): flaky and unrunnable test suites

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -12,10 +12,10 @@ TEST_MOCKSERVER_URL="localhost:35555"
 
 # Container images
 #
-# Both ways of providing test infrastructure read these: build/test/compose.yml
+# Both ways of providing test infrastructure read these: the compose stack
 # (started by `make up/test`, which passes this file as --env-file) and the
-# testcontainers fallback in internal/util/testinfra used when TESTINFRA is
-# unset. Keeping them here is what makes the two paths the same environment.
+# containers the tests start themselves when TESTINFRA is unset. Keeping them
+# here is what makes the two the same environment.
 #
 # Pin exact versions. Floating tags have broken this suite before: an image
 # published a new major under the same tag and every test that needed it failed

--- a/.env.test
+++ b/.env.test
@@ -9,3 +9,22 @@ TEST_GCP_URL="localhost:38085"
 TEST_AZURE_SB_CONNSTRING="Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
 # Misc
 TEST_MOCKSERVER_URL="localhost:35555"
+
+# Container images
+#
+# Both ways of providing test infrastructure read these: build/test/compose.yml
+# (started by `make up/test`, which passes this file as --env-file) and the
+# testcontainers fallback in internal/util/testinfra used when TESTINFRA is
+# unset. Keeping them here is what makes the two paths the same environment.
+#
+# Pin exact versions. Floating tags have broken this suite before: an image
+# published a new major under the same tag and every test that needed it failed
+# on a change nobody made.
+TEST_IMAGE_POSTGRES="postgres:16.10-alpine"
+TEST_IMAGE_CLICKHOUSE="clickhouse/clickhouse-server:24.10-alpine"
+TEST_IMAGE_RABBITMQ="rabbitmq:3.13-management"
+TEST_IMAGE_KAFKA="confluentinc/confluent-local:7.4.0"
+TEST_IMAGE_LOCALSTACK="localstack/localstack:3.8.1"
+TEST_IMAGE_GCP="gcr.io/google.com/cloudsdktool/google-cloud-cli:544.0.0-emulators"
+TEST_IMAGE_REDIS="redis/redis-stack-server:7.4.0-v3"
+TEST_IMAGE_DRAGONFLY="docker.dragonflydb.io/dragonflydb/dragonfly:v1.38.1"

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,12 @@ smoke:
 up/portal:
 	cd internal/portal && npm install && npm run dev
 
+# --env-file supplies the image pins; see the comment at the top of compose.yml.
 up/test:
-	docker-compose -f build/test/compose.yml up -d
+	docker-compose --env-file .env.test -f build/test/compose.yml up -d
 
 down/test:
-	docker-compose -f build/test/compose.yml down --volumes
+	docker-compose --env-file .env.test -f build/test/compose.yml down --volumes
 
 up/test/rediscluster:
 	@echo "Ensuring test network exists..."

--- a/build/test/compose.yml
+++ b/build/test/compose.yml
@@ -1,3 +1,6 @@
+# Image tags live in .env.test so this stack and the testcontainers fallback
+# in internal/util/testinfra run the same versions. Start with `make up/test`.
+
 name: "outpost-test"
 
 services:
@@ -9,11 +12,11 @@ services:
     ports:
       - 35555:5555
   test-clickhouse:
-    image: clickhouse/clickhouse-server:24-alpine
+    image: ${TEST_IMAGE_CLICKHOUSE:?run via `make up/test`, which passes --env-file .env.test}
     ports:
       - 39000:9000
   test-postgres:
-    image: postgres:16-alpine
+    image: ${TEST_IMAGE_POSTGRES:?run via `make up/test`, which passes --env-file .env.test}
     environment:
       - POSTGRES_USER=outpost
       - POSTGRES_PASSWORD=outpost
@@ -21,19 +24,19 @@ services:
     ports:
       - 35432:5432
   test-rabbitmq:
-    image: rabbitmq:3-management
+    image: ${TEST_IMAGE_RABBITMQ:?run via `make up/test`, which passes --env-file .env.test}
     ports:
       - 35672:5672
       - 45672:15672
   test-aws:
-    image: localstack/localstack:3
+    image: ${TEST_IMAGE_LOCALSTACK:?run via `make up/test`, which passes --env-file .env.test}
     environment:
       - SERVICES=s3,sns,sts,sqs,kinesis
     ports:
       - 34566:4566
       - 34571:4571
   test-kafka:
-    image: confluentinc/confluent-local:7.4.0
+    image: ${TEST_IMAGE_KAFKA:?run via `make up/test`, which passes --env-file .env.test}
     environment:
       KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://test-kafka:29092,SASL_PLAINTEXT_HOST://localhost:39092
       KAFKA_LISTENERS: SASL_PLAINTEXT://0.0.0.0:29092,CONTROLLER://localhost:29093,SASL_PLAINTEXT_HOST://0.0.0.0:9092
@@ -47,7 +50,7 @@ services:
     ports:
       - 39092:9092
   test-gcp:
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
+    image: ${TEST_IMAGE_GCP:?run via `make up/test`, which passes --env-file .env.test}
     command:
       [
         "gcloud",

--- a/build/test/compose.yml
+++ b/build/test/compose.yml
@@ -1,5 +1,5 @@
-# Image tags live in .env.test so this stack and the testcontainers fallback
-# in internal/util/testinfra run the same versions. Start with `make up/test`.
+# Image tags live in .env.test so this stack and the containers the tests start
+# themselves run the same versions. Start with `make up/test`.
 
 name: "outpost-test"
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/matoous/go-nanoid/v2 v2.1.0
 	github.com/mikestefanello/batcher v0.1.0
+	github.com/moby/moby/api v1.55.0
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.13.0
 	github.com/redis/go-redis/extra/redisotel/v9 v9.22.0
@@ -164,7 +165,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.3.3 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.1 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.7.0 // indirect

--- a/internal/destregistry/providers/destawskinesis/destawskinesis_publish_test.go
+++ b/internal/destregistry/providers/destawskinesis/destawskinesis_publish_test.go
@@ -79,6 +79,15 @@ func (c *KinesisConsumer) consume() {
 	}
 
 	iterator := iteratorOutput.ShardIterator
+	// lastSeq is the sequence number of the most recent record handed to the
+	// suite. GetRecords can return a record that an earlier call already
+	// returned — observed against localstack, with no error reported and the
+	// iterator advanced normally. Every test in the suite reads one shared
+	// channel, so a single redelivered record shifts every later read by one and
+	// each test then verifies the wrong event. Records within a shard are
+	// ordered, so dropping anything at or before lastSeq makes the stream
+	// deliver-once from the suite's point of view.
+	var lastSeq string
 	for {
 		select {
 		case <-c.done:
@@ -98,6 +107,12 @@ func (c *KinesisConsumer) consume() {
 
 			// Process each record
 			for _, record := range recordsOutput.Records {
+				if seq := aws.ToString(record.SequenceNumber); seq != "" {
+					if lastSeq != "" && !sequenceAfter(seq, lastSeq) {
+						continue
+					}
+					lastSeq = seq
+				}
 				var payload map[string]interface{}
 				err := json.Unmarshal(record.Data, &payload)
 				if err != nil {
@@ -143,6 +158,16 @@ func (c *KinesisConsumer) consume() {
 			}
 		}
 	}
+}
+
+// sequenceAfter reports whether a is a later Kinesis sequence number than b.
+// They are arbitrary-precision decimal integers, so compare by length first and
+// lexically only at equal length.
+func sequenceAfter(a, b string) bool {
+	if len(a) != len(b) {
+		return len(a) > len(b)
+	}
+	return a > b
 }
 
 func (c *KinesisConsumer) Consume() <-chan testsuite.Message {

--- a/internal/destregistry/providers/destawskinesis/destawskinesis_publish_test.go
+++ b/internal/destregistry/providers/destawskinesis/destawskinesis_publish_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/hookdeck/outpost/internal/destregistry"
 	"github.com/hookdeck/outpost/internal/destregistry/partitionkey"
 	"github.com/hookdeck/outpost/internal/destregistry/providers/destawskinesis"
 	testsuite "github.com/hookdeck/outpost/internal/destregistry/testing"
@@ -275,9 +276,11 @@ func deleteKinesisStream(ctx context.Context, client *kinesis.Client, streamName
 // AWSKinesisSuite is the test suite for AWS Kinesis
 type AWSKinesisSuite struct {
 	testsuite.PublisherSuite
-	consumer   *KinesisConsumer
-	client     *kinesis.Client
-	streamName string
+	consumer           *KinesisConsumer
+	client             *kinesis.Client
+	provider           destregistry.Provider
+	localstackEndpoint string
+	streamName         string
 }
 
 func TestAWSKinesisSuite(t *testing.T) {
@@ -288,11 +291,7 @@ func (s *AWSKinesisSuite) SetupSuite() {
 	t := s.T()
 	t.Cleanup(testinfra.Start(t))
 
-	// Create a unique stream name for the test
-	s.streamName = "test-stream-" + idgen.String()
-
-	// Setup AWS config and client
-	localstackEndpoint := testinfra.EnsureLocalStack()
+	s.localstackEndpoint = testinfra.EnsureLocalStack()
 	awsConfig, err := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion("us-east-1"),
 		config.WithCredentialsProvider(
@@ -302,27 +301,31 @@ func (s *AWSKinesisSuite) SetupSuite() {
 
 	// Create Kinesis client with custom endpoint
 	s.client = kinesis.NewFromConfig(awsConfig, func(o *kinesis.Options) {
-		o.BaseEndpoint = aws.String(localstackEndpoint)
+		o.BaseEndpoint = aws.String(s.localstackEndpoint)
 	})
 
-	// Create test stream
-	err = ensureKinesisStream(context.Background(), s.client, s.streamName)
+	s.provider, err = destawskinesis.New(testutil.Registry.MetadataLoader(), nil)
 	require.NoError(t, err)
+}
 
-	// Create consumer
-	s.consumer, err = NewKinesisConsumer(s.client, s.streamName)
+// SetupTest gives each test its own stream and consumer. Sharing them across the
+// suite means anything one test leaves behind — or that the stream redelivers —
+// lands in the next test, which then verifies an event it never published.
+func (s *AWSKinesisSuite) SetupTest() {
+	t := s.T()
+
+	s.streamName = "test-stream-" + idgen.String()
+	require.NoError(t, ensureKinesisStream(context.Background(), s.client, s.streamName))
+
+	consumer, err := NewKinesisConsumer(s.client, s.streamName)
 	require.NoError(t, err)
+	s.consumer = consumer
 
-	// Create provider
-	provider, err := destawskinesis.New(testutil.Registry.MetadataLoader(), nil)
-	require.NoError(t, err)
-
-	// Create destination with partition key template
 	partitionKeyTemplate := "join('__', [metadata.topic, metadata.timestamp, metadata.\"event-id\"])"
 	destination := testutil.DestinationFactory.Any(
 		testutil.DestinationFactory.WithType("aws_kinesis"),
 		testutil.DestinationFactory.WithConfig(map[string]string{
-			"endpoint":               localstackEndpoint,
+			"endpoint":               s.localstackEndpoint,
 			"stream_name":            s.streamName,
 			"region":                 "us-east-1",
 			"partition_key_template": partitionKeyTemplate,
@@ -334,24 +337,27 @@ func (s *AWSKinesisSuite) SetupSuite() {
 		}),
 	)
 
-	// Initialize publisher suite with custom asserter
-	testConfig := testsuite.Config{
-		Provider: provider,
+	s.InitSuite(testsuite.Config{
+		Provider: s.provider,
 		Dest:     &destination,
 		Consumer: s.consumer,
 		Asserter: &KinesisAsserter{
 			partitionKeyTemplate: partitionKeyTemplate,
 		},
-	}
-	s.InitSuite(testConfig)
+	})
+
+	s.PublisherSuite.SetupTest()
 }
 
-func (s *AWSKinesisSuite) TearDownSuite() {
+func (s *AWSKinesisSuite) TearDownTest() {
+	s.PublisherSuite.TearDownTest()
+
 	if s.consumer != nil {
 		s.consumer.Close()
+		s.consumer = nil
 	}
-	if s.client != nil && s.streamName != "" {
-		// Delete the test stream
+	if s.streamName != "" {
 		_ = deleteKinesisStream(context.Background(), s.client, s.streamName)
+		s.streamName = ""
 	}
 }

--- a/internal/destregistry/providers/destawss3/destawss3_validate_test.go
+++ b/internal/destregistry/providers/destawss3/destawss3_validate_test.go
@@ -91,7 +91,11 @@ func TestAWSS3Destination_Validate(t *testing.T) {
 	t.Run("should validate invalid storage class", func(t *testing.T) {
 		t.Parallel()
 		invalidDestination := validDestination
-		invalidDestination.Config["storage_class"] = "INVALID"
+		invalidDestination.Config = map[string]string{
+			"bucket":        "my-bucket",
+			"region":        "us-east-1",
+			"storage_class": "INVALID",
+		}
 		err := awsS3Destination.Validate(context.Background(), &invalidDestination)
 		var validationErr *destregistry.ErrDestinationValidation
 		assert.ErrorAs(t, err, &validationErr)

--- a/internal/destregistry/testing/publisher_suite.go
+++ b/internal/destregistry/testing/publisher_suite.go
@@ -106,6 +106,18 @@ func (s *PublisherSuite) TearDownTest() {
 	}
 }
 
+// requireMessageID reads the message_id the concurrent-publish tests stamp on
+// every event they send. A message without one did not come from the running
+// test, so say that plainly instead of panicking on the type assertion.
+func (s *PublisherSuite) requireMessageID(msg Message) int {
+	var body map[string]interface{}
+	s.Require().NoError(json.Unmarshal(msg.Data, &body))
+
+	id, ok := body["message_id"].(float64)
+	s.Require().True(ok, "consumed a message with no message_id, which this test never published: %s", string(msg.Data))
+	return int(id)
+}
+
 // verifyMessage performs base message verification and calls provider-specific assertions
 func (s *PublisherSuite) verifyMessage(msg Message, event models.Event) {
 	// Base verification of data
@@ -232,10 +244,7 @@ func (s *PublisherSuite) TestConcurrentPublish() {
 		select {
 		case msg := <-s.consumer.Consume():
 			// Get the message ID first
-			var body map[string]interface{}
-			err := json.Unmarshal(msg.Data, &body)
-			s.Require().NoError(err)
-			messageID := int(body["message_id"].(float64))
+			messageID := s.requireMessageID(msg)
 
 			// Verify against the correct event
 			s.verifyMessage(msg, events[messageID])
@@ -333,10 +342,7 @@ func (s *PublisherSuite) TestClosePublisherDuringConcurrentPublish() {
 	for receivedCount < expectedCount {
 		select {
 		case msg := <-s.consumer.Consume():
-			var body map[string]interface{}
-			err := json.Unmarshal(msg.Data, &body)
-			s.Require().NoError(err)
-			messageID := int(body["message_id"].(float64))
+			messageID := s.requireMessageID(msg)
 
 			// Get the original event for verification
 			eventsMu.RLock()

--- a/internal/util/testinfra/aws.go
+++ b/internal/util/testinfra/aws.go
@@ -49,7 +49,6 @@ func EnsureLocalStack() string {
 		localstackOnce.Do(func() {
 			startLocalStackTestContainer(cfg)
 		})
-		return cfg.LocalStackURL
 	}
 	// LocalStack serves HTTP before its individual services are usable, so ask
 	// the health endpoint rather than settling for an open port.
@@ -76,9 +75,7 @@ func EnsureLocalStack() string {
 func startLocalStackTestContainer(cfg *Config) {
 	ctx := context.Background()
 
-	localstackContainer, err := localstack.Run(ctx,
-		"localstack/localstack:latest",
-	)
+	localstackContainer, err := localstack.Run(ctx, cfg.Images.LocalStack)
 
 	if err != nil {
 		panic(err)
@@ -93,11 +90,6 @@ func startLocalStackTestContainer(cfg *Config) {
 	}
 	log.Printf("Localstack running at %s", endpoint)
 	cfg.LocalStackURL = endpoint
-	cfg.cleanupFns = append(cfg.cleanupFns, func() {
-		if err := localstackContainer.Terminate(ctx); err != nil {
-			log.Println("Failed to terminate localstack container", err)
-		}
-	})
 }
 
 func DeclareTestAWSInfrastructure(ctx context.Context, cfg *mqs.AWSSQSConfig, attributes map[string]string) (string, error) {

--- a/internal/util/testinfra/aws.go
+++ b/internal/util/testinfra/aws.go
@@ -2,7 +2,9 @@ package testinfra
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -36,7 +38,10 @@ func NewMQAWSConfig(t *testing.T, attributes map[string]string) mqs.QueueConfig 
 	return queueConfig
 }
 
-var localstackOnce sync.Once
+var (
+	localstackOnce      sync.Once
+	localstackReadyOnce sync.Once
+)
 
 func EnsureLocalStack() string {
 	cfg := ReadConfig()
@@ -44,7 +49,27 @@ func EnsureLocalStack() string {
 		localstackOnce.Do(func() {
 			startLocalStackTestContainer(cfg)
 		})
+		return cfg.LocalStackURL
 	}
+	// LocalStack serves HTTP before its individual services are usable, so ask
+	// the health endpoint rather than settling for an open port.
+	localstackReadyOnce.Do(func() {
+		waitReadyLogged("localstack", cfg.LocalStackURL, func() error {
+			req, err := http.NewRequest(http.MethodGet, cfg.LocalStackURL+"/_localstack/health", nil)
+			if err != nil {
+				return err
+			}
+			resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("health returned %s", resp.Status)
+			}
+			return nil
+		})
+	})
 	return cfg.LocalStackURL
 }
 

--- a/internal/util/testinfra/clickhouse.go
+++ b/internal/util/testinfra/clickhouse.go
@@ -49,7 +49,10 @@ func clearDB(chConfig clickhouse.ClickHouseConfig, database string) {
 	}
 }
 
-var chOnce sync.Once
+var (
+	chOnce      sync.Once
+	chReadyOnce sync.Once
+)
 
 func ensureClickHouse() string {
 	cfg := ReadConfig()
@@ -58,6 +61,19 @@ func ensureClickHouse() string {
 			startCHTestcontainer(cfg)
 		})
 	}
+	chReadyOnce.Do(func() {
+		waitReadyLogged("clickhouse", cfg.ClickHouseURL, func() error {
+			chDB, err := clickhouse.New(&clickhouse.ClickHouseConfig{
+				Addr:     cfg.ClickHouseURL,
+				Username: "default",
+				Database: "default",
+			})
+			if err != nil {
+				return err
+			}
+			return chDB.Exec(context.Background(), "SELECT 1")
+		})
+	})
 	return cfg.ClickHouseURL
 }
 
@@ -65,7 +81,7 @@ func startCHTestcontainer(cfg *Config) {
 	ctx := context.Background()
 
 	clickHouseContainer, err := chTestcontainer.Run(ctx,
-		"clickhouse/clickhouse-server:latest",
+		cfg.Images.ClickHouse,
 		chTestcontainer.WithUsername("default"),
 		chTestcontainer.WithPassword(""),
 		chTestcontainer.WithDatabase("default"),
@@ -80,9 +96,4 @@ func startCHTestcontainer(cfg *Config) {
 	}
 	log.Printf("ClickHouse running at %s", endpoint)
 	cfg.ClickHouseURL = endpoint
-	cfg.cleanupFns = append(cfg.cleanupFns, func() {
-		if err := clickHouseContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-	})
 }

--- a/internal/util/testinfra/gcp.go
+++ b/internal/util/testinfra/gcp.go
@@ -51,13 +51,12 @@ func EnsureGCP() string {
 		gcpOnce.Do(func() {
 			startGCPTestContainer(cfg)
 		})
-	} else {
-		gcpReadyOnce.Do(func() {
-			waitReadyLogged("pubsub emulator", cfg.GCPURL, func() error {
-				return dialTCP(cfg.GCPURL)
-			})
-		})
 	}
+	gcpReadyOnce.Do(func() {
+		waitReadyLogged("pubsub emulator", cfg.GCPURL, func() error {
+			return dialTCP(cfg.GCPURL)
+		})
+	})
 	os.Setenv("PUBSUB_EMULATOR_HOST", cfg.GCPURL)
 	return cfg.GCPURL
 }
@@ -65,10 +64,7 @@ func EnsureGCP() string {
 func startGCPTestContainer(cfg *Config) {
 	ctx := context.Background()
 
-	gcloudContainer, err := gcloud.RunPubsub(ctx,
-		"gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators",
-	)
-
+	gcloudContainer, err := gcloud.RunPubsub(ctx, cfg.Images.GCP)
 	if err != nil {
 		panic(err)
 	}
@@ -79,11 +75,6 @@ func startGCPTestContainer(cfg *Config) {
 	}
 	log.Printf("GCP Emulator running at %s", endpoint)
 	cfg.GCPURL = endpoint
-	cfg.cleanupFns = append(cfg.cleanupFns, func() {
-		if err := gcloudContainer.Terminate(ctx); err != nil {
-			log.Println("Failed to terminate localstack container", err)
-		}
-	})
 }
 
 func DeclareTestGCPInfrastructure(ctx context.Context, cfg *mqs.GCPPubSubConfig, endpoint string) error {

--- a/internal/util/testinfra/gcp.go
+++ b/internal/util/testinfra/gcp.go
@@ -40,13 +40,22 @@ func NewMQGCPConfig(t *testing.T, attributes map[string]string) mqs.QueueConfig 
 	return queueConfig
 }
 
-var gcpOnce sync.Once
+var (
+	gcpOnce      sync.Once
+	gcpReadyOnce sync.Once
+)
 
 func EnsureGCP() string {
 	cfg := ReadConfig()
 	if cfg.GCPURL == "" {
 		gcpOnce.Do(func() {
 			startGCPTestContainer(cfg)
+		})
+	} else {
+		gcpReadyOnce.Do(func() {
+			waitReadyLogged("pubsub emulator", cfg.GCPURL, func() error {
+				return dialTCP(cfg.GCPURL)
+			})
 		})
 	}
 	os.Setenv("PUBSUB_EMULATOR_HOST", cfg.GCPURL)

--- a/internal/util/testinfra/kafka.go
+++ b/internal/util/testinfra/kafka.go
@@ -3,11 +3,24 @@ package testinfra
 import (
 	"context"
 	"log"
+	"net"
+	"net/netip"
+	"path/filepath"
+	"strconv"
 	"sync"
+	"time"
 
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl/plain"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+// kafkaJaasPath is where the broker's JAAS config lands inside the container,
+// matching the mount path in build/test/compose.yml.
+const kafkaJaasPath = "/etc/kafka/jaas.conf"
 
 var (
 	kafkaOnce      sync.Once
@@ -20,11 +33,22 @@ func EnsureKafka() string {
 		kafkaOnce.Do(func() {
 			startKafkaTestContainer(cfg)
 		})
-		return cfg.KafkaURL
 	}
+	// A broker opens 9092 while it is still starting up and drops the SASL
+	// handshake, so authenticate rather than dial.
 	kafkaReadyOnce.Do(func() {
 		waitReadyLogged("kafka", cfg.KafkaURL, func() error {
-			return dialTCP(cfg.KafkaURL)
+			dialer := &kafka.Dialer{
+				SASLMechanism: plain.Mechanism{Username: "admin", Password: "admin-secret"},
+				Timeout:       5 * time.Second,
+			}
+			conn, err := dialer.DialContext(context.Background(), "tcp", cfg.KafkaURL)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			_, err = conn.Brokers()
+			return err
 		})
 	})
 	return cfg.KafkaURL
@@ -33,27 +57,56 @@ func EnsureKafka() string {
 func startKafkaTestContainer(cfg *Config) {
 	ctx := context.Background()
 
-	// Use a fixed host port so advertised listeners match what clients connect to.
-	// Kafka brokers redirect clients to the advertised address, so if testcontainers
-	// maps to a random port but the broker advertises 9092, clients would fail.
-	const hostPort = "19092"
+	// A Kafka broker hands clients the address in its advertised listener, so the
+	// host port has to be known before the container starts — testcontainers'
+	// usual "map to whatever is free and ask afterwards" does not work here.
+	// Claim a free port from the OS and bind the container to it explicitly.
+	// Reserving one per process, rather than hardcoding a port, keeps two test
+	// binaries that both want Kafka from fighting over the same number.
+	hostPort := reserveHostPort()
 
 	jaasConfig := `org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret";`
 
+	// The broker refuses to start without a KafkaServer entry in a JAAS file,
+	// whatever the per-listener SASL config says, so mount the same file the
+	// compose stack mounts.
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		panic(err)
+	}
+	jaasFile := filepath.Join(projectRoot, "build", "test", "kafka_jaas.conf")
+
 	req := testcontainers.ContainerRequest{
-		Image:        "confluentinc/confluent-local:7.4.0",
-		ExposedPorts: []string{hostPort + ":9092/tcp"},
+		Image:        cfg.Images.Kafka,
+		ExposedPorts: []string{"9092/tcp"},
+		Files: []testcontainers.ContainerFile{{
+			HostFilePath:      jaasFile,
+			ContainerFilePath: kafkaJaasPath,
+			FileMode:          0o644,
+		}},
+		HostConfigModifier: func(hostConfig *container.HostConfig) {
+			hostConfig.PortBindings = network.PortMap{
+				network.MustParsePort("9092/tcp"): []network.PortBinding{
+					{HostIP: netip.IPv4Unspecified(), HostPort: hostPort},
+				},
+			}
+		},
 		Env: map[string]string{
-			"KAFKA_ADVERTISED_LISTENERS":                                       "SASL_PLAINTEXT://localhost:29092,SASL_PLAINTEXT_HOST://localhost:" + hostPort,
-			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP":                             "SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_PLAINTEXT_HOST:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT",
-			"KAFKA_LISTENERS":                                                  "SASL_PLAINTEXT://0.0.0.0:29092,SASL_PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093",
+			// Advertise 127.0.0.1, not localhost: the published port is bound on
+			// IPv4 only, and a client that resolves localhost to ::1 first — the
+			// default on macOS — gets connection refused.
+			"KAFKA_ADVERTISED_LISTENERS":           "SASL_PLAINTEXT://localhost:29092,SASL_PLAINTEXT_HOST://127.0.0.1:" + hostPort,
+			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_PLAINTEXT_HOST:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT",
+			// The controller listener has to stay on the address the image's
+			// default quorum voters name, or the broker starts, fails to register
+			// with the quorum, and shuts down again with the port already open.
+			"KAFKA_LISTENERS":                                                  "SASL_PLAINTEXT://0.0.0.0:29092,CONTROLLER://localhost:29093,SASL_PLAINTEXT_HOST://0.0.0.0:9092",
 			"KAFKA_INTER_BROKER_LISTENER_NAME":                                 "SASL_PLAINTEXT",
-			"KAFKA_CONTROLLER_LISTENER_NAMES":                                  "CONTROLLER",
 			"KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL":                       "PLAIN",
 			"KAFKA_SASL_ENABLED_MECHANISMS":                                    "PLAIN",
 			"KAFKA_LISTENER_NAME_SASL__PLAINTEXT_PLAIN_SASL_JAAS_CONFIG":       jaasConfig,
 			"KAFKA_LISTENER_NAME_SASL__PLAINTEXT__HOST_PLAIN_SASL_JAAS_CONFIG": jaasConfig,
-			"KAFKA_OPTS":                                     "-Djava.security.auth.login.config=/dev/null",
+			"KAFKA_OPTS":                                     "-Djava.security.auth.login.config=" + kafkaJaasPath,
 			"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR":         "1",
 			"KAFKA_TRANSACTION_STATE_LOG_MIN_ISR":            "1",
 			"KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "1",
@@ -61,7 +114,7 @@ func startKafkaTestContainer(cfg *Config) {
 		WaitingFor: wait.ForListeningPort("9092/tcp"),
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	_, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
@@ -69,12 +122,19 @@ func startKafkaTestContainer(cfg *Config) {
 		panic(err)
 	}
 
-	endpoint := "localhost:" + hostPort
+	endpoint := "127.0.0.1:" + hostPort
 	log.Printf("Kafka running at %s", endpoint)
 	cfg.KafkaURL = endpoint
-	cfg.cleanupFns = append(cfg.cleanupFns, func() {
-		if err := container.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate kafka container: %s", err)
-		}
-	})
+}
+
+// reserveHostPort returns a port the OS reports as free. The listener is closed
+// before the port is used, so this is a hint rather than a reservation — good
+// enough for picking a broker port, not for anything that must not be raced.
+func reserveHostPort() string {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+	defer listener.Close()
+	return strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
 }

--- a/internal/util/testinfra/kafka.go
+++ b/internal/util/testinfra/kafka.go
@@ -9,7 +9,10 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-var kafkaOnce sync.Once
+var (
+	kafkaOnce      sync.Once
+	kafkaReadyOnce sync.Once
+)
 
 func EnsureKafka() string {
 	cfg := ReadConfig()
@@ -17,7 +20,13 @@ func EnsureKafka() string {
 		kafkaOnce.Do(func() {
 			startKafkaTestContainer(cfg)
 		})
+		return cfg.KafkaURL
 	}
+	kafkaReadyOnce.Do(func() {
+		waitReadyLogged("kafka", cfg.KafkaURL, func() error {
+			return dialTCP(cfg.KafkaURL)
+		})
+	})
 	return cfg.KafkaURL
 }
 

--- a/internal/util/testinfra/pg.go
+++ b/internal/util/testinfra/pg.go
@@ -88,7 +88,10 @@ func (pgDB *PGDB) getPGPort(pgURL string) int {
 	return port
 }
 
-var pgOnce sync.Once
+var (
+	pgOnce      sync.Once
+	pgReadyOnce sync.Once
+)
 
 func ensurePostgres() string {
 	cfg := ReadConfig()
@@ -97,6 +100,19 @@ func ensurePostgres() string {
 			startPGTestcontainer(cfg)
 		})
 	}
+	// The postgres image runs a temporary server to initialise the cluster and
+	// resets connections made to it, so connect rather than dial.
+	pgReadyOnce.Do(func() {
+		waitReadyLogged("postgres", cfg.PostgresURL, func() error {
+			url := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=%s", "outpost", "outpost", cfg.PostgresURL, "default", "disable")
+			db, err := pgxpool.New(context.Background(), url)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			return db.Ping(context.Background())
+		})
+	})
 	return cfg.PostgresURL
 }
 
@@ -104,7 +120,7 @@ func startPGTestcontainer(cfg *Config) {
 	ctx := context.Background()
 
 	pgContainer, err := pgTestcontainer.Run(ctx,
-		"postgres:latest",
+		cfg.Images.Postgres,
 		pgTestcontainer.WithUsername("outpost"),
 		pgTestcontainer.WithPassword("outpost"),
 		pgTestcontainer.WithDatabase("default"),
@@ -119,9 +135,4 @@ func startPGTestcontainer(cfg *Config) {
 	}
 	log.Printf("Postgres running at %s", endpoint)
 	cfg.PostgresURL = endpoint
-	cfg.cleanupFns = append(cfg.cleanupFns, func() {
-		if err := pgContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-	})
 }

--- a/internal/util/testinfra/rabbitmq.go
+++ b/internal/util/testinfra/rabbitmq.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 
+	amqp091 "github.com/rabbitmq/amqp091-go"
+
 	"github.com/google/uuid"
 	"github.com/hookdeck/outpost/internal/mqs"
 	"github.com/hookdeck/outpost/internal/util/testutil"
@@ -32,7 +34,10 @@ func NewMQRabbitMQConfig(t *testing.T) mqs.QueueConfig {
 	return queueConfig
 }
 
-var rabbitmqOnce sync.Once
+var (
+	rabbitmqOnce      sync.Once
+	rabbitmqReadyOnce sync.Once
+)
 
 func EnsureRabbitMQ() string {
 	cfg := ReadConfig()
@@ -40,7 +45,19 @@ func EnsureRabbitMQ() string {
 		rabbitmqOnce.Do(func() {
 			startRabbitMQTestContainer(cfg)
 		})
+		return cfg.RabbitMQURL
 	}
+	// Dial rather than probe the port: RabbitMQ accepts TCP before it will
+	// complete an AMQP handshake, and it is the handshake that tests need.
+	rabbitmqReadyOnce.Do(func() {
+		waitReadyLogged("rabbitmq", cfg.RabbitMQURL, func() error {
+			conn, err := amqp091.Dial(cfg.RabbitMQURL)
+			if err != nil {
+				return err
+			}
+			return conn.Close()
+		})
+	})
 	return cfg.RabbitMQURL
 }
 

--- a/internal/util/testinfra/rabbitmq.go
+++ b/internal/util/testinfra/rabbitmq.go
@@ -45,7 +45,6 @@ func EnsureRabbitMQ() string {
 		rabbitmqOnce.Do(func() {
 			startRabbitMQTestContainer(cfg)
 		})
-		return cfg.RabbitMQURL
 	}
 	// Dial rather than probe the port: RabbitMQ accepts TCP before it will
 	// complete an AMQP handshake, and it is the handshake that tests need.
@@ -64,9 +63,7 @@ func EnsureRabbitMQ() string {
 func startRabbitMQTestContainer(cfg *Config) {
 	ctx := context.Background()
 
-	rabbitmqContainer, err := rabbitmq.Run(ctx,
-		"rabbitmq:3-management-alpine",
-	)
+	rabbitmqContainer, err := rabbitmq.Run(ctx, cfg.Images.RabbitMQ)
 	if err != nil {
 		panic(err)
 	}
@@ -77,9 +74,4 @@ func startRabbitMQTestContainer(cfg *Config) {
 	}
 	log.Printf("RabbitMQ running at %s", endpoint)
 	cfg.RabbitMQURL = "amqp://guest:guest@" + endpoint
-	cfg.cleanupFns = append(cfg.cleanupFns, func() {
-		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-	})
 }

--- a/internal/util/testinfra/ready.go
+++ b/internal/util/testinfra/ready.go
@@ -15,13 +15,15 @@ const readyTimeout = 30 * time.Second
 // waitReady blocks until probe succeeds, and panics if it has not succeeded
 // within readyTimeout.
 //
-// Services started by testcontainers are already gated by that library's wait
-// strategies. Services supplied through the environment — the compose stack
-// behind TESTINFRA=1 — are not: `docker compose up -d` returns once containers
-// are created, not once they accept connections, so a suite that connects
-// immediately can lose the race. Without this, that race surfaces inside a test
-// as a connection reset partway through, which reads as a flaky test rather
-// than as infrastructure that was not ready.
+// Every Ensure* runs its probe, however the service was provided. Neither way of
+// starting one is trustworthy on its own: `docker compose up -d` returns when
+// containers are created, not when they accept connections, and a testcontainers
+// wait strategy watches a port or a log line, which a service can satisfy while
+// still refusing the protocol handshake a test needs. Both surface inside a test
+// as a reset or an EOF partway through, which reads as a flaky test rather than
+// as infrastructure that was not ready.
+//
+// This is why the probes below speak the protocol rather than dialing the port.
 func waitReady(name, endpoint string, probe func() error) {
 	deadline := time.Now().Add(readyTimeout)
 	var lastErr error

--- a/internal/util/testinfra/ready.go
+++ b/internal/util/testinfra/ready.go
@@ -1,0 +1,61 @@
+package testinfra
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"time"
+)
+
+// readyTimeout bounds how long a service gets to start accepting connections.
+// Generous enough for a container that is still booting, short enough that a
+// service which is never coming back fails the run instead of hanging it.
+const readyTimeout = 30 * time.Second
+
+// waitReady blocks until probe succeeds, and panics if it has not succeeded
+// within readyTimeout.
+//
+// Services started by testcontainers are already gated by that library's wait
+// strategies. Services supplied through the environment — the compose stack
+// behind TESTINFRA=1 — are not: `docker compose up -d` returns once containers
+// are created, not once they accept connections, so a suite that connects
+// immediately can lose the race. Without this, that race surfaces inside a test
+// as a connection reset partway through, which reads as a flaky test rather
+// than as infrastructure that was not ready.
+func waitReady(name, endpoint string, probe func() error) {
+	deadline := time.Now().Add(readyTimeout)
+	var lastErr error
+	for {
+		if lastErr = probe(); lastErr == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			panic(fmt.Errorf("%s at %s not ready after %s: %w", name, endpoint, readyTimeout, lastErr))
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// waitReadyLogged is waitReady with a note when the service was not immediately
+// available, so a slow start is visible in test output rather than looking like
+// an unexplained pause.
+func waitReadyLogged(name, endpoint string, probe func() error) {
+	if probe() == nil {
+		return
+	}
+	log.Printf("waiting for %s at %s", name, endpoint)
+	start := time.Now()
+	waitReady(name, endpoint, probe)
+	log.Printf("%s ready after %s", name, time.Since(start).Round(time.Millisecond))
+}
+
+// dialTCP reports whether endpoint accepts TCP connections. It is the right
+// probe for a service whose readiness is "the port is open", and the wrong one
+// for anything that needs a protocol handshake to be meaningfully ready.
+func dialTCP(endpoint string) error {
+	conn, err := net.DialTimeout("tcp", endpoint, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}

--- a/internal/util/testinfra/redis.go
+++ b/internal/util/testinfra/redis.go
@@ -16,14 +16,14 @@ import (
 // Use this for tests that don't need RediSearch.
 // The container is terminated on cleanup.
 func NewRedisConfig(t *testing.T) *redis.RedisConfig {
-	return startRedisContainer(t, "redis/redis-stack-server:latest")
+	return startRedisContainer(t, ReadConfig().Images.Redis)
 }
 
 // NewRedisStackConfig spins up a dedicated Redis Stack container for tests requiring RediSearch.
 // Each test gets its own isolated container, eliminating cross-test interference.
 // The container is terminated on cleanup.
 func NewRedisStackConfig(t *testing.T) *redis.RedisConfig {
-	return startRedisContainer(t, "redis/redis-stack-server:latest")
+	return startRedisContainer(t, ReadConfig().Images.Redis)
 }
 
 // NewDragonflyConfig spins up a dedicated Dragonfly container for the test.
@@ -33,7 +33,7 @@ func NewDragonflyConfig(t *testing.T) *redis.RedisConfig {
 	ctx := context.Background()
 
 	req := testcontainers.ContainerRequest{
-		Image:        "docker.dragonflydb.io/dragonflydb/dragonfly:latest",
+		Image:        ReadConfig().Images.Dragonfly,
 		ExposedPorts: []string{"6379/tcp"},
 		Cmd:          []string{"--proactor_threads=1", "--maxmemory=256mb"},
 		WaitingFor:   wait.ForListeningPort("6379/tcp"),

--- a/internal/util/testinfra/testinfra.go
+++ b/internal/util/testinfra/testinfra.go
@@ -1,11 +1,11 @@
 package testinfra
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/hookdeck/outpost/internal/util/testutil"
@@ -13,10 +13,8 @@ import (
 )
 
 var (
-	suiteCounter int64
-	suiteCleanup sync.Once
-	cfgSync      sync.Once
-	cfg          *Config
+	cfgSync sync.Once
+	cfg     *Config
 )
 
 type Config struct {
@@ -30,7 +28,42 @@ type Config struct {
 	MockServerURL     string
 	GCPURL            string
 	AzureSBConnString string
-	cleanupFns        []func()
+	Images            Images
+}
+
+// Images holds the container images testcontainers starts when TESTINFRA is
+// unset. They are the same images build/test/compose.yml runs, read from the
+// same .env.test, so a test sees one environment either way.
+type Images struct {
+	Postgres   string
+	ClickHouse string
+	RabbitMQ   string
+	Kafka      string
+	LocalStack string
+	GCP        string
+	Redis      string
+	Dragonfly  string
+}
+
+func readImages(v *viper.Viper) Images {
+	return Images{
+		Postgres:   requireImage(v, "TEST_IMAGE_POSTGRES"),
+		ClickHouse: requireImage(v, "TEST_IMAGE_CLICKHOUSE"),
+		RabbitMQ:   requireImage(v, "TEST_IMAGE_RABBITMQ"),
+		Kafka:      requireImage(v, "TEST_IMAGE_KAFKA"),
+		LocalStack: requireImage(v, "TEST_IMAGE_LOCALSTACK"),
+		GCP:        requireImage(v, "TEST_IMAGE_GCP"),
+		Redis:      requireImage(v, "TEST_IMAGE_REDIS"),
+		Dragonfly:  requireImage(v, "TEST_IMAGE_DRAGONFLY"),
+	}
+}
+
+func requireImage(v *viper.Viper, key string) string {
+	image := v.GetString(key)
+	if image == "" {
+		panic(fmt.Errorf("%s is not set; add it to .env.test (see the repo copy for the current pins)", key))
+	}
+	return image
 }
 
 func initConfig() {
@@ -78,6 +111,7 @@ func initConfig() {
 			RabbitMQURL:       rabbitmqURL,
 			KafkaURL:          v.GetString("TEST_KAFKA_URL"),
 			MockServerURL:     mockServerURL,
+			Images:            readImages(v),
 		}
 		return
 	}
@@ -93,6 +127,7 @@ func initConfig() {
 		RabbitMQURL:       "",
 		KafkaURL:          "",
 		MockServerURL:     "",
+		Images:            readImages(v),
 	}
 }
 
@@ -101,23 +136,17 @@ func ReadConfig() *Config {
 	return cfg
 }
 
+// Start marks a suite as needing test infrastructure and returns the func to
+// defer at the end of it.
+//
+// The containers started for the TESTINFRA-unset path are shared by every suite
+// in a test binary and deliberately outlive all of them: they are torn down by
+// the testcontainers reaper when the process exits. Stopping them when a suite
+// finishes does not work, because the sync.Once guarding each container has
+// already fired — the next suite would reuse an endpoint with nothing behind it.
 func Start(t *testing.T) func() {
 	testutil.CheckIntegrationTest(t)
-	atomic.AddInt64(&suiteCounter, 1)
-	return func() {
-		if atomic.AddInt64(&suiteCounter, -1) == 0 {
-			suiteCleanup.Do(func() {
-				// Ensure cfg is initialized and not nil before accessing cleanupFns
-				if cfg != nil && cfg.cleanupFns != nil {
-					for _, fn := range cfg.cleanupFns {
-						if fn != nil {
-							fn()
-						}
-					}
-				}
-			})
-		}
-	}
+	return func() {}
 }
 
 func findProjectRoot() (string, error) {


### PR DESCRIPTION
Test-only changes. Four suites failed on state they did not create, or could not start at all.

## 1. S3 — parallel subtests shared a map

Subtests in `TestAWSS3Destination_Validate` all run `t.Parallel()` and share one `Config` map. The storage-class subtest wrote `INVALID` into it, which could fail the valid-destination case. Each subtest now gets its own map.

## 2. Kinesis — the consumer assumed deliver-once

A stream is an at-least-once log. `GetRecords` can return a record it already returned — seen against localstack with no error reported and the iterator advanced normally. Every test in a provider suite reads one channel, so a single redelivered record shifted every later read by one and each test then verified another test's event: a missing `message_id` panicked the concurrent tests, a stale event mismatched `event-id` in the sequential one.

- The consumer drops anything at or before the last sequence number it delivered.
- Each test gets its own stream and consumer instead of sharing one per suite.

## 3. Readiness — `Ensure*` returned endpoints unchecked

Neither `docker compose up -d` returning nor a wait strategy seeing an open port proves a service will complete a handshake, and both surface inside a test rather than at startup — seen as a RabbitMQ connection reset in `SetupSuite`, and as a Kafka SASL EOF.

Every `Ensure*` now waits up to 30s before the first test, speaking the protocol rather than dialing the port: authenticate to Kafka, connect to Postgres, query ClickHouse, AMQP dial for RabbitMQ, health endpoint for LocalStack.

## 4. Running without `TESTINFRA=1` was broken

Without `TESTINFRA=1` the tests start their own containers. That path had rotted — six of nine infrastructure-dependent packages failed before a single assertion. All four causes sit in code the `TESTINFRA=1` path never executes, so nothing surfaced them:

- **Floating image tags.** `localstack:latest` had become a licensed build that exits during startup; `postgres:latest` and `clickhouse:latest` had drifted past what the code assumes. Tags are now pinned in `.env.test`, which compose reads via `--env-file` and the tests read via viper, so both ways of providing infrastructure run the same versions. The compose stack was pinned only loosely (`:3`, `16-alpine`) with one floating tag; those are exact now too.
- **Kafka's host port** used a mapping syntax testcontainers has rejected since v0.42, so the package had been unrunnable across two dependency bumps. It now binds through `HostConfigModifier` on an OS-assigned port rather than a hardcoded `19092` that two test binaries would contend for.
- **Kafka's broker config** needs a JAAS file, and needs its controller listener on the address the image's quorum voters name. Without the latter it starts, fails to register with the quorum, and shuts down — after the port-listening wait strategy has already called it ready.
- **Shared containers were torn down mid-run.** They were terminated when the first suite in a binary finished, by which point the `sync.Once` guarding each had already fired, so every later suite in that binary connected to an endpoint with nothing behind it. They now live for the process; the testcontainers reaper removes them at exit.

Note for reviewers: `make up/test` and `make down/test` now pass `--env-file .env.test`. Running `docker-compose -f build/test/compose.yml up -d` directly fails with a message pointing at the Makefile, rather than silently substituting an empty image name.

## Verification

Kinesis suite, cold start (`docker compose restart test-aws` immediately before each run):

| | Failures |
|---|---|
| before | **10 / 20** |
| after | **0 / 20** |

Per-package, both paths:

| | before | after |
|---|---|---|
| no `TESTINFRA` | 3 / 9 | **15 / 15** |
| `TESTINFRA=1` | — | **16 / 16** (incl. `cmd/e2e`) |

S3 fix verified with `-count=20` and `-race`. `go vet ./...` and the `-short` suite CI runs are clean.

Not addressed: `mqinfra`'s `should_create_dlq_queue` waits for 6 SQS redeliveries inside a fixed 10s budget and fails under load on both paths (1 failure, then 3/3 clean). Pre-existing, and a property of the test's design rather than of the infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
