### PR TITLE
fix(test): pin ClickHouse merges in the chlogstore dedup tests

### DIFF
--- a/internal/logstore/chlogstore/chlogstore_test.go
+++ b/internal/logstore/chlogstore/chlogstore_test.go
@@ -62,7 +62,8 @@ func setupClickHouseConnection(t *testing.T) clickhouse.DB {
 }
 
 // stopMerges disables background merges for one table in the calling test's
-// database.
+// database. Pass the logStore's own table field so the name cannot drift from
+// the one the code under test queries.
 //
 // ReplacingMergeTree collapses rows sharing the ORDER BY key whenever the
 // server decides to merge parts. Tests that assert on raw duplicate rows are
@@ -78,14 +79,14 @@ func stopMerges(t *testing.T, chDB clickhouse.DB, table string) {
 	var database string
 	require.NoError(t, chDB.QueryRow(ctx, "SELECT currentDatabase()").Scan(&database))
 
-	// SYSTEM STOP MERGES accepts a table that does not exist without error, so
-	// a wrong name here would silently leave merges running and hand back the
-	// flake it is meant to remove.
+	// SYSTEM STOP MERGES reports success for a table that does not exist, so an
+	// unmatched name would leave merges running and silently restore the race
+	// this call exists to remove.
 	var exists uint64
 	require.NoError(t, chDB.QueryRow(ctx,
 		"SELECT count() FROM system.tables WHERE database = ? AND name = ?",
 		database, table).Scan(&exists))
-	require.Equal(t, uint64(1), exists, "table %s.%s must exist before stopping merges", database, table)
+	require.Equal(t, uint64(1), exists, "no table %s.%s to stop merges on", database, table)
 
 	require.NoError(t, chDB.Exec(ctx, "SYSTEM STOP MERGES "+database+"."+table))
 }
@@ -185,14 +186,15 @@ func TestEventDedup(t *testing.T) {
 	chDB := setupClickHouseConnection(t)
 	defer chDB.Close()
 
+	// Concrete type so the test uses the same table names the code under test does.
+	logStore := NewLogStore(chDB, "").(*logStoreImpl)
+
 	// The injected legacy duplicates below reuse the originals' (event_time,
 	// event_id), so a background merge would collapse them and the raw row
 	// count would drop from 9 to 3. Production reads unmerged parts — that is
 	// why the read path dedups at all — so this test asserts on the unmerged
 	// state and holds merges off to keep it.
-	stopMerges(t, chDB, "events")
-
-	logStore := NewLogStore(chDB, "")
+	stopMerges(t, chDB, logStore.eventsTable)
 
 	tenantID := "dedup-tenant"
 	baseTime := time.Now().Truncate(time.Second)
@@ -321,11 +323,14 @@ func TestFetchAndDedupTruncation(t *testing.T) {
 	chDB := setupClickHouseConnection(t)
 	defer chDB.Close()
 
+	// Concrete type so the test uses the same table names the code under test does.
+	logStore := NewLogStore(chDB, "").(*logStoreImpl)
+
 	// evt-trunc-a is inserted twice at the same event_time, so a background
 	// merge would collapse it and the first batch would come back already
 	// deduplicated — the overshoot this test exists to cover would never
 	// happen and the assertion would pass without exercising anything.
-	stopMerges(t, chDB, "events")
+	stopMerges(t, chDB, logStore.eventsTable)
 
 	tenantID := "dedup-truncation"
 	baseTime := time.Now().Truncate(time.Second)
@@ -352,7 +357,7 @@ func TestFetchAndDedupTruncation(t *testing.T) {
 		Compare: "<",
 		SortDir: "desc",
 	}, func(qi pagination.QueryInput) (string, []any) {
-		return buildEventQuery("events", driver.ListEventRequest{
+		return buildEventQuery(logStore.eventsTable, driver.ListEventRequest{
 			TenantIDs:  []string{tenantID},
 			TimeFilter: driver.TimeFilter{GTE: &startTime},
 		}, qi)

--- a/internal/logstore/chlogstore/chlogstore_test.go
+++ b/internal/logstore/chlogstore/chlogstore_test.go
@@ -61,6 +61,35 @@ func setupClickHouseConnection(t *testing.T) clickhouse.DB {
 	return chDB
 }
 
+// stopMerges disables background merges for one table in the calling test's
+// database.
+//
+// ReplacingMergeTree collapses rows sharing the ORDER BY key whenever the
+// server decides to merge parts. Tests that assert on raw duplicate rows are
+// asserting on the pre-merge state, which the engine is otherwise free to
+// change at any moment. Qualifying the table name is what keeps this scoped:
+// bare `SYSTEM STOP MERGES` applies server-wide, and every test shares one
+// ClickHouse server. Each test has its own database (testinfra.NewClickHouseConfig),
+// which is dropped on cleanup, so the setting goes with it.
+func stopMerges(t *testing.T, chDB clickhouse.DB, table string) {
+	t.Helper()
+
+	ctx := context.Background()
+	var database string
+	require.NoError(t, chDB.QueryRow(ctx, "SELECT currentDatabase()").Scan(&database))
+
+	// SYSTEM STOP MERGES accepts a table that does not exist without error, so
+	// a wrong name here would silently leave merges running and hand back the
+	// flake it is meant to remove.
+	var exists uint64
+	require.NoError(t, chDB.QueryRow(ctx,
+		"SELECT count() FROM system.tables WHERE database = ? AND name = ?",
+		database, table).Scan(&exists))
+	require.Equal(t, uint64(1), exists, "table %s.%s must exist before stopping merges", database, table)
+
+	require.NoError(t, chDB.Exec(ctx, "SYSTEM STOP MERGES "+database+"."+table))
+}
+
 func newHarness(_ context.Context, t *testing.T) (drivertest.Harness, error) {
 	t.Helper()
 
@@ -155,6 +184,13 @@ func TestEventDedup(t *testing.T) {
 	ctx := context.Background()
 	chDB := setupClickHouseConnection(t)
 	defer chDB.Close()
+
+	// The injected legacy duplicates below reuse the originals' (event_time,
+	// event_id), so a background merge would collapse them and the raw row
+	// count would drop from 9 to 3. Production reads unmerged parts — that is
+	// why the read path dedups at all — so this test asserts on the unmerged
+	// state and holds merges off to keep it.
+	stopMerges(t, chDB, "events")
 
 	logStore := NewLogStore(chDB, "")
 
@@ -284,6 +320,12 @@ func TestFetchAndDedupTruncation(t *testing.T) {
 	ctx := context.Background()
 	chDB := setupClickHouseConnection(t)
 	defer chDB.Close()
+
+	// evt-trunc-a is inserted twice at the same event_time, so a background
+	// merge would collapse it and the first batch would come back already
+	// deduplicated — the overshoot this test exists to cover would never
+	// happen and the assertion would pass without exercising anything.
+	stopMerges(t, chDB, "events")
 
 	tenantID := "dedup-truncation"
 	baseTime := time.Now().Truncate(time.Second)

--- a/internal/logstore/chlogstore/chlogstore_test.go
+++ b/internal/logstore/chlogstore/chlogstore_test.go
@@ -61,17 +61,11 @@ func setupClickHouseConnection(t *testing.T) clickhouse.DB {
 	return chDB
 }
 
-// stopMerges disables background merges for one table in the calling test's
-// database. Pass the logStore's own table field so the name cannot drift from
-// the one the code under test queries.
+// stopMerges holds duplicate rows in place for tests that assert on them —
+// ReplacingMergeTree collapses rows sharing the ORDER BY key on merge.
 //
-// ReplacingMergeTree collapses rows sharing the ORDER BY key whenever the
-// server decides to merge parts. Tests that assert on raw duplicate rows are
-// asserting on the pre-merge state, which the engine is otherwise free to
-// change at any moment. Qualifying the table name is what keeps this scoped:
-// bare `SYSTEM STOP MERGES` applies server-wide, and every test shares one
-// ClickHouse server. Each test has its own database (testinfra.NewClickHouseConfig),
-// which is dropped on cleanup, so the setting goes with it.
+// The table must be qualified: bare SYSTEM STOP MERGES is server-wide, and every
+// test shares one ClickHouse server.
 func stopMerges(t *testing.T, chDB clickhouse.DB, table string) {
 	t.Helper()
 
@@ -79,9 +73,7 @@ func stopMerges(t *testing.T, chDB clickhouse.DB, table string) {
 	var database string
 	require.NoError(t, chDB.QueryRow(ctx, "SELECT currentDatabase()").Scan(&database))
 
-	// SYSTEM STOP MERGES reports success for a table that does not exist, so an
-	// unmatched name would leave merges running and silently restore the race
-	// this call exists to remove.
+	// SYSTEM STOP MERGES reports success for a table that does not exist.
 	var exists uint64
 	require.NoError(t, chDB.QueryRow(ctx,
 		"SELECT count() FROM system.tables WHERE database = ? AND name = ?",
@@ -186,14 +178,11 @@ func TestEventDedup(t *testing.T) {
 	chDB := setupClickHouseConnection(t)
 	defer chDB.Close()
 
-	// Concrete type so the test uses the same table names the code under test does.
+	// Concrete type: the test needs the same table name the queries use.
 	logStore := NewLogStore(chDB, "").(*logStoreImpl)
 
-	// The injected legacy duplicates below reuse the originals' (event_time,
-	// event_id), so a background merge would collapse them and the raw row
-	// count would drop from 9 to 3. Production reads unmerged parts — that is
-	// why the read path dedups at all — so this test asserts on the unmerged
-	// state and holds merges off to keep it.
+	// The injected duplicates below share (event_time, event_id) with the
+	// originals, so a merge would collapse the raw count from 9 to 3.
 	stopMerges(t, chDB, logStore.eventsTable)
 
 	tenantID := "dedup-tenant"
@@ -323,13 +312,11 @@ func TestFetchAndDedupTruncation(t *testing.T) {
 	chDB := setupClickHouseConnection(t)
 	defer chDB.Close()
 
-	// Concrete type so the test uses the same table names the code under test does.
+	// Concrete type: the test needs the same table name the queries use.
 	logStore := NewLogStore(chDB, "").(*logStoreImpl)
 
-	// evt-trunc-a is inserted twice at the same event_time, so a background
-	// merge would collapse it and the first batch would come back already
-	// deduplicated — the overshoot this test exists to cover would never
-	// happen and the assertion would pass without exercising anything.
+	// evt-trunc-a is inserted twice at one event_time; a merge would collapse it
+	// and the first batch would come back deduplicated, so no overshoot to catch.
 	stopMerges(t, chDB, logStore.eventsTable)
 
 	tenantID := "dedup-truncation"


### PR DESCRIPTION
`TestEventDedup` failed a full-suite run with `expected 0x9, got 0x3`, and passed on every retry in isolation.

## The case

The test asserts on the **unmerged** state: it injects six duplicate event rows, checks the raw count is 9, then checks `ListEvent` still returns 3. That's the state production reads — queries never use `FINAL`, which is why the read path dedups client-side at all.

`events` is a `ReplacingMergeTree` keyed on `(event_time, event_id)`, and the injected rows reuse the originals' values for both. During a full suite run the ClickHouse server is busy enough that it sometimes merges the parts before the test's `SELECT` lands, collapsing 9 rows to 3 and failing the assertion. Nothing in the test told it to hold off.

Fix: `SYSTEM STOP MERGES <database>.<table>` in the two tests that depend on unmerged rows.

Notes on the details:

- Qualifying the table is what keeps it scoped. Bare `SYSTEM STOP MERGES` is server-wide, and all tests share one ClickHouse server — that would break the conformance harness, whose `FlushWrites` calls `OPTIMIZE ... FINAL`. Each test already has its own `test_<random>` database, dropped on cleanup.
- `OPTIMIZE ... FINAL` is the wrong tool here. It forces the merged state, so the count becomes 3 and the read-path dedup never gets exercised.
- The table name comes from `logStoreImpl.eventsTable`, the same field the queries use, so it can't drift. `SYSTEM STOP MERGES` reports success for a table that doesn't exist, so there's also a `system.tables` check — otherwise a wrong name would silently restore the race.

`TestFetchAndDedupTruncation` has the same dependency and is pinned too. A merge there doesn't fail it — it makes the `LessOrEqual` assertion vacuous, so the overshoot path goes unexercised without any signal.

## Verification

- `chlogstore` package green, conformance included
- Both dedup tests `-count=10`, clean
- With merges stopped, an explicit `OPTIMIZE TABLE events FINAL` returns `code: 236, Cancelled merging parts` and the duplicates are still there — confirms it isn't a silent no-op

Test-only; production dedup behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
