### PR TITLE
fix(cli): print the error before exiting non-zero

### DIFF
--- a/cmd/outpost/main.go
+++ b/cmd/outpost/main.go
@@ -32,7 +32,11 @@ func main() {
 		},
 	}
 
+	// Print the error before exiting. Without this a failed `outpost migrate`
+	// — a bad config path, an unreachable database — reports nothing but a
+	// status of 1, during the one step an upgrade depends on.
 	if err := app.Run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
`cmd/outpost/main.go` discarded the error from `app.Run` and exited 1 with nothing on stderr.

The command that suffers most is `outpost migrate`. A mistyped config path, a malformed YAML field, or an unreachable database all surface the same way:

```
$ outpost migrate apply --yes -c ./upgrade.yaml
exit status 1
```

The actual cause was:

```
load config: error parsing yaml config: yaml: unmarshal errors:
  line 9: cannot unmarshal !!map into string
```

Found while smoke-testing the v1.1.0 → main upgrade path locally.

## Verification

| case | before | after |
|---|---|---|
| `migrate list -c /nope.yaml` | `exit status 1` | `Error: load config: error reading config file: open /nope.yaml: no such file or directory` |
| `migrate --help` | rc 0, no stderr | unchanged |
| no args | rc 0, no stderr | unchanged |
| `migrate --bogus` | help + rc 1 | help + `Error: flag provided but not defined: -bogus` |

urfave/cli does not print the error itself, so nothing double-prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
