### PR TITLE
fix(logmq): filter unsubscribed operator events before suppression

### DIFF
--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -506,6 +506,14 @@ func (bp *BatchProcessor) plan(ctx context.Context, eval alert.Evaluation, entry
 // entry's other events (attempt.failed) on redelivery, and the window's
 // contract is one alert per destination anyway.
 func (bp *BatchProcessor) send(ctx context.Context, de deliveryEvent) error {
+	// Filter before entering a suppression window. Emit also filters as a
+	// boundary safeguard, but an unsubscribed event must not touch Redis or
+	// turn a suppression failure into a delivery failure for an event that
+	// would never be sent.
+	if !bp.alerts.Emitter.Enabled(de.event.Topic) {
+		return nil
+	}
+
 	emit := func(ctx context.Context) error {
 		return bp.alerts.Emitter.Emit(ctx, de.event)
 	}

--- a/internal/logmq/characterization_harness_test.go
+++ b/internal/logmq/characterization_harness_test.go
@@ -320,7 +320,7 @@ type doublesConfig struct {
 	sinkBlockOn map[string]bool         // block sink.Send for these attemptIDs/topics until h.sink.release()
 	evalBlockOn map[string]bool         // block Evaluate for these attemptIDs until h.eval.release()
 	logStore    logmq.LogStore          // override the store (e.g. failingLogStore); nil = memlogstore
-	idemp       idempotence.Idempotence // exhausted-retries suppression; nil = unsuppressed
+	idemp       logmq.SuppressionWindow // exhausted-retries suppression; nil = unsuppressed
 	// failMarkProcessed makes every MarkProcessed call on the replay gate
 	// error (the Processed check still works). Simulates Redis failing after
 	// the attempt's events were delivered.

--- a/internal/logmq/delivery_suppression_test.go
+++ b/internal/logmq/delivery_suppression_test.go
@@ -6,6 +6,8 @@ package logmq_test
 // it).
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +16,15 @@ import (
 	"github.com/hookdeck/outpost/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 )
+
+type failingSuppressionWindow struct {
+	calls atomic.Int32
+}
+
+func (w *failingSuppressionWindow) Exec(context.Context, string, func(context.Context) error) error {
+	w.calls.Add(1)
+	return context.DeadlineExceeded
+}
 
 // makeExhaustedEntry builds a failed attempt past the retry limit for a fixed
 // tenant+destination, so its exhausted-retries suppression key is deterministic.
@@ -96,6 +107,35 @@ func TestDelivery_ExhaustedRetries_NoWindowEmitsEvery(t *testing.T) {
 	cm2.requireAcked(t)
 	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust, topicExhaust}, topics(h.sink.forDest(dest)),
 		"with no window, every exhaustion delivers")
+}
+
+// An exhausted-retries event that is not subscribed must be filtered before
+// touching its suppression window. Otherwise a Redis timeout for an event that
+// can never be emitted nacks the whole log message and is misleadingly logged
+// as an operator-event delivery failure.
+func TestDelivery_ExhaustedRetries_UnsubscribedSkipsSuppression(t *testing.T) {
+	t.Parallel()
+	window := &failingSuppressionWindow{}
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 1},
+		alert: alertConfig{
+			thresholds:       []int{100},
+			autoDisableCount: 1,
+			retryMaxLimit:    3,
+			withDisabler:     true,
+			opeventTopics:    []string{topicDisabled},
+		},
+		doubles: doublesConfig{idemp: window},
+	})
+
+	dest, tenant := "dest_unsub", "tenant_unsub"
+	cm, msg := newCountingMessage(makeExhaustedEntry(dest, tenant, "evt_unsub", "att_unsub", 4))
+	h.add(msg)
+	h.waitTerminal([]*countingMessage{cm})
+
+	cm.requireAcked(t)
+	assert.Zero(t, window.calls.Load(), "unsubscribed exhausted-retries must not touch its suppression window")
+	assert.Equal(t, []string{topicDisabled}, topics(h.sink.forDest(dest)))
 }
 
 // Distinct events exhausting on the same destination share the window key →


### PR DESCRIPTION
## Summary

Filter unsubscribed operator events before entering their delivery suppression window.

This prevents an event that will never be emitted from:

- reading or writing suppression state in Redis;
- failing log processing because of an unrelated Redis error;
- producing a misleading `opevent delivery failed` log;
- nacking and redelivering an otherwise successfully persisted log message.

## Problem

Operator-event topic filtering currently happens inside `Emitter.Emit`.

For events with a suppression key, `logmq.BatchProcessor.send` enters the Redis-backed suppression window before calling `Emitter.Emit`. This means the topic filter is applied too late.

For example:

```env
OPERATOR_EVENTS_TOPICS=alert.destination.disabled
```

When an attempt exhausts its retries, the alert evaluator can still plan an `alert.attempt.exhausted_retries` event. Although that topic is not subscribed, the previous delivery path was:

1. Build the exhausted-retries event.
2. Enter its Redis suppression window.
3. Only then call `Emitter.Emit`.
4. `Emitter.Emit` sees that the topic is disabled and discards it.

As a result, an unsubscribed event could fail before reaching the component responsible for filtering it:

```text
opevent delivery failed
topic=alert.attempt.exhausted_retries
error=context deadline exceeded
```

The log message was then nacked even though no exhausted-retries event was configured for delivery.

## Root cause

Topic eligibility was checked after optional delivery-layer behavior:

```text
suppression window -> emitter -> topic filter
```

Filtering needs to happen before any behavior specific to delivering the event:

```text
topic filter -> suppression window -> emitter
```

## Fix

`BatchProcessor.send` now checks `Emitter.Enabled` before entering the suppression window:

```go
if !bp.alerts.Emitter.Enabled(de.event.Topic) {
    return nil
}
```

`Emitter.Emit` retains its existing topic check as a boundary safeguard.

Subscribed events continue through the same suppression and delivery path as before.

## Tests

Added a regression test covering the reported configuration:

- only `alert.destination.disabled` is subscribed;
- the evaluated attempt also exhausts its retries;
- the exhausted-retries suppression dependency is configured to return `context.DeadlineExceeded`;
- the log message is acknowledged;
- `alert.destination.disabled` is delivered;
- `alert.attempt.exhausted_retries` is not delivered;
- the exhausted-retries suppression window is never called.

The existing delivery-suppression tests continue to cover subscribed exhausted-retry events, including:

- sequential window suppression;
- per-destination suppression;
- tenant isolation;
- concurrent suppression conflicts;
- suppression cleanup after delivery failure.

## Impact

- No configuration or API changes.
- No behavior change for subscribed operator-event topics.
- Unsubscribed topics no longer perform delivery-related Redis work.
- Redis failures for unsubscribed topics can no longer nack log messages.
- Avoids misleading delivery-failure logs for events that were intentionally filtered.

## Test command

```sh
go test ./internal/logmq
```

## For maintainers
Please review if the change makes sense in a broader scope that I may be missing here as I have found this issue in my use case where I am only interested in `alert.destination.disabled` events running 3 replicas of outpost-log service specifically.