### PR TITLE
chore(release): publish signed images with SBOM and provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Declaring permissions replaces the defaults entirely, so contents: write
+    # has to be listed for the GitHub release. id-token: write mints the OIDC
+    # token cosign exchanges for a short-lived signing certificate.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Code checkout
         uses: actions/checkout@v5
@@ -36,6 +42,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.26.5
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	@echo "Binaries built in ./bin/"
 
 build/goreleaser:
-	goreleaser release -f ./build/.goreleaser.yaml --snapshot --clean
+	goreleaser release -f ./build/.goreleaser.yaml --snapshot --clean --skip=sign
 
 build/outpost:
 	go build -tags nomsgpack -o bin/outpost ./cmd/outpost
@@ -144,7 +144,7 @@ logs:
 # Use docker/push to push to Docker Hub: DOCKER_USER=<your-username> make docker/push TAG=v0.13.3-beta
 docker/build:
 	@if [ -z "$(TAG)" ]; then echo "Usage: make docker/build TAG=v0.13.3-beta"; exit 1; fi
-	GORELEASER_CURRENT_TAG=$(TAG) goreleaser release -f ./build/.goreleaser.yaml --snapshot --clean
+	GORELEASER_CURRENT_TAG=$(TAG) goreleaser release -f ./build/.goreleaser.yaml --snapshot --clean --skip=sign
 
 # Tag and push image to Docker Hub under DOCKER_USER (e.g. make docker/push DOCKER_USER=alexbouchard TAG=v0.13.3-beta).
 # Requires: docker login first.

--- a/build/.goreleaser.yaml
+++ b/build/.goreleaser.yaml
@@ -112,12 +112,14 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
-    # No attestations, so the manifest keeps the same two platform entries as
-    # today. Takes both switches — buildx adds provenance on its own.
-    sbom: false
+    # Publish SBOM and provenance attestations. Both are on by default here:
+    # sbom: true adds --attest=type=sbom, and buildx attaches provenance itself
+    # whenever it pushes. They ride along as extra manifest entries reported as
+    # "unknown/unknown" platforms, which is how attestations are always carried —
+    # Docker Hub's UI filters them out of the tag listing.
+    sbom: true
     flags:
       - "--pull"
-      - "--provenance=false"
     labels:
       org.opencontainers.image.created: "{{ .Date }}"
       org.opencontainers.image.name: "{{ .ProjectName }}"
@@ -125,3 +127,11 @@ dockers_v2:
       org.opencontainers.image.version: "{{ .Version }}"
       repository: "https://github.com/hookdeck/outpost"
       homepage: "https://hookdeck.com"
+
+# Sign published images with cosign, keyless via the workflow's OIDC token. The
+# default args sign with a local cosign.key; dropping --key is what selects
+# keyless. Runs in the publish phase, so --snapshot builds never reach it and
+# local builds need neither cosign nor credentials.
+docker_signs:
+  - artifacts: images
+    args: ["sign", "${artifact}@${digest}", "--yes"]

--- a/build/.goreleaser.yaml
+++ b/build/.goreleaser.yaml
@@ -128,10 +128,17 @@ dockers_v2:
       repository: "https://github.com/hookdeck/outpost"
       homepage: "https://hookdeck.com"
 
-# Sign published images with cosign, keyless via the workflow's OIDC token. The
-# default args sign with a local cosign.key; dropping --key is what selects
-# keyless. Runs in the publish phase, so --snapshot builds never reach it and
-# local builds need neither cosign nor credentials.
+# Signs checksums.txt, which covers every archive transitively. This one runs
+# before publish, so local snapshot builds pass --skip=sign to avoid needing
+# cosign installed.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    artifacts: checksum
+    args: ["sign-blob", "--bundle=${signature}", "${artifact}", "--yes"]
+
+# Keyless cosign signing via the workflow's OIDC token. Omitting --key is what
+# selects keyless; publish-phase only, so --snapshot never invokes cosign.
 docker_signs:
   - artifacts: images
     args: ["sign", "${artifact}@${digest}", "--yes"]


### PR DESCRIPTION
> Stacked on #1045 — merge that one first.

## What this does

Every released image gets an SBOM (what packages are inside it) and provenance (which workflow built it, from which commit), both signed by the release workflow.

Signing releases and publishing SBOMs has become standard practice in open source. GitHub ships [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) as a built-in feature, [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md) scores projects on whether their releases are signed, and Docker Official Images (nginx, postgres, python) all publish the same attestations today. The signing uses [Sigstore](https://www.sigstore.dev/)/cosign, a CNCF project, with no key to manage — identity comes from the workflow's OIDC token.

Nothing changes for anyone pulling or running the image, and GoReleaser supports all of it directly, so adopting it here is a few lines of config.

## Why it matters

Anyone can confirm an image genuinely came from this repo:

```bash
cosign verify hookdeck/outpost:v1.2.1 \
  --certificate-identity-regexp '^https://github.com/hookdeck/outpost/\.github/workflows/release\.yml@refs/tags/v' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

The signature is tied to this repo, this workflow file, and a version tag, so an image pushed by anything else fails the check — including one pushed with a stolen Docker Hub credential. Anyone who wants to enforce that can run it as a deploy gate, or as a Kubernetes admission policy.

The SBOM is the more day-to-day one: scanners like Docker Scout, Trivy and grype read it straight from the registry. "Which released versions contain this vulnerable Go module?" becomes a registry query instead of pulling and rebuilding every tag.

The tarballs on the GitHub release are covered too — `checksums.txt` is signed, so verifying it verifies every archive listed in it. That's also the form supply-chain tooling looks for: OpenSSF Scorecard's Signed-Releases check inspects release assets, and doesn't see container signatures.

## Changes

- `sbom: true` — buildx attaches provenance on its own
- `docker_signs` and `signs` using cosign, keyless (no key to manage or rotate)
- `id-token: write` on the release job, which is what lets cosign get a signing certificate
- the two Makefile targets that build snapshots locally pass `--skip=sign`, so local builds don't need cosign installed

## References

- [Docker — Build attestations](https://docs.docker.com/build/metadata/attestations/)
- [GoReleaser — docker_signs](https://goreleaser.com/customization/sign/docker_sign/)
