### PR TITLE
Support custom dead-letter-queue names for self-provisioned SQS/RabbitMQ queues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,10 @@
 # GCP_PUBSUB_DELIVERY_SUBSCRIPTION="outpost-delivery-sub"
 # GCP_PUBSUB_LOG_TOPIC="outpost-log"
 # GCP_PUBSUB_LOG_SUBSCRIPTION="outpost-log-sub"
+# GCP_PUBSUB_DELIVERY_DLQ_TOPIC="outpost-delivery-dlq"
+# GCP_PUBSUB_DELIVERY_DLQ_SUBSCRIPTION="outpost-delivery-dlq-sub"
+# GCP_PUBSUB_LOG_DLQ_TOPIC="outpost-log-dlq"
+# GCP_PUBSUB_LOG_DLQ_SUBSCRIPTION="outpost-log-dlq-sub"
 
 ## Azure ServiceBus
 # AZURE_SERVICEBUS_TENANT_ID=""

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,8 @@
 # RABBITMQ_EXCHANGE="outpost"
 # RABBITMQ_DELIVERY_QUEUE="outpost-delivery"
 # RABBITMQ_LOG_QUEUE="outpost-log"
+# RABBITMQ_DELIVERY_DLQ="outpost-delivery.dlq"
+# RABBITMQ_LOG_DLQ="outpost-log.dlq"
 
 ## AWS SQS
 # AWS_SQS_ENDPOINT="http://aws:4566"
@@ -50,6 +52,8 @@
 # AWS_SQS_SECRET_ACCESS_KEY="test"
 # AWS_SQS_DELIVERY_QUEUE="outpost-delivery"
 # AWS_SQS_LOG_QUEUE="outpost-log"
+# AWS_SQS_DELIVERY_DLQ="outpost-delivery-dlq"
+# AWS_SQS_LOG_DLQ="outpost-log-dlq"
 
 ## GCP PubSub
 # GCP_PUBSUB_PROJECT="test"

--- a/docs/content/self-hosting/guides/byo-mqs.mdoc
+++ b/docs/content/self-hosting/guides/byo-mqs.mdoc
@@ -98,8 +98,8 @@ The following table shows the resources, default names, and configuration variab
 |----------|--------------------|-----------------|-----------------------|
 | Topic | `outpost-delivery` | `outpost-log` | `GCP_PUBSUB_DELIVERY_TOPIC` / `GCP_PUBSUB_LOG_TOPIC` |
 | Subscription | `outpost-delivery-sub` | `outpost-log-sub` | `GCP_PUBSUB_DELIVERY_SUBSCRIPTION` / `GCP_PUBSUB_LOG_SUBSCRIPTION` |
-| DLQ Topic | `outpost-delivery-dlq` | `outpost-log-dlq` | (auto-derived from topic name) |
-| DLQ Subscription | `outpost-delivery-dlq-sub` | `outpost-log-dlq-sub` | (auto-derived from topic name) |
+| DLQ Topic | `outpost-delivery-dlq` | `outpost-log-dlq` | `GCP_PUBSUB_DELIVERY_DLQ_TOPIC` / `GCP_PUBSUB_LOG_DLQ_TOPIC` (optional; defaults to `<topic>-dlq` if unset) |
+| DLQ Subscription | `outpost-delivery-dlq-sub` | `outpost-log-dlq-sub` | `GCP_PUBSUB_DELIVERY_DLQ_SUBSCRIPTION` / `GCP_PUBSUB_LOG_DLQ_SUBSCRIPTION` (optional; defaults to `<dlq-topic>-sub` if unset) |
 
 **Configuration requirements:**
 - Create both topic and subscription pairs

--- a/docs/content/self-hosting/guides/byo-mqs.mdoc
+++ b/docs/content/self-hosting/guides/byo-mqs.mdoc
@@ -71,7 +71,7 @@ The following table shows the resources, default names, and configuration variab
 |----------|--------------------|-----------------|-----------------------|
 | Exchange | `outpost` | `outpost` | `RABBITMQ_EXCHANGE` |
 | Queue | `outpost-delivery` | `outpost-log` | `RABBITMQ_DELIVERY_QUEUE` / `RABBITMQ_LOG_QUEUE` |
-| DLQ | `outpost-delivery.dlq` | `outpost-log.dlq` | (auto-derived from queue name) |
+| DLQ | `outpost-delivery.dlq` | `outpost-log.dlq` | `RABBITMQ_DELIVERY_DLQ` / `RABBITMQ_LOG_DLQ` (optional; defaults to `<queue>.dlq` if unset) |
 
 **Configuration requirements:**
 - Exchange type: `topic`
@@ -84,7 +84,7 @@ The following table shows the resources, default names, and configuration variab
 | Resource | Delivery MQ Default | Log MQ Default | Environment Variable |
 |----------|--------------------|-----------------|-----------------------|
 | Queue | `outpost-delivery` | `outpost-log` | `AWS_SQS_DELIVERY_QUEUE` / `AWS_SQS_LOG_QUEUE` |
-| DLQ | `outpost-delivery-dlq` | `outpost-log-dlq` | (auto-derived from queue name) |
+| DLQ | `outpost-delivery-dlq` | `outpost-log-dlq` | `AWS_SQS_DELIVERY_DLQ` / `AWS_SQS_LOG_DLQ` (optional; defaults to `<queue>-dlq` if unset) |
 
 **Configuration requirements:**
 - Configure `RedrivePolicy` on main queue pointing to DLQ

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -162,6 +162,8 @@ func (c *Config) getMQSpecificFields(mqType string) []zap.Field {
 			zap.String("rabbitmq_exchange", c.MQs.RabbitMQ.Exchange),
 			zap.String("rabbitmq_delivery_queue", c.MQs.RabbitMQ.DeliveryQueue),
 			zap.String("rabbitmq_log_queue", c.MQs.RabbitMQ.LogQueue),
+			zap.String("rabbitmq_delivery_dlq", c.MQs.RabbitMQ.getDLQName("deliverymq")),
+			zap.String("rabbitmq_log_dlq", c.MQs.RabbitMQ.getDLQName("logmq")),
 		}
 	case "awssqs":
 		return []zap.Field{
@@ -170,6 +172,8 @@ func (c *Config) getMQSpecificFields(mqType string) []zap.Field {
 			zap.String("aws_region", c.MQs.AWSSQS.Region),
 			zap.String("aws_delivery_queue", c.MQs.AWSSQS.DeliveryQueue),
 			zap.String("aws_log_queue", c.MQs.AWSSQS.LogQueue),
+			zap.String("aws_delivery_dlq", c.MQs.AWSSQS.getDLQName("deliverymq")),
+			zap.String("aws_log_dlq", c.MQs.AWSSQS.getDLQName("logmq")),
 		}
 	case "gcppubsub":
 		return []zap.Field{

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -183,6 +183,10 @@ func (c *Config) getMQSpecificFields(mqType string) []zap.Field {
 			zap.String("gcp_delivery_subscription", c.MQs.GCPPubSub.DeliverySubscription),
 			zap.String("gcp_log_topic", c.MQs.GCPPubSub.LogTopic),
 			zap.String("gcp_log_subscription", c.MQs.GCPPubSub.LogSubscription),
+			zap.String("gcp_delivery_dlq_topic", c.MQs.GCPPubSub.getDLQTopicByQueueType("deliverymq")),
+			zap.String("gcp_delivery_dlq_subscription", c.MQs.GCPPubSub.getDLQSubscriptionByQueueType("deliverymq")),
+			zap.String("gcp_log_dlq_topic", c.MQs.GCPPubSub.getDLQTopicByQueueType("logmq")),
+			zap.String("gcp_log_dlq_subscription", c.MQs.GCPPubSub.getDLQSubscriptionByQueueType("logmq")),
 		}
 	case "azureservicebus":
 		return []zap.Field{

--- a/internal/config/mqconfig_aws.go
+++ b/internal/config/mqconfig_aws.go
@@ -20,6 +20,8 @@ type AWSSQSConfig struct {
 	Endpoint        string `yaml:"endpoint" env:"AWS_SQS_ENDPOINT" desc:"Custom AWS SQS endpoint URL. Optional, typically used for local testing (e.g., LocalStack)." required:"N"`
 	DeliveryQueue   string `yaml:"delivery_queue" env:"AWS_SQS_DELIVERY_QUEUE" desc:"Name of the SQS queue for delivery events." required:"N"`
 	LogQueue        string `yaml:"log_queue" env:"AWS_SQS_LOG_QUEUE" desc:"Name of the SQS queue for log events." required:"N"`
+	DeliveryDLQ     string `yaml:"delivery_dlq" env:"AWS_SQS_DELIVERY_DLQ" desc:"Name of the dead-letter queue for the delivery queue. Optional; defaults to '<delivery_queue>-dlq' if unset." required:"N"`
+	LogDLQ          string `yaml:"log_dlq" env:"AWS_SQS_LOG_DLQ" desc:"Name of the dead-letter queue for the log queue. Optional; defaults to '<log_queue>-dlq' if unset." required:"N"`
 }
 
 func (c *AWSSQSConfig) getQueueName(queueType string) string {
@@ -28,6 +30,17 @@ func (c *AWSSQSConfig) getQueueName(queueType string) string {
 		return c.DeliveryQueue
 	case "logmq":
 		return c.LogQueue
+	default:
+		return ""
+	}
+}
+
+func (c *AWSSQSConfig) getDLQName(queueType string) string {
+	switch queueType {
+	case "deliverymq":
+		return c.DeliveryDLQ
+	case "logmq":
+		return c.LogDLQ
 	default:
 		return ""
 	}
@@ -44,6 +57,7 @@ func (c *AWSSQSConfig) ToInfraConfig(queueType string) *mqinfra.MQInfraConfig {
 			Region:                    c.Region,
 			ServiceAccountCredentials: c.getCredentials(),
 			Topic:                     c.getQueueName(queueType),
+			DLQ:                       c.getDLQName(queueType),
 		},
 	}
 }

--- a/internal/config/mqconfig_aws.go
+++ b/internal/config/mqconfig_aws.go
@@ -36,14 +36,22 @@ func (c *AWSSQSConfig) getQueueName(queueType string) string {
 }
 
 func (c *AWSSQSConfig) getDLQName(queueType string) string {
+	var dlq string
 	switch queueType {
 	case "deliverymq":
-		return c.DeliveryDLQ
+		dlq = c.DeliveryDLQ
 	case "logmq":
-		return c.LogDLQ
+		dlq = c.LogDLQ
 	default:
 		return ""
 	}
+	if dlq != "" {
+		return dlq
+	}
+	if queue := c.getQueueName(queueType); queue != "" {
+		return mqinfra.DefaultAWSSQSDLQName(queue)
+	}
+	return ""
 }
 
 func (c *AWSSQSConfig) getCredentials() string {

--- a/internal/config/mqconfig_aws_test.go
+++ b/internal/config/mqconfig_aws_test.go
@@ -46,6 +46,69 @@ func TestAWSSQSConfig_IsConfigured(t *testing.T) {
 	}
 }
 
+func TestAWSSQSConfig_DLQName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       config.AWSSQSConfig
+		queueType string
+		want      string
+	}{
+		{
+			name:      "delivery falls back to derived name",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1", DeliveryQueue: "outpost-delivery"},
+			queueType: "deliverymq",
+			want:      "outpost-delivery-dlq",
+		},
+		{
+			name:      "log falls back to derived name",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1", LogQueue: "outpost-log"},
+			queueType: "logmq",
+			want:      "outpost-log-dlq",
+		},
+		{
+			name:      "delivery override wins",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1", DeliveryQueue: "outpost-delivery", DeliveryDLQ: "dead_letter-outpost-delivery"},
+			queueType: "deliverymq",
+			want:      "dead_letter-outpost-delivery",
+		},
+		{
+			name:      "log override wins",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1", LogQueue: "outpost-log", LogDLQ: "dead_letter-outpost-log"},
+			queueType: "logmq",
+			want:      "dead_letter-outpost-log",
+		},
+		{
+			name:      "log override does not leak into delivery",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1", DeliveryQueue: "outpost-delivery", LogDLQ: "dead_letter-outpost-log"},
+			queueType: "deliverymq",
+			want:      "outpost-delivery-dlq",
+		},
+		{
+			name:      "no queue name yields no dlq name",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1"},
+			queueType: "deliverymq",
+			want:      "",
+		},
+		{
+			name:      "unknown queue type yields no dlq name",
+			cfg:       config.AWSSQSConfig{Region: "us-east-1", DeliveryQueue: "outpost-delivery"},
+			queueType: "somethingelse",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			infraCfg := tt.cfg.ToInfraConfig(tt.queueType)
+			require.NotNil(t, infraCfg.AWSSQS)
+			assert.Equal(t, tt.want, infraCfg.AWSSQS.DLQ)
+		})
+	}
+}
+
 func TestAWSSQSConfig_ToQueueConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/mqconfig_azure.go
+++ b/internal/config/mqconfig_azure.go
@@ -24,6 +24,9 @@ type AzureServiceBusConfig struct {
 	LogTopic             string `yaml:"log_topic" env:"AZURE_SERVICEBUS_LOG_TOPIC" desc:"Topic name for log queue" required:"N" default:"outpost-log"`
 	LogSubscription      string `yaml:"log_subscription" env:"AZURE_SERVICEBUS_LOG_SUBSCRIPTION" desc:"Subscription name for log queue" required:"N" default:"outpost-log-sub"`
 
+	// No DLQ name settings: Azure dead-letters into each subscription's built-in
+	// $DeadLetterQueue sub-queue, whose name is fixed by the platform.
+
 	// connectionStringOnce  sync.Once
 	// connectionString      string
 	// connectionStringError error

--- a/internal/config/mqconfig_gcp.go
+++ b/internal/config/mqconfig_gcp.go
@@ -15,6 +15,10 @@ type GCPPubSubConfig struct {
 	DeliverySubscription      string `yaml:"delivery_subscription" env:"GCP_PUBSUB_DELIVERY_SUBSCRIPTION" desc:"Name of the GCP Pub/Sub subscription for delivery events." required:"N"`
 	LogTopic                  string `yaml:"log_topic" env:"GCP_PUBSUB_LOG_TOPIC" desc:"Name of the GCP Pub/Sub topic for log events." required:"N"`
 	LogSubscription           string `yaml:"log_subscription" env:"GCP_PUBSUB_LOG_SUBSCRIPTION" desc:"Name of the GCP Pub/Sub subscription for log events." required:"N"`
+	DeliveryDLQTopic          string `yaml:"delivery_dlq_topic" env:"GCP_PUBSUB_DELIVERY_DLQ_TOPIC" desc:"Name of the GCP Pub/Sub dead-letter topic for delivery events. Optional; defaults to '<delivery_topic>-dlq' if unset." required:"N"`
+	DeliveryDLQSubscription   string `yaml:"delivery_dlq_subscription" env:"GCP_PUBSUB_DELIVERY_DLQ_SUBSCRIPTION" desc:"Name of the GCP Pub/Sub subscription on the delivery dead-letter topic. Optional; defaults to '<delivery_dlq_topic>-sub' if unset." required:"N"`
+	LogDLQTopic               string `yaml:"log_dlq_topic" env:"GCP_PUBSUB_LOG_DLQ_TOPIC" desc:"Name of the GCP Pub/Sub dead-letter topic for log events. Optional; defaults to '<log_topic>-dlq' if unset." required:"N"`
+	LogDLQSubscription        string `yaml:"log_dlq_subscription" env:"GCP_PUBSUB_LOG_DLQ_SUBSCRIPTION" desc:"Name of the GCP Pub/Sub subscription on the log dead-letter topic. Optional; defaults to '<log_dlq_topic>-sub' if unset." required:"N"`
 }
 
 func (c *GCPPubSubConfig) getTopicByQueueType(queueType string) string {
@@ -39,6 +43,44 @@ func (c *GCPPubSubConfig) getSubscriptionByQueueType(queueType string) string {
 	}
 }
 
+func (c *GCPPubSubConfig) getDLQTopicByQueueType(queueType string) string {
+	var dlqTopic string
+	switch queueType {
+	case "deliverymq":
+		dlqTopic = c.DeliveryDLQTopic
+	case "logmq":
+		dlqTopic = c.LogDLQTopic
+	default:
+		return ""
+	}
+	if dlqTopic != "" {
+		return dlqTopic
+	}
+	if topic := c.getTopicByQueueType(queueType); topic != "" {
+		return mqinfra.DefaultGCPPubSubDLQTopicName(topic)
+	}
+	return ""
+}
+
+func (c *GCPPubSubConfig) getDLQSubscriptionByQueueType(queueType string) string {
+	var dlqSub string
+	switch queueType {
+	case "deliverymq":
+		dlqSub = c.DeliveryDLQSubscription
+	case "logmq":
+		dlqSub = c.LogDLQSubscription
+	default:
+		return ""
+	}
+	if dlqSub != "" {
+		return dlqSub
+	}
+	if dlqTopic := c.getDLQTopicByQueueType(queueType); dlqTopic != "" {
+		return mqinfra.DefaultGCPPubSubDLQSubscriptionName(dlqTopic)
+	}
+	return ""
+}
+
 func (c *GCPPubSubConfig) ToInfraConfig(queueType string) *mqinfra.MQInfraConfig {
 	return &mqinfra.MQInfraConfig{
 		GCPPubSub: &mqinfra.GCPPubSubInfraConfig{
@@ -46,6 +88,8 @@ func (c *GCPPubSubConfig) ToInfraConfig(queueType string) *mqinfra.MQInfraConfig
 			ServiceAccountCredentials: c.ServiceAccountCredentials,
 			TopicID:                   c.getTopicByQueueType(queueType),
 			SubscriptionID:            c.getSubscriptionByQueueType(queueType),
+			DLQTopicID:                c.getDLQTopicByQueueType(queueType),
+			DLQSubscriptionID:         c.getDLQSubscriptionByQueueType(queueType),
 		},
 	}
 }

--- a/internal/config/mqconfig_gcp_test.go
+++ b/internal/config/mqconfig_gcp_test.go
@@ -1,0 +1,88 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPPubSubConfig_DLQNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       config.GCPPubSubConfig
+		queueType string
+		wantTopic string
+		wantSub   string
+	}{
+		{
+			name:      "delivery falls back to derived names",
+			cfg:       config.GCPPubSubConfig{Project: "p", DeliveryTopic: "outpost-delivery"},
+			queueType: "deliverymq",
+			wantTopic: "outpost-delivery-dlq",
+			wantSub:   "outpost-delivery-dlq-sub",
+		},
+		{
+			name:      "log falls back to derived names",
+			cfg:       config.GCPPubSubConfig{Project: "p", LogTopic: "outpost-log"},
+			queueType: "logmq",
+			wantTopic: "outpost-log-dlq",
+			wantSub:   "outpost-log-dlq-sub",
+		},
+		{
+			name:      "topic and subscription overrides both win",
+			cfg:       config.GCPPubSubConfig{Project: "p", DeliveryTopic: "outpost-delivery", DeliveryDLQTopic: "dead_letter-delivery", DeliveryDLQSubscription: "dead_letter-delivery-consumer"},
+			queueType: "deliverymq",
+			wantTopic: "dead_letter-delivery",
+			wantSub:   "dead_letter-delivery-consumer",
+		},
+		{
+			name:      "derived subscription follows an overridden dlq topic",
+			cfg:       config.GCPPubSubConfig{Project: "p", DeliveryTopic: "outpost-delivery", DeliveryDLQTopic: "dead_letter-delivery"},
+			queueType: "deliverymq",
+			wantTopic: "dead_letter-delivery",
+			wantSub:   "dead_letter-delivery-sub",
+		},
+		{
+			name:      "subscription override alone leaves topic derived",
+			cfg:       config.GCPPubSubConfig{Project: "p", DeliveryTopic: "outpost-delivery", DeliveryDLQSubscription: "dead_letter-delivery-consumer"},
+			queueType: "deliverymq",
+			wantTopic: "outpost-delivery-dlq",
+			wantSub:   "dead_letter-delivery-consumer",
+		},
+		{
+			name:      "log overrides do not leak into delivery",
+			cfg:       config.GCPPubSubConfig{Project: "p", DeliveryTopic: "outpost-delivery", LogDLQTopic: "dead_letter-log", LogDLQSubscription: "dead_letter-log-consumer"},
+			queueType: "deliverymq",
+			wantTopic: "outpost-delivery-dlq",
+			wantSub:   "outpost-delivery-dlq-sub",
+		},
+		{
+			name:      "no topic name yields no dlq names",
+			cfg:       config.GCPPubSubConfig{Project: "p"},
+			queueType: "deliverymq",
+			wantTopic: "",
+			wantSub:   "",
+		},
+		{
+			name:      "unknown queue type yields no dlq names",
+			cfg:       config.GCPPubSubConfig{Project: "p", DeliveryTopic: "outpost-delivery"},
+			queueType: "somethingelse",
+			wantTopic: "",
+			wantSub:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			infraCfg := tt.cfg.ToInfraConfig(tt.queueType)
+			require.NotNil(t, infraCfg.GCPPubSub)
+			assert.Equal(t, tt.wantTopic, infraCfg.GCPPubSub.DLQTopicID)
+			assert.Equal(t, tt.wantSub, infraCfg.GCPPubSub.DLQSubscriptionID)
+		})
+	}
+}

--- a/internal/config/mqconfig_rabbitmq.go
+++ b/internal/config/mqconfig_rabbitmq.go
@@ -13,6 +13,8 @@ type RabbitMQConfig struct {
 	Exchange      string `yaml:"exchange" env:"RABBITMQ_EXCHANGE" desc:"Name of the RabbitMQ exchange to use." required:"N"`
 	DeliveryQueue string `yaml:"delivery_queue" env:"RABBITMQ_DELIVERY_QUEUE" desc:"Name of the RabbitMQ queue for delivery events." required:"N"`
 	LogQueue      string `yaml:"log_queue" env:"RABBITMQ_LOG_QUEUE" desc:"Name of the RabbitMQ queue for log events." required:"N"`
+	DeliveryDLQ   string `yaml:"delivery_dlq" env:"RABBITMQ_DELIVERY_DLQ" desc:"Name of the dead-letter queue for the delivery queue. Optional; defaults to '<delivery_queue>.dlq' if unset." required:"N"`
+	LogDLQ        string `yaml:"log_dlq" env:"RABBITMQ_LOG_DLQ" desc:"Name of the dead-letter queue for the log queue. Optional; defaults to '<log_queue>.dlq' if unset." required:"N"`
 }
 
 func (c *RabbitMQConfig) getQueueName(queueType string) string {
@@ -26,12 +28,24 @@ func (c *RabbitMQConfig) getQueueName(queueType string) string {
 	}
 }
 
+func (c *RabbitMQConfig) getDLQName(queueType string) string {
+	switch queueType {
+	case "deliverymq":
+		return c.DeliveryDLQ
+	case "logmq":
+		return c.LogDLQ
+	default:
+		return ""
+	}
+}
+
 func (c *RabbitMQConfig) ToInfraConfig(queueType string) *mqinfra.MQInfraConfig {
 	return &mqinfra.MQInfraConfig{
 		RabbitMQ: &mqinfra.RabbitMQInfraConfig{
 			ServerURL: c.ServerURL,
 			Exchange:  c.Exchange,
 			Queue:     c.getQueueName(queueType),
+			DLQ:       c.getDLQName(queueType),
 		},
 	}
 }

--- a/internal/config/mqconfig_rabbitmq.go
+++ b/internal/config/mqconfig_rabbitmq.go
@@ -29,14 +29,22 @@ func (c *RabbitMQConfig) getQueueName(queueType string) string {
 }
 
 func (c *RabbitMQConfig) getDLQName(queueType string) string {
+	var dlq string
 	switch queueType {
 	case "deliverymq":
-		return c.DeliveryDLQ
+		dlq = c.DeliveryDLQ
 	case "logmq":
-		return c.LogDLQ
+		dlq = c.LogDLQ
 	default:
 		return ""
 	}
+	if dlq != "" {
+		return dlq
+	}
+	if queue := c.getQueueName(queueType); queue != "" {
+		return mqinfra.DefaultRabbitMQDLQName(queue)
+	}
+	return ""
 }
 
 func (c *RabbitMQConfig) ToInfraConfig(queueType string) *mqinfra.MQInfraConfig {

--- a/internal/config/mqconfig_rabbitmq_test.go
+++ b/internal/config/mqconfig_rabbitmq_test.go
@@ -1,0 +1,72 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRabbitMQConfig_DLQName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       config.RabbitMQConfig
+		queueType string
+		want      string
+	}{
+		{
+			name:      "delivery falls back to derived name",
+			cfg:       config.RabbitMQConfig{DeliveryQueue: "outpost-delivery"},
+			queueType: "deliverymq",
+			want:      "outpost-delivery.dlq",
+		},
+		{
+			name:      "log falls back to derived name",
+			cfg:       config.RabbitMQConfig{LogQueue: "outpost-log"},
+			queueType: "logmq",
+			want:      "outpost-log.dlq",
+		},
+		{
+			name:      "delivery override wins",
+			cfg:       config.RabbitMQConfig{DeliveryQueue: "outpost-delivery", DeliveryDLQ: "dead_letter-outpost-delivery"},
+			queueType: "deliverymq",
+			want:      "dead_letter-outpost-delivery",
+		},
+		{
+			name:      "log override wins",
+			cfg:       config.RabbitMQConfig{LogQueue: "outpost-log", LogDLQ: "dead_letter-outpost-log"},
+			queueType: "logmq",
+			want:      "dead_letter-outpost-log",
+		},
+		{
+			name:      "log override does not leak into delivery",
+			cfg:       config.RabbitMQConfig{DeliveryQueue: "outpost-delivery", LogDLQ: "dead_letter-outpost-log"},
+			queueType: "deliverymq",
+			want:      "outpost-delivery.dlq",
+		},
+		{
+			name:      "no queue name yields no dlq name",
+			cfg:       config.RabbitMQConfig{},
+			queueType: "deliverymq",
+			want:      "",
+		},
+		{
+			name:      "unknown queue type yields no dlq name",
+			cfg:       config.RabbitMQConfig{DeliveryQueue: "outpost-delivery"},
+			queueType: "somethingelse",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			infraCfg := tt.cfg.ToInfraConfig(tt.queueType)
+			require.NotNil(t, infraCfg.RabbitMQ)
+			assert.Equal(t, tt.want, infraCfg.RabbitMQ.DLQ)
+		})
+	}
+}

--- a/internal/mqinfra/awssqs.go
+++ b/internal/mqinfra/awssqs.go
@@ -15,11 +15,15 @@ type infraAWSSQS struct {
 	cfg *MQInfraConfig
 }
 
+func DefaultAWSSQSDLQName(topic string) string {
+	return topic + "-dlq"
+}
+
 func (infra *infraAWSSQS) dlqName() string {
 	if infra.cfg.AWSSQS.DLQ != "" {
 		return infra.cfg.AWSSQS.DLQ
 	}
-	return infra.cfg.AWSSQS.Topic + "-dlq"
+	return DefaultAWSSQSDLQName(infra.cfg.AWSSQS.Topic)
 }
 
 func (infra *infraAWSSQS) Exist(ctx context.Context) (bool, error) {

--- a/internal/mqinfra/awssqs.go
+++ b/internal/mqinfra/awssqs.go
@@ -15,6 +15,13 @@ type infraAWSSQS struct {
 	cfg *MQInfraConfig
 }
 
+func (infra *infraAWSSQS) dlqName() string {
+	if infra.cfg.AWSSQS.DLQ != "" {
+		return infra.cfg.AWSSQS.DLQ
+	}
+	return infra.cfg.AWSSQS.Topic + "-dlq"
+}
+
 func (infra *infraAWSSQS) Exist(ctx context.Context) (bool, error) {
 	if infra.cfg == nil || infra.cfg.AWSSQS == nil {
 		return false, errors.New("failed assertion: cfg.AWSSQS != nil") // IMPOSSIBLE
@@ -44,7 +51,7 @@ func (infra *infraAWSSQS) Exist(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	dlqName := infra.cfg.AWSSQS.Topic + "-dlq"
+	dlqName := infra.dlqName()
 	_, err = awsutil.RetrieveQueueURL(ctx, sqsClient, dlqName)
 	if err != nil {
 		var apiErr smithy.APIError
@@ -82,7 +89,7 @@ func (infra *infraAWSSQS) Declare(ctx context.Context) error {
 		attributes["VisibilityTimeout"] = fmt.Sprintf("%d", infra.cfg.Policy.VisibilityTimeout)
 	}
 
-	dlqName := infra.cfg.AWSSQS.Topic + "-dlq"
+	dlqName := infra.dlqName()
 	dlqURL, err := awsutil.EnsureQueue(ctx, sqsClient, dlqName, awsutil.MakeCreateQueue(attributes))
 	if err != nil {
 		return err
@@ -127,7 +134,7 @@ func (infra *infraAWSSQS) TearDown(ctx context.Context) error {
 		return err
 	}
 
-	dlqURL, err := awsutil.RetrieveQueueURL(ctx, sqsClient, infra.cfg.AWSSQS.Topic+"-dlq")
+	dlqURL, err := awsutil.RetrieveQueueURL(ctx, sqsClient, infra.dlqName())
 	if err != nil {
 		return err
 	}

--- a/internal/mqinfra/gcppubsub.go
+++ b/internal/mqinfra/gcppubsub.go
@@ -21,6 +21,28 @@ type infraGCPPubSub struct {
 	cfg *MQInfraConfig
 }
 
+func DefaultGCPPubSubDLQTopicName(topicID string) string {
+	return topicID + "-dlq"
+}
+
+func DefaultGCPPubSubDLQSubscriptionName(dlqTopicID string) string {
+	return dlqTopicID + "-sub"
+}
+
+func (infra *infraGCPPubSub) dlqTopicID() string {
+	if infra.cfg.GCPPubSub.DLQTopicID != "" {
+		return infra.cfg.GCPPubSub.DLQTopicID
+	}
+	return DefaultGCPPubSubDLQTopicName(infra.cfg.GCPPubSub.TopicID)
+}
+
+func (infra *infraGCPPubSub) dlqSubscriptionID() string {
+	if infra.cfg.GCPPubSub.DLQSubscriptionID != "" {
+		return infra.cfg.GCPPubSub.DLQSubscriptionID
+	}
+	return DefaultGCPPubSubDLQSubscriptionName(infra.dlqTopicID())
+}
+
 func (infra *infraGCPPubSub) Exist(ctx context.Context) (bool, error) {
 	if infra.cfg == nil || infra.cfg.GCPPubSub == nil {
 		return false, errors.New("failed assertion: cfg.GCPPubSub != nil") // IMPOSSIBLE
@@ -47,7 +69,7 @@ func (infra *infraGCPPubSub) Exist(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	dlqTopicID := topicID + "-dlq"
+	dlqTopicID := infra.dlqTopicID()
 	dlqTopic := client.Topic(dlqTopicID)
 	dlqTopicExists, err := dlqTopic.Exists(ctx)
 	if err != nil {
@@ -57,7 +79,7 @@ func (infra *infraGCPPubSub) Exist(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	dlqSubID := dlqTopicID + "-sub"
+	dlqSubID := infra.dlqSubscriptionID()
 	dlqSub := client.Subscription(dlqSubID)
 	dlqSubExists, err := dlqSub.Exists(ctx)
 	if err != nil {
@@ -115,7 +137,7 @@ func (infra *infraGCPPubSub) Declare(ctx context.Context) error {
 		}
 	}
 
-	dlqTopicID := topicID + "-dlq"
+	dlqTopicID := infra.dlqTopicID()
 	dlqTopic := client.Topic(dlqTopicID)
 	dlqTopicExists, err := dlqTopic.Exists(ctx)
 	if err != nil {
@@ -134,7 +156,7 @@ func (infra *infraGCPPubSub) Declare(ctx context.Context) error {
 		}
 	}
 
-	dlqSubID := dlqTopicID + "-sub"
+	dlqSubID := infra.dlqSubscriptionID()
 	dlqSub := client.Subscription(dlqSubID)
 	dlqSubExists, err := dlqSub.Exists(ctx)
 	if err != nil {
@@ -233,8 +255,8 @@ func (infra *infraGCPPubSub) TearDown(ctx context.Context) error {
 		}
 	}
 
-	dlqTopicID := infra.cfg.GCPPubSub.TopicID + "-dlq"
-	dlqSubID := dlqTopicID + "-sub"
+	dlqTopicID := infra.dlqTopicID()
+	dlqSubID := infra.dlqSubscriptionID()
 	dlqSub := client.Subscription(dlqSubID)
 	dlqSubExists, err := dlqSub.Exists(ctx)
 	if err != nil {

--- a/internal/mqinfra/mqinfra.go
+++ b/internal/mqinfra/mqinfra.go
@@ -30,6 +30,7 @@ type AWSSQSInfraConfig struct {
 	Region                    string
 	ServiceAccountCredentials string
 	Topic                     string
+	DLQ                       string // optional override; falls back to Topic+"-dlq" if empty
 }
 
 type AzureServiceBusInfraConfig struct {
@@ -58,6 +59,7 @@ type RabbitMQInfraConfig struct {
 	ServerURL string
 	Exchange  string
 	Queue     string
+	DLQ       string // optional override; falls back to Queue+".dlq" if empty
 }
 
 func New(cfg *MQInfraConfig) MQInfra {

--- a/internal/mqinfra/mqinfra.go
+++ b/internal/mqinfra/mqinfra.go
@@ -30,7 +30,7 @@ type AWSSQSInfraConfig struct {
 	Region                    string
 	ServiceAccountCredentials string
 	Topic                     string
-	DLQ                       string // optional override; falls back to Topic+"-dlq" if empty
+	DLQ                       string // optional
 }
 
 type AzureServiceBusInfraConfig struct {
@@ -59,7 +59,7 @@ type RabbitMQInfraConfig struct {
 	ServerURL string
 	Exchange  string
 	Queue     string
-	DLQ       string // optional override; falls back to Queue+".dlq" if empty
+	DLQ       string // optional
 }
 
 func New(cfg *MQInfraConfig) MQInfra {

--- a/internal/mqinfra/mqinfra.go
+++ b/internal/mqinfra/mqinfra.go
@@ -50,6 +50,8 @@ type GCPPubSubInfraConfig struct {
 	ProjectID                 string
 	TopicID                   string
 	SubscriptionID            string
+	DLQTopicID                string // optional
+	DLQSubscriptionID         string // optional
 	ServiceAccountCredentials string
 	MinRetryBackoff           int // seconds, for PubSub RetryPolicy (default: 10)
 	MaxRetryBackoff           int // seconds, for PubSub RetryPolicy (default: 600)

--- a/internal/mqinfra/mqinfra_test.go
+++ b/internal/mqinfra/mqinfra_test.go
@@ -518,6 +518,64 @@ func TestIntegrationMQInfra_GCPPubSub(t *testing.T) {
 	)
 }
 
+func TestIntegrationMQInfra_GCPPubSub_CustomDLQNames(t *testing.T) {
+	testutil.CheckIntegrationTest(t)
+	// Set PUBSUB_EMULATOR_HOST environment variable
+	testinfra.EnsureGCP()
+
+	topicID := "test-" + idgen.String()
+	subscriptionID := topicID + "-subscription"
+	customDLQTopic := "dead-letter-" + topicID
+	customDLQSub := customDLQTopic + "-consumer"
+
+	testMQInfra(t,
+		&Config{
+			infra: mqinfra.MQInfraConfig{
+				GCPPubSub: &mqinfra.GCPPubSubInfraConfig{
+					ProjectID:                 "test-project",
+					TopicID:                   topicID,
+					SubscriptionID:            subscriptionID,
+					DLQTopicID:                customDLQTopic,
+					DLQSubscriptionID:         customDLQSub,
+					ServiceAccountCredentials: "",
+					MinRetryBackoff:           1,
+					MaxRetryBackoff:           1,
+				},
+				Policy: mqinfra.Policy{
+					RetryLimit:        retryLimit,
+					VisibilityTimeout: 10,
+				},
+			},
+			mq: mqs.QueueConfig{
+				GCPPubSub: &mqs.GCPPubSubConfig{
+					ProjectID:                 "test-project",
+					TopicID:                   topicID,
+					SubscriptionID:            subscriptionID,
+					ServiceAccountCredentials: "",
+				},
+			},
+		},
+		&Config{
+			infra: mqinfra.MQInfraConfig{
+				GCPPubSub: &mqinfra.GCPPubSubInfraConfig{
+					ProjectID:                 "test-project",
+					TopicID:                   customDLQTopic,
+					SubscriptionID:            customDLQSub,
+					ServiceAccountCredentials: "",
+				},
+			},
+			mq: mqs.QueueConfig{
+				GCPPubSub: &mqs.GCPPubSubConfig{
+					ProjectID:                 "test-project",
+					TopicID:                   customDLQTopic,
+					SubscriptionID:            customDLQSub,
+					ServiceAccountCredentials: "",
+				},
+			},
+		},
+	)
+}
+
 func TestIntegrationMQInfra_AzureServiceBus(t *testing.T) {
 	t.Skip("skip TestIntegrationMQInfra_AzureServiceBus integration test for now since the emulator doesn't support managing resources")
 

--- a/internal/mqinfra/mqinfra_test.go
+++ b/internal/mqinfra/mqinfra_test.go
@@ -225,6 +225,52 @@ func TestIntegrationMQInfra_RabbitMQ(t *testing.T) {
 	)
 }
 
+func TestIntegrationMQInfra_RabbitMQ_CustomDLQName(t *testing.T) {
+	testutil.CheckIntegrationTest(t)
+	exchange := idgen.String()
+	queue := idgen.String()
+	customDLQ := "dead_letter-" + queue
+
+	testMQInfra(t,
+		&Config{
+			infra: mqinfra.MQInfraConfig{
+				RabbitMQ: &mqinfra.RabbitMQInfraConfig{
+					ServerURL: testinfra.EnsureRabbitMQ(),
+					Exchange:  exchange,
+					Queue:     queue,
+					DLQ:       customDLQ,
+				},
+				Policy: mqinfra.Policy{
+					RetryLimit: retryLimit,
+				},
+			},
+			mq: mqs.QueueConfig{
+				RabbitMQ: &mqs.RabbitMQConfig{
+					ServerURL: testinfra.EnsureRabbitMQ(),
+					Exchange:  exchange,
+					Queue:     queue,
+				},
+			},
+		},
+		&Config{
+			infra: mqinfra.MQInfraConfig{
+				RabbitMQ: &mqinfra.RabbitMQInfraConfig{
+					ServerURL: testinfra.EnsureRabbitMQ(),
+					Exchange:  exchange,
+					Queue:     customDLQ,
+				},
+			},
+			mq: mqs.QueueConfig{
+				RabbitMQ: &mqs.RabbitMQConfig{
+					ServerURL: testinfra.EnsureRabbitMQ(),
+					Exchange:  exchange,
+					Queue:     customDLQ,
+				},
+			},
+		},
+	)
+}
+
 func TestIntegrationMQInfra_AWSSQS(t *testing.T) {
 	testutil.CheckIntegrationTest(t)
 	q := idgen.String()
@@ -268,6 +314,58 @@ func TestIntegrationMQInfra_AWSSQS(t *testing.T) {
 					ServiceAccountCredentials: "test:test:",
 					Region:                    "us-east-1",
 					Topic:                     q + "-dlq",
+					WaitTime:                  1 * time.Second,
+				},
+			},
+		},
+	)
+}
+
+func TestIntegrationMQInfra_AWSSQS_CustomDLQName(t *testing.T) {
+	testutil.CheckIntegrationTest(t)
+	q := idgen.String()
+	customDLQ := "dead_letter-" + q
+
+	testMQInfra(t,
+		&Config{
+			infra: mqinfra.MQInfraConfig{
+				AWSSQS: &mqinfra.AWSSQSInfraConfig{
+					Endpoint:                  testinfra.EnsureLocalStack(),
+					ServiceAccountCredentials: "test:test:",
+					Region:                    "us-east-1",
+					Topic:                     q,
+					DLQ:                       customDLQ,
+				},
+				Policy: mqinfra.Policy{
+					RetryLimit:        retryLimit,
+					VisibilityTimeout: 1,
+				},
+			},
+			mq: mqs.QueueConfig{
+				AWSSQS: &mqs.AWSSQSConfig{
+					Endpoint:                  testinfra.EnsureLocalStack(),
+					ServiceAccountCredentials: "test:test:",
+					Region:                    "us-east-1",
+					Topic:                     q,
+					WaitTime:                  1 * time.Second,
+				},
+			},
+		},
+		&Config{
+			infra: mqinfra.MQInfraConfig{
+				AWSSQS: &mqinfra.AWSSQSInfraConfig{
+					Endpoint:                  testinfra.EnsureLocalStack(),
+					ServiceAccountCredentials: "test:test:",
+					Region:                    "us-east-1",
+					Topic:                     customDLQ,
+				},
+			},
+			mq: mqs.QueueConfig{
+				AWSSQS: &mqs.AWSSQSConfig{
+					Endpoint:                  testinfra.EnsureLocalStack(),
+					ServiceAccountCredentials: "test:test:",
+					Region:                    "us-east-1",
+					Topic:                     customDLQ,
 					WaitTime:                  1 * time.Second,
 				},
 			},

--- a/internal/mqinfra/rabbitmq.go
+++ b/internal/mqinfra/rabbitmq.go
@@ -11,11 +11,15 @@ type infraRabbitMQ struct {
 	cfg *MQInfraConfig
 }
 
+func DefaultRabbitMQDLQName(queue string) string {
+	return queue + ".dlq"
+}
+
 func (infra *infraRabbitMQ) dlqName() string {
 	if infra.cfg.RabbitMQ.DLQ != "" {
 		return infra.cfg.RabbitMQ.DLQ
 	}
-	return infra.cfg.RabbitMQ.Queue + ".dlq"
+	return DefaultRabbitMQDLQName(infra.cfg.RabbitMQ.Queue)
 }
 
 func (infra *infraRabbitMQ) Exist(ctx context.Context) (bool, error) {

--- a/internal/mqinfra/rabbitmq.go
+++ b/internal/mqinfra/rabbitmq.go
@@ -11,6 +11,13 @@ type infraRabbitMQ struct {
 	cfg *MQInfraConfig
 }
 
+func (infra *infraRabbitMQ) dlqName() string {
+	if infra.cfg.RabbitMQ.DLQ != "" {
+		return infra.cfg.RabbitMQ.DLQ
+	}
+	return infra.cfg.RabbitMQ.Queue + ".dlq"
+}
+
 func (infra *infraRabbitMQ) Exist(ctx context.Context) (bool, error) {
 	if infra.cfg == nil || infra.cfg.RabbitMQ == nil {
 		return false, errors.New("failed assertion: cfg.RabbitMQ != nil") // IMPOSSIBLE
@@ -27,7 +34,7 @@ func (infra *infraRabbitMQ) Exist(ctx context.Context) (bool, error) {
 	}
 	defer ch.Close()
 
-	dlq := infra.cfg.RabbitMQ.Queue + ".dlq"
+	dlq := infra.dlqName()
 
 	if err := ch.ExchangeDeclarePassive(
 		infra.cfg.RabbitMQ.Exchange, // name
@@ -94,7 +101,7 @@ func (infra *infraRabbitMQ) Declare(ctx context.Context) error {
 	}
 	defer ch.Close()
 
-	dlq := infra.cfg.RabbitMQ.Queue + ".dlq"
+	dlq := infra.dlqName()
 
 	if err := ch.ExchangeDeclare(
 		infra.cfg.RabbitMQ.Exchange, // name
@@ -173,7 +180,7 @@ func (infra *infraRabbitMQ) TearDown(ctx context.Context) error {
 	}
 	defer ch.Close()
 
-	dlq := infra.cfg.RabbitMQ.Queue + ".dlq"
+	dlq := infra.dlqName()
 
 	if _, err := ch.QueueDelete(
 		infra.cfg.RabbitMQ.Queue, // name


### PR DESCRIPTION
> Note: I haven't opened an issue for this first; happy to file one if that's preferred, or to close/rework this MR if you would rather take a different approach. Posting the implementation directly since it was small enough to just try out. Open to feedback, alternative designs if this direction makes sense.

**Why**
When Outpost self-provisions its internal delivery and log queues, it also auto-creates a DLQ for each, but the DLQ name is currently hardcoded as a derived suffix (`<queue>-dlq` for SQS, `<queue>.dlq` for RabbitMQ), with no way to override it.

If you're self-provisioning, it seems reasonable that you'd want to control the name of every resource Outpost creates, not just the main queues. Our organization has its own naming standard for dead-letter queues driven by infra/security policy (`dead_letter-<queue_name>`), which doesn't match what's assumed here, and we suspect other self-hosters run into the same kind of mismatch with their own conventions. Without an override, the only options are to fight the convention or build workarounds outside Outpost just to get provisioning to comply.

**Wanted to check**: is this something you'd be open to supporting, and if so, does this approach look right, or would you prefer a different shape (e.g. a full name-pattern/template instead of a fixed override, or a single shared suffix config instead of per-queue)?

**What changed**
Added optional config fields, symmetric to the existing `*_DELIVERY_QUEUE` / `*_LOG_QUEUE` settings, that let operators name each DLQ explicitly:
- `AWS_SQS_DELIVERY_DLQ` / `AWS_SQS_LOG_DLQ`
- `RABBITMQ_DELIVERY_DLQ` / `RABBITMQ_LOG_DLQ`

When unset, behavior is unchanged — Outpost falls back to the existing derived name (`<queue>-dlq` / `<queue>.dlq`), so this is purely additive and backward compatible.