### PR TITLE
chore(release): pin GoReleaser and migrate off deprecated config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      # https://goreleaser.com/customization/docker_manifest/
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Code checkout
         uses: actions/checkout@v5
@@ -40,9 +37,12 @@ jobs:
         with:
           go-version: 1.26.5
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          # Pinned deliberately: an unpinned "latest" means every tag push builds
+          # with whatever GoReleaser shipped that morning, and a breaking change
+          # surfaces mid-release, after the tag exists.
+          version: "v2.17.1"
           args: release -f build/.goreleaser.yaml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/.goreleaser.yaml
+++ b/build/.goreleaser.yaml
@@ -104,12 +104,8 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
-    # Keep the published manifest to just the two platform entries, matching what
-    # the dockers/docker_manifests setup produced. Attestations are published as
-    # extra manifest entries that show up as "unknown/unknown" platforms on Docker
-    # Hub, and both sources have to be turned off: sbom drops --attest=type=sbom,
-    # and --provenance=false overrides buildx's default of attaching provenance
-    # whenever it pushes. GoReleaser never passes --provenance itself.
+    # No attestations, so the manifest keeps the same two platform entries as
+    # today. Takes both switches — buildx adds provenance on its own.
     sbom: false
     flags:
       - "--pull"

--- a/build/.goreleaser.yaml
+++ b/build/.goreleaser.yaml
@@ -104,11 +104,16 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
-    # Keep the published manifest to just the two platforms. Enabling SBOM adds
-    # attestation entries that surface as "unknown/unknown" platforms on Docker Hub.
+    # Keep the published manifest to just the two platform entries, matching what
+    # the dockers/docker_manifests setup produced. Attestations are published as
+    # extra manifest entries that show up as "unknown/unknown" platforms on Docker
+    # Hub, and both sources have to be turned off: sbom drops --attest=type=sbom,
+    # and --provenance=false overrides buildx's default of attaching provenance
+    # whenever it pushes. GoReleaser never passes --provenance itself.
     sbom: false
     flags:
       - "--pull"
+      - "--provenance=false"
     labels:
       org.opencontainers.image.created: "{{ .Date }}"
       org.opencontainers.image.name: "{{ .ProjectName }}"

--- a/build/.goreleaser.yaml
+++ b/build/.goreleaser.yaml
@@ -70,7 +70,7 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -79,10 +79,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
 
 changelog:
   sort: asc
@@ -91,53 +87,32 @@ changelog:
       - "^docs:"
       - "^test:"
 
-dockers:
-  - goos: linux
-    goarch: amd64
+dockers_v2:
+  - images:
+      - "hookdeck/outpost"
+    tags:
+      - "{{ .Tag }}"
+      - "latest"
     dockerfile: ./build/Dockerfile.goreleaser
     ids:
       - outpost
-      - outpost-server
-    extra_files:
-      - build/entrypoint.sh
-    image_templates:
-      - "hookdeck/outpost:latest-amd64"
-      - "hookdeck/outpost:{{ .Tag }}-amd64"
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=repository=https://github.com/hookdeck/outpost"
-      - "--label=homepage=https://hookdeck.com"
-      - "--platform=linux/amd64"
-  - goos: linux
-    goarch: arm64
-    dockerfile: ./build/Dockerfile.goreleaser
-    ids:
       - outpost-arm64
+      - outpost-server
       - outpost-server-arm64
     extra_files:
       - build/entrypoint.sh
-    image_templates:
-      - "hookdeck/outpost:latest-arm64"
-      - "hookdeck/outpost:{{ .Tag }}-arm64"
-    build_flag_templates:
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    # Keep the published manifest to just the two platforms. Enabling SBOM adds
+    # attestation entries that surface as "unknown/unknown" platforms on Docker Hub.
+    sbom: false
+    flags:
       - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=repository=https://github.com/hookdeck/outpost"
-      - "--label=homepage=https://hookdeck.com"
-      - "--platform=linux/arm64/v8"
-docker_manifests:
-  - name_template: "hookdeck/outpost:latest"
-    image_templates:
-      - "hookdeck/outpost:latest-amd64"
-      - "hookdeck/outpost:latest-arm64"
-  - name_template: "hookdeck/outpost:{{ .Tag }}"
-    image_templates:
-      - "hookdeck/outpost:{{ .Tag }}-amd64"
-      - "hookdeck/outpost:{{ .Tag }}-arm64"
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.name: "{{ .ProjectName }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      repository: "https://github.com/hookdeck/outpost"
+      homepage: "https://hookdeck.com"

--- a/build/Dockerfile.goreleaser
+++ b/build/Dockerfile.goreleaser
@@ -5,9 +5,11 @@ FROM gcr.io/distroless/base-debian13:nonroot
 # Copy statically linked shell from busybox for entrypoint script
 COPY --from=busybox /bin/sh /bin/sh
 
-# Copy all binaries
-COPY outpost /usr/local/bin/outpost
-COPY outpost-server /usr/local/bin/outpost-server
+# Copy all binaries. GoReleaser stages each platform's artifacts under
+# $TARGETPLATFORM/ in the build context, since one buildx build covers both arches.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/outpost /usr/local/bin/outpost
+COPY $TARGETPLATFORM/outpost-server /usr/local/bin/outpost-server
 
 # Copy entrypoint script
 COPY build/entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## TL;DR

The release workflow downloaded a different GoReleaser on every tag push, and our config used three things GoReleaser has deprecated. Neither has broken a release yet, but both would break one without warning — and the only place that failure can surface is a tag push, after the tag exists.

This pins the version and clears all three deprecations. Nothing about the published release changes: same archives, same image name, same two-platform manifest.

## What was wrong

`release.yml` ran `goreleaser-action@v4` with `version: latest`. v1.2.0 built with GoReleaser 2.17.1 — not because we chose it, but because that's what was newest that morning. Meanwhile `goreleaser check` exited non-zero on three deprecated properties. Put together: the day GoReleaser removes one of them, a release fails mid-flight.

## Changes

**Pin the version.** `version: "v2.17.1"` — the version v1.2.0 actually released with, so this is a no-op for the next release. Action bumped `v4` → `v6`.

**`archives.format` → `formats`.** Also deletes the windows→zip `format_overrides`, which was dead code: `builds` are `goos: [linux]` only, so a windows override could never fire.

**`dockers` + `docker_manifests` → `dockers_v2`.** The bigger one. GoReleaser now does a single `buildx` build across both platforms and pushes the manifest in one step, instead of building per-arch images and stitching a manifest afterward. Two consequences:

- The build context stages each platform's artifacts under `$TARGETPLATFORM/`, so `Dockerfile.goreleaser` copies from `$TARGETPLATFORM/outpost` rather than `outpost`.
- `dockers_v2` attaches SBOM and provenance attestations by default. This PR turns both off (`sbom: false` plus `--provenance=false`, since GoReleaser never passes `--provenance` and buildx attaches it whenever it pushes) so the published manifest stays exactly the two platform entries it has today. That keeps this PR to "the release still works," with no change to the artifact. #1046 turns them on deliberately.

`DOCKER_CLI_EXPERIMENTAL` dropped, only the old `docker_manifests` path needed it. The existing QEMU and Buildx setup steps are still required.

## Verification

`goreleaser check` is clean (exit 0, no deprecations) on 2.17.1.

`goreleaser release --snapshot --clean` completes and produces:

- archives at the same names as today — `outpost_Linux_x86_64.tar.gz`, `outpost_Linux_arm64.tar.gz`
- both images, `arch=amd64` / `arch=arm64` confirmed via `docker image inspect`
- `outpost --version` runs in each and reports the right version, so the ldflags still apply
- `outpost`, `outpost-server`, `entrypoint.sh`, `/bin/sh` all present, entrypoint unchanged

**Not verified locally:** the manifest push. `dockers_v2` can't produce a multi-arch manifest without pushing, so snapshot mode builds platform-suffixed images instead. Worth a throwaway sha tag to a personal namespace before this merges, to confirm the pushed manifest lists exactly `linux/amd64` and `linux/arm64` — matching what `hookdeck/outpost:v1.2.0` looks like today.
