### PR TITLE
fix: SIGTERM never reached the server; exec outpost-server instead of spawning it

### DIFF
--- a/cmd/outpost/exec_unix.go
+++ b/cmd/outpost/exec_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// execBinary replaces the current process with the target binary rather than
+// running it as a child. Spawning would keep this process, and its Go runtime,
+// resident for the lifetime of the server. It also makes signals reach the
+// server directly instead of being delivered to a wrapper that ignores them.
+func execBinary(binary string, args []string) error {
+	return syscall.Exec(binary, append([]string{binary}, args...), os.Environ())
+}

--- a/cmd/outpost/exec_windows.go
+++ b/cmd/outpost/exec_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Windows has no exec(2) equivalent, so the child-process form is kept here.
+// Release builds are linux-only; this exists so the repo still builds on
+// Windows for development.
+func execBinary(binary string, args []string) error {
+	cmd := exec.Command(binary, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/outpost/main.go
+++ b/cmd/outpost/main.go
@@ -53,13 +53,7 @@ func delegateToBinary(binaryName string, c *cli.Command) error {
 	// Build arguments
 	args := buildArgs(c)
 
-	// Execute the binary
-	cmd := exec.Command(binary, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
+	return execBinary(binary, args)
 }
 
 func runWithGo(binaryName string, c *cli.Command) error {


### PR DESCRIPTION
## The bug

`outpost serve` reached the server through `exec.Command(binary).Run()`: the `outpost` wrapper stayed as PID 1 and `outpost-server` ran as its child. The wrapper installs no signal handling, so on container stop:

- `SIGTERM` kills the wrapper immediately (unhandled signal as PID 1 → the Go runtime's `exit(2)` fallback)
- PID 1's death tears down the container, and the server is SIGKILLed mid-flight

So graceful shutdown never ran in a container — the server's `SIGINT`/`SIGTERM` handling exists but was unreachable behind the wrapper.

Reproduced on the `v1.2.0` image: `docker stop` returns in 0.2s, exit code **2**, and the logs end at startup — no shutdown lines at all. With this fix, the same `docker stop` produces the full sequence — `shutdown signal received`, all four workers `worker stopped gracefully`, `outpost shutdown complete` — and exit code **0**.

## The change

`syscall.Exec` replaces the process image instead of forking, so the server *is* PID 1 and receives signals directly. This also makes the chain consistent: `build/entrypoint.sh` already `exec`s into `outpost`; now the last hop execs too.

Build-tagged: Windows has no `exec(2)`, so it keeps the child-process form. Release builds are Linux-only.

Side effects:

- **Exit codes propagate.** `cmd.Run()` collapsed every non-zero server exit into `os.Exit(1)`; the server's own status now surfaces.
- **Less memory.** One fewer resident Go runtime (~14 MiB) and one fewer mapped binary per container.

## Not affected

Only `serve` delegates. `migrate` and `config` run in-process in `outpost` and already ran as PID 1 via the entrypoint's `exec`, so their signal handling and exit codes were already correct — this brings `serve` in line with them.

`go test -short ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
