### PR TITLE
migrator: rename stale deliveries_* pkey indexes to attempts_*

### DIFF
--- a/internal/migrator/migrations/postgres/000010_rename_attempts_pkey.down.sql
+++ b/internal/migrator/migrations/postgres/000010_rename_attempts_pkey.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER INDEX IF EXISTS attempts_pkey RENAME TO deliveries_pkey;
+ALTER INDEX IF EXISTS attempts_default_pkey RENAME TO deliveries_default_pkey;
+
+COMMIT;

--- a/internal/migrator/migrations/postgres/000010_rename_attempts_pkey.up.sql
+++ b/internal/migrator/migrations/postgres/000010_rename_attempts_pkey.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- =============================================================================
+-- Migration: Rename the stale deliveries_* primary key indexes to attempts_*
+--
+-- 000005 renamed the deliveries tables to attempts, but Postgres does not
+-- rename dependent indexes and constraints on a table rename, so the primary
+-- key of attempts (and of its default partition) still carries the old name.
+--
+-- Indexes renamed:
+--   deliveries_pkey         -> attempts_pkey
+--   deliveries_default_pkey -> attempts_default_pkey
+-- =============================================================================
+
+ALTER INDEX IF EXISTS deliveries_pkey RENAME TO attempts_pkey;
+ALTER INDEX IF EXISTS deliveries_default_pkey RENAME TO attempts_default_pkey;
+
+COMMIT;


### PR DESCRIPTION
The `deliveries` -> `attempts` table rename in `000005_denormalize_attempts` did not carry the index names with it — Postgres does not rename dependent indexes/constraints on `ALTER TABLE ... RENAME`. Both the parent partitioned index (`deliveries_pkey`) and the default partition index (`deliveries_default_pkey`) are still stale on every Postgres install.

`ALTER INDEX ... RENAME` is catalog-only: it takes SHARE UPDATE EXCLUSIVE on the index, no lock on the table, and does not block concurrent DML. `pg_constraint.conname` follows automatically and the partition-index attachment is unaffected.

Refs hookdeck/outpost#1027 (the "unrelated finding" at the end; this does not address partition management).

🤖 Generated with [Claude Code](https://claude.com/claude-code)