### PR TITLE
test(logmq): fail fast when batcher.Shutdown deadlocks

### DIFF
--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -28,6 +28,16 @@ var ErrInvalidLogEntry = errors.New("invalid log entry: both event and attempt a
 // slower fails into the nack/redelivery path.
 const emitTimeout = 5 * time.Second
 
+// shutdownTimeout caps Shutdown so a stuck drain cannot hold the process open
+// indefinitely. It sits above the legitimate worst case — the final flush's
+// 30s insert plus one emitTimeout drain — so it only ever fires on a hang.
+//
+// The known hang is in batcher.Shutdown: it stops the ticker, then calls
+// processQueue, whose defer restarts it. If a tick lands between the
+// processingMutex acquisition and the send on its shutdown channel, the ticker
+// goroutine blocks on that mutex forever and the send never finds a receiver.
+const shutdownTimeout = 60 * time.Second
+
 // LogStore defines the interface for persisting log entries.
 // This is a consumer-defined interface containing only what logmq needs.
 type LogStore interface {
@@ -181,10 +191,26 @@ func (bp *BatchProcessor) Add(ctx context.Context, msg *mqs.Message) error {
 // the in-flight entries drain. Every dispatched message reaches a terminal
 // state before Shutdown returns, and the drain is bounded by emitTimeout.
 // Idempotent.
+//
+// Shutdown gives up after shutdownTimeout and returns, abandoning the drain
+// goroutine. Messages still in flight are never acked, so the broker
+// redelivers them. Losing the process to a stuck drain would strand them the
+// same way, with the process hanging until it is killed.
 func (bp *BatchProcessor) Shutdown() {
 	bp.shutdownOnce.Do(func() {
-		bp.batcher.Shutdown()
-		bp.inflight.Wait()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			bp.batcher.Shutdown()
+			bp.inflight.Wait()
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(shutdownTimeout):
+			bp.logger.Ctx(bp.ctx).Error("logmq batch processor shutdown timed out",
+				zap.Duration("timeout", shutdownTimeout))
+		}
 	})
 }
 

--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -28,16 +28,6 @@ var ErrInvalidLogEntry = errors.New("invalid log entry: both event and attempt a
 // slower fails into the nack/redelivery path.
 const emitTimeout = 5 * time.Second
 
-// shutdownTimeout caps Shutdown so a stuck drain cannot hold the process open
-// indefinitely. It sits above the legitimate worst case — the final flush's
-// 30s insert plus one emitTimeout drain — so it only ever fires on a hang.
-//
-// The known hang is in batcher.Shutdown: it stops the ticker, then calls
-// processQueue, whose defer restarts it. If a tick lands between the
-// processingMutex acquisition and the send on its shutdown channel, the ticker
-// goroutine blocks on that mutex forever and the send never finds a receiver.
-const shutdownTimeout = 60 * time.Second
-
 // LogStore defines the interface for persisting log entries.
 // This is a consumer-defined interface containing only what logmq needs.
 type LogStore interface {
@@ -191,26 +181,10 @@ func (bp *BatchProcessor) Add(ctx context.Context, msg *mqs.Message) error {
 // the in-flight entries drain. Every dispatched message reaches a terminal
 // state before Shutdown returns, and the drain is bounded by emitTimeout.
 // Idempotent.
-//
-// Shutdown gives up after shutdownTimeout and returns, abandoning the drain
-// goroutine. Messages still in flight are never acked, so the broker
-// redelivers them. Losing the process to a stuck drain would strand them the
-// same way, with the process hanging until it is killed.
 func (bp *BatchProcessor) Shutdown() {
 	bp.shutdownOnce.Do(func() {
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			bp.batcher.Shutdown()
-			bp.inflight.Wait()
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(shutdownTimeout):
-			bp.logger.Ctx(bp.ctx).Error("logmq batch processor shutdown timed out",
-				zap.Duration("timeout", shutdownTimeout))
-		}
+		bp.batcher.Shutdown()
+		bp.inflight.Wait()
 	})
 }
 

--- a/internal/logmq/batchprocessor_test.go
+++ b/internal/logmq/batchprocessor_test.go
@@ -88,7 +88,7 @@ func TestBatchProcessor_ValidEntry(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	event := testutil.EventFactory.Any()
 	attempt := testutil.AttemptFactory.Any()
@@ -122,7 +122,7 @@ func TestBatchProcessor_InvalidEntry_MissingEvent(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	attempt := testutil.AttemptFactory.Any()
 	entry := models.LogEntry{
@@ -155,7 +155,7 @@ func TestBatchProcessor_InvalidEntry_MissingAttempt(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	event := testutil.EventFactory.Any()
 	entry := models.LogEntry{
@@ -188,7 +188,7 @@ func TestBatchProcessor_InvalidEntry_DoesNotBlockBatch(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	// Create valid entry 1
 	event1 := testutil.EventFactory.Any()
@@ -244,7 +244,7 @@ func TestBatchProcessor_DuplicateMessages(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	// Two byte-identical copies of the same entry (redelivery / re-publish)
 	event := testutil.EventFactory.Any()
@@ -297,7 +297,7 @@ func TestBatchProcessor_MalformedJSON(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	mock, msg := newMockMessageFromBytes([]byte("not valid json"))
 	err = bp.Add(ctx, msg)
@@ -363,7 +363,7 @@ func TestBatchProcessor_AlertEvaluator_WithDestination(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	event := testutil.EventFactory.Any()
 	attempt := testutil.AttemptFactory.Any()
@@ -398,7 +398,7 @@ func TestBatchProcessor_AlertEvaluator_NilDestination(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	event := testutil.EventFactory.Any()
 	attempt := testutil.AttemptFactory.Any()
@@ -429,7 +429,7 @@ func TestBatchProcessor_AlertEvaluator_Error(t *testing.T) {
 		DelayThreshold:     1 * time.Second,
 	})
 	require.NoError(t, err)
-	defer bp.Shutdown()
+	defer shutdownBounded(t, bp)
 
 	event := testutil.EventFactory.Any()
 	attempt := testutil.AttemptFactory.Any()

--- a/internal/logmq/characterization_decoupling_test.go
+++ b/internal/logmq/characterization_decoupling_test.go
@@ -115,7 +115,7 @@ func TestCharacterization_ShutdownDrainsDeliveries(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		h.sink.release()
 	}()
-	h.bp.Shutdown()
+	shutdownBounded(t, h.bp)
 
 	// Shutdown returned → the delivery completed and acked.
 	cm.requireAcked(t)

--- a/internal/logmq/characterization_harness_test.go
+++ b/internal/logmq/characterization_harness_test.go
@@ -182,6 +182,34 @@ func (e *blockingEvaluator) release() {
 func (e *blockingEvaluator) blockedEvals() int32 { return e.blocked.Load() }
 func (e *blockingEvaluator) enteredEvals() int32 { return e.entered.Load() }
 
+// shutdownGrace bounds bp.Shutdown in tests. Nothing here legitimately takes
+// this long — the whole package runs in a few seconds.
+const shutdownGrace = 30 * time.Second
+
+// shutdownBounded calls bp.Shutdown and fails the test if it does not return
+// within shutdownGrace, instead of riding the 10m package timeout.
+//
+// batcher.Shutdown (mikestefanello/batcher@v0.1.0) can deadlock: it stops the
+// ticker, then calls processQueue, whose defer restarts it. A tick landing
+// between the processingMutex acquisition and the send on its shutdown channel
+// strands the ticker goroutine on that mutex, leaving the send with no
+// receiver. Rare, but it takes the whole package down with it when it happens.
+func shutdownBounded(t *testing.T, bp *logmq.BatchProcessor) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		bp.Shutdown()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(shutdownGrace):
+		t.Errorf("bp.Shutdown did not return within %s", shutdownGrace)
+	}
+}
+
 type disableRecord struct {
 	tenantID      string
 	destinationID string
@@ -411,7 +439,7 @@ func newHarness(t *testing.T, cfg harnessConfig) *harness {
 		EmitTimeout:        cfg.batcher.emitTimeout,
 	})
 	require.NoError(t, err)
-	t.Cleanup(bp.Shutdown)
+	t.Cleanup(func() { shutdownBounded(t, bp) })
 	// LIFO: releases run BEFORE bp.Shutdown, so a test that never released its
 	// blocked sends/evals can't deadlock the drain.
 	if sink.blockCh != nil {

--- a/internal/logmq/characterization_postprocess_test.go
+++ b/internal/logmq/characterization_postprocess_test.go
@@ -111,7 +111,7 @@ func TestCharacterization_ShutdownDrainsPostprocess(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		h.eval.release()
 	}()
-	h.bp.Shutdown()
+	shutdownBounded(t, h.bp)
 
 	// Shutdown returned → the eval ran, the alert delivered and the msg acked.
 	cm.requireAcked(t)


### PR DESCRIPTION
### TL;DR

`internal/logmq` hung for the full 10-minute test timeout once during a suite run, then passed on a rerun. The cause is a rare deadlock in our batching library's `Shutdown`, triggered by unlucky timing under load.

This PR **does not fix the deadlock** and does not change any production behavior. It only makes the tests give up after 30 seconds instead of 10 minutes, so if it ever happens again CI fails quickly and prints a useful stack trace instead of stalling the pipeline.

Test-only change. Nothing ships differently.

### Why not fix it properly

The bug is in `mikestefanello/batcher@v0.1.0`, not in our code. Production runs the same path on SIGTERM, but with a 10s batch interval the odds are somewhere around one in a hundred million shutdowns — not worth adding shutdown-behavior changes to defend against. If it ever did fire in production, the messages in flight are simply redelivered by the broker.

Replacing the dependency is the real fix and a reasonable follow-up: we use one group and one goroutine, so it's roughly 40 lines against the library's 150.

### The deadlock, for the record

```go
func (b *Batcher[T]) Shutdown() {
	b.ticker.Stop()
	b.processQueue()          // its defer calls ticker.Reset — ticker is live again
	b.processingMutex.Lock()  // taken, never released
	close(b.jobs)
	close(b.results)
	b.shutdown <- struct{}{}  // unbuffered; only tickerListener receives
	close(b.shutdown)
}
```

`processQueue` is written for the steady-state caller, so its deferred `ticker.Reset` undoes the `Stop` on the line above. If a tick lands after `processingMutex` is taken but before the send, `tickerListener` takes its tick branch, calls `processQueue`, and blocks on a mutex nobody will release. Nothing is left to receive the send, so `Shutdown` blocks too. Neither goroutine ever recovers, and there is no timeout anywhere.

The window is the two lines between the lock and the send. Scaling the deadlock rate against the ticker period puts it at roughly 15-50ns: 4.75% of shutdowns deadlock at a 1µs period, 0.15% at 10µs, none at 100µs and above. A scheduler stall widens it to however long the goroutine is parked there, which is why a loaded machine is where you would see it.

To be clear about what is proven: the mechanism is real and reproducible, but I did not capture a goroutine dump from the original hang, so this is consistent with what we saw rather than confirmed as its cause. The 30s bound gets us that dump next time.

### The change

`shutdownBounded` runs `bp.Shutdown` on its own goroutine and fails the test after 30s. Applied to all 12 shutdown sites in the package — the harness cleanup plus the direct calls. The package runs in a few seconds, so nothing legitimate is anywhere near the bound.