### PR TITLE
docs(config): document RETRY_POLL_BACKOFF_MS and log its resolved value

### DIFF
--- a/docs/content/self-hosting/configuration.mdoc
+++ b/docs/content/self-hosting/configuration.mdoc
@@ -73,6 +73,7 @@ Choose one for event log persistence:
 | `MAX_RETRY_LIMIT` | `10` | Max retry attempts before giving up |
 | `RETRY_INTERVAL_SECONDS` | `30` | Base interval for exponential backoff retries |
 | `RETRY_SCHEDULE` | — | Comma-separated retry delays in seconds (overrides interval/limit) |
+| `RETRY_POLL_BACKOFF_MS` | `0` (auto) | Maximum time the retry monitor sleeps between polls while idle. `0` sleeps until the next retry comes due, capped at the shorter of 30 seconds and your shortest configured retry delay, so a retry is never late. An explicit positive value is honored as a fixed maximum, which can delay a retry scheduled while the monitor is already sleeping by up to that much. |
 
 ## Topics
 

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -99,8 +99,7 @@ func (c *Config) LogConfigurationSummary() []zap.Field {
 		zap.Int("delivery_max_concurrency", c.DeliveryMaxConcurrency),
 		zap.Int("log_max_concurrency", c.LogMaxConcurrency),
 
-		// Delivery Retry. retry_poll_backoff_ms is the resolved value: with
-		// RETRY_POLL_BACKOFF_MS unset or 0 it is derived from the retry delays.
+		// Delivery Retry
 		zap.Ints("retry_schedule", c.RetrySchedule),
 		zap.Int("retry_interval_seconds", c.RetryIntervalSeconds),
 		zap.Int("retry_max_limit", c.RetryMaxLimit),

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -99,10 +99,12 @@ func (c *Config) LogConfigurationSummary() []zap.Field {
 		zap.Int("delivery_max_concurrency", c.DeliveryMaxConcurrency),
 		zap.Int("log_max_concurrency", c.LogMaxConcurrency),
 
-		// Delivery Retry
+		// Delivery Retry. retry_poll_backoff_ms is the resolved value: with
+		// RETRY_POLL_BACKOFF_MS unset or 0 it is derived from the retry delays.
 		zap.Ints("retry_schedule", c.RetrySchedule),
 		zap.Int("retry_interval_seconds", c.RetryIntervalSeconds),
 		zap.Int("retry_max_limit", c.RetryMaxLimit),
+		zap.Int("retry_poll_backoff_ms", int(c.GetRetryPollBackoff().Milliseconds())),
 
 		// Event Delivery
 		zap.Int("max_destinations_per_tenant", c.MaxDestinationsPerTenant),


### PR DESCRIPTION
#1026 redefined `RETRY_POLL_BACKOFF_MS`: a fixed poll interval defaulting to `100` became a maximum idle sleep defaulting to `0` (auto). The variable appears in neither the configuration reference nor the startup log, so an operator can't see what the retry monitor is actually using — and with `0`, the effective value is derived from the configured retry delays rather than being the literal setting.

- Adds the variable to the Delivery section of the configuration reference.
- Logs `retry_poll_backoff_ms` in the startup summary, as the resolved value from `GetRetryPollBackoff()`.

Verified the logged value resolves correctly: `30000` with defaults, `5000` with `RETRY_SCHEDULE=5,60`, and `250` when set explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)