### PR TITLE
docs: drop stale go generate step from config contributing guide

### DIFF
--- a/contributing/config.md
+++ b/contributing/config.md
@@ -112,7 +112,7 @@ When adding or modifying configuration fields, use this checklist:
 - [ ] **Sensitive fields are masked (showing only if configured, not actual value)**
 - [ ] MQ-specific fields added to `getMQSpecificFields()` (if applicable)
 - [ ] Validation added (if required)
-- [ ] Documentation regenerated with `go generate`
+- [ ] Field documented in `docs/content/self-hosting/configuration.mdoc`
 - [ ] Changes tested with `LOG_LEVEL=info` to verify logs appear correctly
 
 ## Why Configuration Logging Matters


### PR DESCRIPTION
The config contributing checklist still tells contributors to regenerate docs with `go generate`. There are no `go:generate` directives under `internal/config/`, so the command is a no-op, and the file it targeted (`docs/pages/references/configuration.mdx`) does not exist.

#1035 retired the generator and rewrote the guide's "6. Update Documentation" section to point at the curated page, but left this checklist item behind. Points it at the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)