### PR TITLE
fix(logretention): wrap ClickHouse TTL column in toDateTime

### DIFF
--- a/internal/logretention/clickhouse_ttl.go
+++ b/internal/logretention/clickhouse_ttl.go
@@ -64,7 +64,7 @@ func (c *ClickHouseTTL) alterTableTTL(ctx context.Context, tableName, timeColumn
 	if ttlDays == 0 {
 		query = fmt.Sprintf("ALTER TABLE %s REMOVE TTL", tableName)
 	} else {
-		query = fmt.Sprintf("ALTER TABLE %s MODIFY TTL %s + INTERVAL %d DAY", tableName, timeColumn, ttlDays)
+		query = fmt.Sprintf("ALTER TABLE %s MODIFY TTL toDateTime(%s) + INTERVAL %d DAY", tableName, timeColumn, ttlDays)
 	}
 
 	return c.conn.Exec(ctx, query)

--- a/internal/logretention/clickhouse_ttl_test.go
+++ b/internal/logretention/clickhouse_ttl_test.go
@@ -48,8 +48,8 @@ func TestClickHouseTTL_ApplyTTL(t *testing.T) {
 			deploymentID: "",
 			ttlDays:      30,
 			wantQueries: []string{
-				"ALTER TABLE events MODIFY TTL event_time + INTERVAL 30 DAY",
-				"ALTER TABLE attempts MODIFY TTL attempt_time + INTERVAL 30 DAY",
+				"ALTER TABLE events MODIFY TTL toDateTime(event_time) + INTERVAL 30 DAY",
+				"ALTER TABLE attempts MODIFY TTL toDateTime(attempt_time) + INTERVAL 30 DAY",
 			},
 			wantQueryCount: 2,
 		},
@@ -58,8 +58,8 @@ func TestClickHouseTTL_ApplyTTL(t *testing.T) {
 			deploymentID: "dpm_001",
 			ttlDays:      7,
 			wantQueries: []string{
-				"ALTER TABLE dpm_001_events MODIFY TTL event_time + INTERVAL 7 DAY",
-				"ALTER TABLE dpm_001_attempts MODIFY TTL attempt_time + INTERVAL 7 DAY",
+				"ALTER TABLE dpm_001_events MODIFY TTL toDateTime(event_time) + INTERVAL 7 DAY",
+				"ALTER TABLE dpm_001_attempts MODIFY TTL toDateTime(attempt_time) + INTERVAL 7 DAY",
 			},
 			wantQueryCount: 2,
 		},


### PR DESCRIPTION
`CLICKHOUSE_LOG_RETENTION_TTL_DAYS=30` crash-loops the service at startup on ClickHouse older than 25.7:

```
failed to alter TTL on events table: code: 450, message: TTL expression result column should have DateTime or Date type, but has DateTime64(3)
exit status 1
```

`event_time`/`attempt_time` are `DateTime64(3)`, so `MODIFY TTL event_time + INTERVAL n DAY` yields `DateTime64`. ClickHouse only started accepting that in 25.7 ([ClickHouse#80710](https://github.com/ClickHouse/ClickHouse/pull/80710)) — 24.8 LTS through 25.6 reject it, including 25.3 LTS.

Fix: `MODIFY TTL toDateTime(event_time) + INTERVAL n DAY`. Works on every version, same daily-granularity expiry. Servers that already applied the old TTL get re-altered on next boot.

Verified booting on `clickhouse/clickhouse-server:24-alpine` (the pin in `build/dev/deps/compose.yml`) with the TTL set; `go test -short ./...` passes.
