### PR TITLE
feat(cli): add outpost config list command

### DIFF
--- a/cmd/outpost/config.go
+++ b/cmd/outpost/config.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hookdeck/outpost/internal/config"
+	"github.com/urfave/cli/v3"
+)
+
+// newConfigCommand builds the `outpost config` subcommand tree.
+func newConfigCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "config",
+		Usage: "Inspect the effective configuration",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "Path to config file",
+				Sources: cli.EnvVars("CONFIG"),
+			},
+		},
+		Commands: []*cli.Command{
+			{
+				Name:   "list",
+				Usage:  "Print the effective, resolved configuration with secrets masked",
+				Action: runConfigList,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			return cli.ShowSubcommandHelp(c)
+		},
+	}
+}
+
+func runConfigList(ctx context.Context, c *cli.Command) error {
+	flags := config.Flags{Config: c.String("config")}
+
+	// Load without validation: an operator reaching for `config list` is
+	// often trying to see why the server won't start (a missing required
+	// field), so failing validation must not also hide the resolved config.
+	cfg, err := config.LoadWithoutValidation(flags)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	// Reuse the same masked field set written to the startup logs, so the
+	// CLI output and the logs can never drift apart.
+	printConfigList(os.Stdout, cfg.LogConfigurationSummary())
+
+	if err := cfg.Validate(flags); err != nil {
+		fmt.Fprintf(os.Stderr, "\nWarning: config is invalid: %v\n", err)
+	}
+	return nil
+}

--- a/cmd/outpost/config_output.go
+++ b/cmd/outpost/config_output.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// printConfigList renders the output for `outpost config list`: one
+// "key  value" line per field, sorted by key for a stable, diffable output.
+func printConfigList(w io.Writer, fields []zap.Field) {
+	sorted := make([]zap.Field, len(fields))
+	copy(sorted, fields)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Key < sorted[j].Key })
+
+	maxKeyLen := 0
+	for _, f := range sorted {
+		if len(f.Key) > maxKeyLen {
+			maxKeyLen = len(f.Key)
+		}
+	}
+
+	for _, f := range sorted {
+		fmt.Fprintf(w, "%-*s  %s\n", maxKeyLen, f.Key, formatFieldValue(f))
+	}
+}
+
+// formatFieldValue renders a zap.Field's value as plain text. It covers the
+// field types LogConfigurationSummary actually produces — bool/string/int64
+// via zap.Bool/String/Int, plus zap.Strings/zap.Ints arrays. Anything else
+// falls back to fmt.Sprint on the boxed value, which is sufficient for
+// display purposes.
+func formatFieldValue(f zap.Field) string {
+	switch f.Type {
+	case zapcore.BoolType:
+		return strconv.FormatBool(f.Integer == 1)
+	case zapcore.StringType:
+		return f.String
+	case zapcore.Int64Type:
+		return strconv.FormatInt(f.Integer, 10)
+	default:
+		return fmt.Sprint(f.Interface)
+	}
+}

--- a/cmd/outpost/config_output_test.go
+++ b/cmd/outpost/config_output_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestFormatFieldValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		field zap.Field
+		want  string
+	}{
+		{"bool true", zap.Bool("k", true), "true"},
+		{"bool false", zap.Bool("k", false), "false"},
+		{"string", zap.String("k", "value"), "value"},
+		{"int", zap.Int("k", 42), "42"},
+		{"strings array", zap.Strings("k", []string{"a", "b"}), "[a b]"},
+		{"ints array", zap.Ints("k", []int{1, 2}), "[1 2]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatFieldValue(tt.field))
+		})
+	}
+}
+
+func TestPrintConfigList(t *testing.T) {
+	var buf bytes.Buffer
+	printConfigList(&buf, []zap.Field{
+		zap.String("service", "api"),
+		zap.Bool("api_key_configured", true),
+		zap.Int("api_port", 3333),
+	})
+
+	assert.Equal(t,
+		"api_key_configured  true\n"+
+			"api_port            3333\n"+
+			"service             api\n",
+		buf.String(),
+	)
+}

--- a/cmd/outpost/main.go
+++ b/cmd/outpost/main.go
@@ -25,6 +25,7 @@ func main() {
 				},
 			},
 			newMigrateCommand(),
+			newConfigCommand(),
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			// Default action - show help

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -392,6 +392,13 @@ func Parse(flags Flags) (*Config, error) {
 	return ParseWithOS(flags, defaultOS)
 }
 
+// LoadWithoutValidation parses config the same way Parse does, but skips
+// validation. It's for tools like `outpost config list` that want to show
+// the resolved configuration even when required fields are missing.
+func LoadWithoutValidation(flags Flags) (*Config, error) {
+	return ParseWithoutValidation(flags, defaultOS)
+}
+
 // ParseWithOS parses and validates config with a custom OS interface
 func ParseWithOS(flags Flags, osInterface OSInterface) (*Config, error) {
 	config, err := ParseWithoutValidation(flags, osInterface)


### PR DESCRIPTION
Adds `outpost config list` to print the effective, resolved config with secrets masked — useful for debugging why the server won't start, since it works  even when required fields are missing.
Closes #188