### PR TITLE
chore: upgrade docker base image to debian13

### DIFF
--- a/build/Dockerfile.example
+++ b/build/Dockerfile.example
@@ -28,7 +28,7 @@ FROM busybox:1.36-musl AS busybox
 
 # Stage 2
 # Copy binaries to a new image
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/base-debian13:nonroot
 
 # Copy statically linked shell from busybox for entrypoint script
 COPY --from=busybox /bin/sh /bin/sh

--- a/build/Dockerfile.goreleaser
+++ b/build/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 FROM busybox:1.36-musl AS busybox
 
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/base-debian13:nonroot
 
 # Copy statically linked shell from busybox for entrypoint script
 COPY --from=busybox /bin/sh /bin/sh


### PR DESCRIPTION
debian12 has reached security end of life see https://endoflife.date/debian

so this is a simple PR to update the docker files to debian13
