### PR TITLE
build: drop gin's unused msgpack binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,23 +12,23 @@ build:
 		exit 1; \
 	fi
 	@echo "Building all binaries..."
-	go build -o bin/outpost ./cmd/outpost
-	go build -o bin/outpost-server ./cmd/outpost-server
+	go build -tags nomsgpack -o bin/outpost ./cmd/outpost
+	go build -tags nomsgpack -o bin/outpost-server ./cmd/outpost-server
 	@echo "Binaries built in ./bin/"
 
 build/goreleaser:
 	goreleaser release -f ./build/.goreleaser.yaml --snapshot --clean
 
 build/outpost:
-	go build -o bin/outpost ./cmd/outpost
+	go build -tags nomsgpack -o bin/outpost ./cmd/outpost
 
 build/server:
-	go build -o bin/outpost-server ./cmd/outpost-server
+	go build -tags nomsgpack -o bin/outpost-server ./cmd/outpost-server
 
 install:
 	@echo "Installing binaries to GOPATH/bin..."
-	go install ./cmd/outpost
-	go install ./cmd/outpost-server
+	go install -tags nomsgpack ./cmd/outpost
+	go install -tags nomsgpack ./cmd/outpost-server
 	@echo "Installation complete"
 
 clean:

--- a/build/.goreleaser.yaml
+++ b/build/.goreleaser.yaml
@@ -19,6 +19,8 @@ builds:
       - -s -w
       - -X github.com/hookdeck/outpost/internal/version.version={{.Version}}
       - -X github.com/hookdeck/outpost/internal/version.commit={{.FullCommit}}
+    flags:
+      - -tags=nomsgpack
     binary: outpost
     env:
       - CGO_ENABLED=0
@@ -32,6 +34,8 @@ builds:
       - -s -w
       - -X github.com/hookdeck/outpost/internal/version.version={{.Version}}
       - -X github.com/hookdeck/outpost/internal/version.commit={{.FullCommit}}
+    flags:
+      - -tags=nomsgpack
     binary: outpost
     env:
       - CGO_ENABLED=0
@@ -47,6 +51,8 @@ builds:
       - -s -w
       - -X github.com/hookdeck/outpost/internal/version.version={{.Version}}
       - -X github.com/hookdeck/outpost/internal/version.commit={{.FullCommit}}
+    flags:
+      - -tags=nomsgpack
     binary: outpost-server
     env:
       - CGO_ENABLED=0
@@ -60,6 +66,8 @@ builds:
       - -s -w
       - -X github.com/hookdeck/outpost/internal/version.version={{.Version}}
       - -X github.com/hookdeck/outpost/internal/version.commit={{.FullCommit}}
+    flags:
+      - -tags=nomsgpack
     binary: outpost-server
     env:
       - CGO_ENABLED=0

--- a/build/Dockerfile.example
+++ b/build/Dockerfile.example
@@ -19,8 +19,8 @@ RUN go mod download
 COPY . .
 
 # Build all binaries
-RUN go build -o ./bin/outpost ./cmd/outpost && \
-    go build -o ./bin/outpost-server ./cmd/outpost-server
+RUN go build -tags nomsgpack -o ./bin/outpost ./cmd/outpost && \
+    go build -tags nomsgpack -o ./bin/outpost-server ./cmd/outpost-server
 
 # Stage 1
 # Get busybox shell for entrypoint script


### PR DESCRIPTION
gin links its msgpack request binding unconditionally, which pulls in `github.com/ugorji/go/codec`. Outpost never uses msgpack — the API is JSON only — so it is dead weight in every binary.

gin guards that binding behind the `nomsgpack` build tag, so setting the tag drops the dependency. No code change and no capability change.

## Effect

Measured on the goreleaser release artifacts, this branch against its parent commit, built identically:

| binary | before | after | |
| --- | --- | --- | --- |
| `outpost-server` linux/amd64 | 72.6 MiB | 66.6 MiB | -8.3% |
| `outpost-server` linux/arm64 | 66.7 MiB | 61.1 MiB | -8.3% |
| `outpost` linux/amd64 | 54.0 MiB | 48.0 MiB | -11.1% |
| `outpost` linux/arm64 | 49.8 MiB | 44.3 MiB | -11.0% |

The wrapper binary links gin too, so it drops the dependency as well — proportionally the larger win.

Verified on the release binaries rather than a hand-rolled build: `go version -m` records `build -tags=nomsgpack` on all four, the `github.com/ugorji/go/codec` dep entry is gone from all four, and `strings | grep -c ugorji` goes from ~5,900 to 0. (`go tool nm` is no use here — release ldflags are `-s -w`, so there is no symbol table.)

## Build paths

Applied to goreleaser (all four build blocks), the Makefile `build`, `build/outpost`, `build/server` and `install` targets, and `Dockerfile.example`. The `install` target uses `go install` rather than `go build`, so it is easy to miss when grepping.

A tag set in only some paths would be worse than not setting it — `make install` would silently produce a binary that differs from the release — so the completeness is deliberate.

`goreleaser release --snapshot --clean` succeeds, produces all four binaries and both Docker images, and the image runs (`--version` exits 0). No schema warnings about the added `flags:` key; the deprecation notices in the output are pre-existing and appear identically on `main`.

`go test -short ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)