### PR TITLE
fix(topics): honor wildcard flag during matching

### DIFF
--- a/docs/content/features/topics.mdoc
+++ b/docs/content/features/topics.mdoc
@@ -35,7 +35,7 @@ Wildcard topic subscriptions are disabled by default. Set `TOPICS_ALLOW_WILDCARD
 {% /tab %}
 {% /tabs %}
 
-When wildcard topic subscriptions are disabled, Outpost ignores stored wildcard patterns during matching. The stored topics are not changed, so re-enabling wildcard subscriptions restores the patterns. Exact topic subscriptions and the standalone `"*"` subscribe-to-all value continue to work.
+When wildcard topic subscriptions are disabled, Outpost ignores stored wildcard patterns during matching and omits them from destination and tenant API responses. The stored topics are not changed, so re-enabling wildcard subscriptions restores the patterns. Exact topic subscriptions and the standalone `"*"` subscribe-to-all value continue to work.
 
 ## Destination Topic Subscriptions
 

--- a/docs/content/features/topics.mdoc
+++ b/docs/content/features/topics.mdoc
@@ -35,6 +35,8 @@ Wildcard topic subscriptions are disabled by default. Set `TOPICS_ALLOW_WILDCARD
 {% /tab %}
 {% /tabs %}
 
+When wildcard topic subscriptions are disabled, Outpost ignores stored wildcard patterns during matching. The stored topics are not changed, so re-enabling wildcard subscriptions restores the patterns. Exact topic subscriptions and the standalone `"*"` subscribe-to-all value continue to work.
+
 ## Destination Topic Subscriptions
 
 Each destination subscribes to one or more topics. A destination receives an event only if:

--- a/docs/content/self-hosting/configuration.mdoc
+++ b/docs/content/self-hosting/configuration.mdoc
@@ -81,7 +81,7 @@ Choose one for event log persistence:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TOPICS` | — | Comma-separated list of topics your instance supports |
-| `TOPICS_ALLOW_WILDCARDS` | `false` | Allow `*` inside destination topic subscriptions, such as `user.*` |
+| `TOPICS_ALLOW_WILDCARDS` | `false` | Allow `*` inside destination topic subscriptions, such as `user.*`. When disabled, stored wildcard patterns are ignored but not deleted. |
 
 ## Portal
 

--- a/internal/apirouter/destination_displayer.go
+++ b/internal/apirouter/destination_displayer.go
@@ -1,20 +1,36 @@
 package apirouter
 
 import (
+	"strings"
+
 	"github.com/hookdeck/outpost/internal/destregistry"
 	"github.com/hookdeck/outpost/internal/models"
 )
 
 type destinationDisplayer struct {
-	registry destregistry.Registry
+	registry             destregistry.Registry
+	topicsAllowWildcards bool
 }
 
-func newDestinationDisplayer(r destregistry.Registry) *destinationDisplayer {
-	return &destinationDisplayer{registry: r}
+func newDestinationDisplayer(r destregistry.Registry, topicsAllowWildcards bool) *destinationDisplayer {
+	return &destinationDisplayer{
+		registry:             r,
+		topicsAllowWildcards: topicsAllowWildcards,
+	}
 }
 
 func (d *destinationDisplayer) Display(dest *models.Destination) (*destregistry.DestinationDisplay, error) {
-	return d.registry.DisplayDestination(dest)
+	display, err := d.registry.DisplayDestination(dest)
+	if err != nil {
+		return nil, err
+	}
+	if !d.topicsAllowWildcards {
+		displayDestination := *display.Destination
+		displayDestination.Topics = filterWildcardTopicPatterns(display.Destination.Topics)
+		display.Destination = &displayDestination
+	}
+
+	return display, nil
 }
 
 func (d *destinationDisplayer) DisplayList(destinations []models.Destination) ([]*destregistry.DestinationDisplay, error) {
@@ -27,4 +43,19 @@ func (d *destinationDisplayer) DisplayList(destinations []models.Destination) ([
 		result[i] = display
 	}
 	return result, nil
+}
+
+func filterWildcardTopicPatterns(topics []string) []string {
+	if topics == nil {
+		return nil
+	}
+
+	filteredTopics := make([]string, 0, len(topics))
+	for _, topic := range topics {
+		if topic == "*" || !strings.Contains(topic, "*") {
+			filteredTopics = append(filteredTopics, topic)
+		}
+	}
+
+	return filteredTopics
 }

--- a/internal/apirouter/destination_handlers.go
+++ b/internal/apirouter/destination_handlers.go
@@ -56,9 +56,10 @@ func (h *DestinationHandlers) List(c *gin.Context) {
 	tenant := mustTenantFromContext(c)
 
 	destinations, err := h.tenantStore.ListDestination(c.Request.Context(), tenantstore.ListDestinationRequest{
-		TenantID: tenant.ID,
-		Type:     ParseArrayQueryParam(c, "type"),
-		Topics:   ParseArrayQueryParam(c, "topics"),
+		TenantID:       tenant.ID,
+		Type:           ParseArrayQueryParam(c, "type"),
+		Topics:         ParseArrayQueryParam(c, "topics"),
+		AllowWildcards: h.topicsAllowWildcards,
 	})
 	if err != nil {
 		AbortWithError(c, http.StatusInternalServerError, NewErrInternalServer(err))

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -379,6 +379,49 @@ func TestAPI_Destinations(t *testing.T) {
 			assert.Equal(t, "d1", dest.ID)
 		})
 
+		t.Run("wildcard patterns are hidden when disabled without changing storage", func(t *testing.T) {
+			store := tenantstore.NewMemTenantStore()
+			h := newAPITest(t, withTenantStore(store))
+			reenabled := newAPITest(t, withTenantStore(store), withTopicsAllowWildcards(true))
+			restoredTopics := models.Topics{"user.*", "order.created"}
+
+			require.NoError(t, store.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1"))))
+			require.NoError(t, store.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"),
+				df.WithTenantID("t1"),
+				df.WithTopics(restoredTopics),
+			)))
+			require.NoError(t, store.CreateDestination(t.Context(), df.Any(
+				df.WithID("d2"),
+				df.WithTenantID("t1"),
+				df.WithTopics([]string{"*"}),
+			)))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t1/destinations/d1", nil)
+			resp := h.do(h.withAPIKey(req))
+			require.Equal(t, http.StatusOK, resp.Code)
+
+			var dest destregistry.DestinationDisplay
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Topics{"order.created"}, dest.Topics)
+
+			req = httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t1/destinations/d2", nil)
+			resp = h.do(h.withAPIKey(req))
+			require.Equal(t, http.StatusOK, resp.Code)
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, models.Topics{"*"}, dest.Topics)
+
+			stored, err := store.RetrieveDestination(t.Context(), "t1", "d1")
+			require.NoError(t, err)
+			assert.Equal(t, restoredTopics, stored.Topics)
+
+			req = httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t1/destinations/d1", nil)
+			resp = reenabled.do(reenabled.withAPIKey(req))
+			require.Equal(t, http.StatusOK, resp.Code)
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &dest))
+			assert.Equal(t, restoredTopics, dest.Topics)
+		})
+
 		t.Run("nonexistent destination returns 404", func(t *testing.T) {
 			h := newAPITest(t)
 			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))

--- a/internal/apirouter/destination_handlers_test.go
+++ b/internal/apirouter/destination_handlers_test.go
@@ -456,6 +456,10 @@ func TestAPI_Destinations(t *testing.T) {
 				df.WithID("d2"), df.WithTenantID("t1"),
 				df.WithType("aws_sqs"), df.WithTopics([]string{"user.deleted"}),
 			))
+			h.tenantStore.CreateDestination(t.Context(), df.Any(
+				df.WithID("d3"), df.WithTenantID("t1"),
+				df.WithType("aws_sqs"), df.WithTopics([]string{"user.*"}),
+			))
 
 			t.Run("type filter", func(t *testing.T) {
 				req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t1/destinations?type=webhook", nil)

--- a/internal/apirouter/retry_handlers.go
+++ b/internal/apirouter/retry_handlers.go
@@ -17,10 +17,11 @@ type deliveryPublisher interface {
 }
 
 type RetryHandlers struct {
-	logger            *logging.Logger
-	tenantStore       tenantstore.TenantStore
-	logStore          logstore.LogStore
-	deliveryPublisher deliveryPublisher
+	logger               *logging.Logger
+	tenantStore          tenantstore.TenantStore
+	logStore             logstore.LogStore
+	deliveryPublisher    deliveryPublisher
+	topicsAllowWildcards bool
 }
 
 func NewRetryHandlers(
@@ -28,12 +29,14 @@ func NewRetryHandlers(
 	tenantStore tenantstore.TenantStore,
 	logStore logstore.LogStore,
 	deliveryPublisher deliveryPublisher,
+	topicsAllowWildcards bool,
 ) *RetryHandlers {
 	return &RetryHandlers{
-		logger:            logger,
-		tenantStore:       tenantStore,
-		logStore:          logStore,
-		deliveryPublisher: deliveryPublisher,
+		logger:               logger,
+		tenantStore:          tenantStore,
+		logStore:             logStore,
+		deliveryPublisher:    deliveryPublisher,
+		topicsAllowWildcards: topicsAllowWildcards,
 	}
 }
 
@@ -107,7 +110,7 @@ func (h *RetryHandlers) Retry(c *gin.Context) {
 		return
 	}
 
-	if !destination.MatchEvent(*event) {
+	if !destination.MatchEvent(*event, h.topicsAllowWildcards) {
 		AbortWithError(c, http.StatusBadRequest, ErrorResponse{
 			Code:    http.StatusBadRequest,
 			Message: "destination does not match event",

--- a/internal/apirouter/retry_handlers_test.go
+++ b/internal/apirouter/retry_handlers_test.go
@@ -232,6 +232,25 @@ func TestAPI_Retry(t *testing.T) {
 
 			require.Equal(t, http.StatusAccepted, resp.Code)
 		})
+
+		t.Run("embedded wildcard is ignored when disabled", func(t *testing.T) {
+			h := newAPITest(t)
+			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))
+			h.tenantStore.UpsertDestination(t.Context(), df.Any(
+				df.WithID("d1"), df.WithTenantID("t1"), df.WithTopics([]string{"user.*"}),
+			))
+			e := ef.AnyPointer(ef.WithID("e1"), ef.WithTenantID("t1"), ef.WithTopic("user.created"))
+			require.NoError(t, h.logStore.InsertMany(t.Context(), []*models.LogEntry{
+				{Event: e, Attempt: attemptForEvent(e, af.WithDestinationID("d1"))},
+			}))
+
+			req := h.jsonReq(http.MethodPost, "/api/v1/retry", map[string]any{
+				"event_id":       "e1",
+				"destination_id": "d1",
+			})
+			resp := h.do(h.withAPIKey(req))
+			require.Equal(t, http.StatusBadRequest, resp.Code)
+		})
 	})
 
 	t.Run("Delivery task", func(t *testing.T) {

--- a/internal/apirouter/router.go
+++ b/internal/apirouter/router.go
@@ -144,7 +144,7 @@ func NewRouter(cfg RouterConfig, deps RouterDeps) http.Handler {
 	destinationHandlers := NewDestinationHandlers(deps.Logger, deps.Telemetry, deps.TenantStore, deps.SubscriptionEmitter, cfg.Topics, cfg.TopicsAllowWildcards, cfg.Registry, displayer)
 	publishHandlers := NewPublishHandlers(deps.Logger, deps.EventHandler)
 	logHandlers := NewLogHandlers(deps.Logger, deps.LogStore, deps.TenantStore, displayer)
-	retryHandlers := NewRetryHandlers(deps.Logger, deps.TenantStore, deps.LogStore, deps.DeliveryPublisher)
+	retryHandlers := NewRetryHandlers(deps.Logger, deps.TenantStore, deps.LogStore, deps.DeliveryPublisher, cfg.TopicsAllowWildcards)
 	topicHandlers := NewTopicHandlers(deps.Logger, cfg.Topics)
 	metricsHandlers := NewMetricsHandlers(deps.Logger, deps.LogStore)
 

--- a/internal/apirouter/router.go
+++ b/internal/apirouter/router.go
@@ -138,9 +138,9 @@ func NewRouter(cfg RouterConfig, deps RouterDeps) http.Handler {
 
 	apiRouter := r.Group("/api/v1")
 
-	displayer := newDestinationDisplayer(cfg.Registry)
+	displayer := newDestinationDisplayer(cfg.Registry, cfg.TopicsAllowWildcards)
 
-	tenantHandlers := NewTenantHandlers(deps.Logger, deps.Telemetry, cfg.JWTSecret, cfg.DeploymentID, deps.TenantStore)
+	tenantHandlers := NewTenantHandlers(deps.Logger, deps.Telemetry, cfg.JWTSecret, cfg.DeploymentID, deps.TenantStore, cfg.TopicsAllowWildcards)
 	destinationHandlers := NewDestinationHandlers(deps.Logger, deps.Telemetry, deps.TenantStore, deps.SubscriptionEmitter, cfg.Topics, cfg.TopicsAllowWildcards, cfg.Registry, displayer)
 	publishHandlers := NewPublishHandlers(deps.Logger, deps.EventHandler)
 	logHandlers := NewLogHandlers(deps.Logger, deps.LogStore, deps.TenantStore, displayer)

--- a/internal/apirouter/tenant_handlers.go
+++ b/internal/apirouter/tenant_handlers.go
@@ -15,11 +15,12 @@ import (
 )
 
 type TenantHandlers struct {
-	logger       *logging.Logger
-	telemetry    telemetry.Telemetry
-	jwtSecret    string
-	deploymentID string
-	tenantStore  tenantstore.TenantStore
+	logger               *logging.Logger
+	telemetry            telemetry.Telemetry
+	jwtSecret            string
+	deploymentID         string
+	tenantStore          tenantstore.TenantStore
+	topicsAllowWildcards bool
 }
 
 func NewTenantHandlers(
@@ -28,14 +29,38 @@ func NewTenantHandlers(
 	jwtSecret string,
 	deploymentID string,
 	tenantStore tenantstore.TenantStore,
+	topicsAllowWildcards bool,
 ) *TenantHandlers {
 	return &TenantHandlers{
-		logger:       logger,
-		telemetry:    telemetry,
-		jwtSecret:    jwtSecret,
-		deploymentID: deploymentID,
-		tenantStore:  tenantStore,
+		logger:               logger,
+		telemetry:            telemetry,
+		jwtSecret:            jwtSecret,
+		deploymentID:         deploymentID,
+		tenantStore:          tenantStore,
+		topicsAllowWildcards: topicsAllowWildcards,
 	}
+}
+
+func (h *TenantHandlers) postprocessTenant(tenant models.Tenant) models.Tenant {
+	if !h.topicsAllowWildcards {
+		tenant.Topics = filterWildcardTopicPatterns(tenant.Topics)
+	}
+
+	return tenant
+}
+
+func (h *TenantHandlers) postprocessTenantList(tenants *tenantstore.TenantPaginatedResult) *tenantstore.TenantPaginatedResult {
+	if h.topicsAllowWildcards {
+		return tenants
+	}
+
+	processedTenants := *tenants
+	processedTenants.Models = make([]models.Tenant, len(tenants.Models))
+	for i, tenant := range tenants.Models {
+		processedTenants.Models[i] = h.postprocessTenant(tenant)
+	}
+
+	return &processedTenants
 }
 
 func (h *TenantHandlers) Upsert(c *gin.Context) {
@@ -71,7 +96,7 @@ func (h *TenantHandlers) Upsert(c *gin.Context) {
 		h.logger.Ctx(c.Request.Context()).Audit("tenant updated",
 			zap.String("tenant_id", tenantID),
 		)
-		c.JSON(http.StatusOK, existingTenant)
+		c.JSON(http.StatusOK, h.postprocessTenant(*existingTenant))
 		return
 	}
 
@@ -92,21 +117,21 @@ func (h *TenantHandlers) Upsert(c *gin.Context) {
 	h.logger.Ctx(c.Request.Context()).Audit("tenant created",
 		zap.String("tenant_id", tenantID),
 	)
-	c.JSON(http.StatusCreated, tenant)
+	c.JSON(http.StatusCreated, h.postprocessTenant(*tenant))
 }
 
 func (h *TenantHandlers) Retrieve(c *gin.Context) {
 	tenant := mustTenantFromContext(c)
-	c.JSON(http.StatusOK, tenant)
+	c.JSON(http.StatusOK, h.postprocessTenant(*tenant))
 }
 
 func (h *TenantHandlers) List(c *gin.Context) {
 	// Authz: JWT users can only see their own tenant
 	if tenant := tenantFromContext(c); tenant != nil {
-		c.JSON(http.StatusOK, tenantstore.TenantPaginatedResult{
+		c.JSON(http.StatusOK, h.postprocessTenantList(&tenantstore.TenantPaginatedResult{
 			Models: []models.Tenant{*tenant},
 			Count:  1,
-		})
+		}))
 		return
 	}
 
@@ -177,7 +202,7 @@ func (h *TenantHandlers) List(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, resp)
+	c.JSON(http.StatusOK, h.postprocessTenantList(resp))
 }
 
 func (h *TenantHandlers) Delete(c *gin.Context) {

--- a/internal/apirouter/tenant_handlers_test.go
+++ b/internal/apirouter/tenant_handlers_test.go
@@ -150,6 +150,45 @@ func TestAPI_Tenants(t *testing.T) {
 			assert.Equal(t, "t1", tenant.ID)
 		})
 
+		t.Run("wildcard patterns are hidden when disabled without changing storage", func(t *testing.T) {
+			store := tenantstore.NewMemTenantStore()
+			h := newAPITest(t, withTenantStore(store))
+			reenabled := newAPITest(t, withTenantStore(store), withTopicsAllowWildcards(true))
+
+			require.NoError(t, store.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1"))))
+			require.NoError(t, store.CreateDestination(t.Context(), df.Any(
+				df.WithID("d1"),
+				df.WithTenantID("t1"),
+				df.WithTopics([]string{"user.*", "order.created"}),
+			)))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t1", nil)
+			resp := h.do(h.withAPIKey(req))
+			require.Equal(t, http.StatusOK, resp.Code)
+
+			var tenant models.Tenant
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &tenant))
+			assert.Equal(t, []string{"order.created"}, tenant.Topics)
+
+			listReq := httptest.NewRequest(http.MethodGet, "/api/v1/tenants", nil)
+			listResp := h.do(h.withAPIKey(listReq))
+			require.Equal(t, http.StatusOK, listResp.Code)
+			var tenants tenantstore.TenantPaginatedResult
+			require.NoError(t, json.Unmarshal(listResp.Body.Bytes(), &tenants))
+			require.Len(t, tenants.Models, 1)
+			assert.Equal(t, []string{"order.created"}, tenants.Models[0].Topics)
+
+			stored, err := store.RetrieveTenant(t.Context(), "t1")
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"user.*", "order.created"}, stored.Topics)
+
+			req = httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t1", nil)
+			resp = reenabled.do(reenabled.withAPIKey(req))
+			require.Equal(t, http.StatusOK, resp.Code)
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &tenant))
+			assert.ElementsMatch(t, []string{"user.*", "order.created"}, tenant.Topics)
+		})
+
 		t.Run("jwt returns own tenant", func(t *testing.T) {
 			h := newAPITest(t)
 			h.tenantStore.UpsertTenant(t.Context(), tf.Any(tf.WithID("t1")))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	DeploymentID         string   `yaml:"deployment_id" env:"DEPLOYMENT_ID" desc:"Optional deployment identifier for multi-tenancy. Enables multiple deployments to share the same infrastructure while maintaining data isolation." required:"N"`
 	AESEncryptionSecret  string   `yaml:"aes_encryption_secret" env:"AES_ENCRYPTION_SECRET" desc:"A 16, 24, or 32 byte secret key used for AES encryption of sensitive data at rest." required:"Y"`
 	Topics               []string `yaml:"topics" env:"TOPICS" envSeparator:"," desc:"Comma-separated list of topics that this Outpost instance should subscribe to for event processing." required:"N"`
-	TopicsAllowWildcards bool     `yaml:"topics_allow_wildcards" env:"TOPICS_ALLOW_WILDCARDS" desc:"If true, destination topic subscriptions can use '*' inside topic strings as a wildcard pattern." required:"N" default:"false"`
+	TopicsAllowWildcards bool     `yaml:"topics_allow_wildcards" env:"TOPICS_ALLOW_WILDCARDS" desc:"If true, destination topic subscriptions can use '*' inside topic strings as a wildcard pattern. If false, stored wildcard patterns are ignored without being deleted." required:"N" default:"false"`
 	HTTPUserAgent        string   `yaml:"http_user_agent" env:"HTTP_USER_AGENT" desc:"Custom HTTP User-Agent string for outgoing webhook deliveries. If unset, defaults to 'Outpost/{version}'." required:"N"`
 
 	// Infrastructure

--- a/internal/models/entities.go
+++ b/internal/models/entities.go
@@ -48,11 +48,12 @@ func (d *Destination) Validate(topics []string, allowWildcards bool) error {
 
 // MatchEvent checks if the destination matches the given event.
 // Returns true if the destination is enabled, topic matches, and filter matches.
-func (d *Destination) MatchEvent(event Event) bool {
+// Embedded wildcard topic patterns are ignored when allowWildcards is false.
+func (d *Destination) MatchEvent(event Event, allowWildcards bool) bool {
 	if d.DisabledAt != nil {
 		return false
 	}
-	if !d.Topics.MatchTopic(event.Topic) {
+	if !d.Topics.MatchTopic(event.Topic, allowWildcards) {
 		return false
 	}
 	return MatchFilter(d.Filter, event)
@@ -147,11 +148,17 @@ func (t *Topics) MatchesAll() bool {
 	return len(*t) == 1 && (*t)[0] == "*"
 }
 
-func (t *Topics) MatchTopic(eventTopic string) bool {
+// MatchTopic reports whether an event topic matches this subscription.
+// The standalone "*" keeps its subscribe-to-all meaning when allowWildcards is
+// false, while embedded wildcard patterns such as "user.*" are ignored.
+func (t *Topics) MatchTopic(eventTopic string, allowWildcards bool) bool {
 	if eventTopic == "" || eventTopic == "*" || t.MatchesAll() {
 		return true
 	}
 	for _, topic := range *t {
+		if !allowWildcards && topic != "*" && strings.Contains(topic, "*") {
+			continue
+		}
 		if matchTopicPattern(topic, eventTopic) {
 			return true
 		}

--- a/internal/models/entities_test.go
+++ b/internal/models/entities_test.go
@@ -395,9 +395,23 @@ func TestTopics_MatchTopic(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.expected, tc.topics.MatchTopic(tc.eventTopic))
+			assert.Equal(t, tc.expected, tc.topics.MatchTopic(tc.eventTopic, true))
 		})
 	}
+
+	t.Run("disabled wildcards are ignored while exact topics still match", func(t *testing.T) {
+		t.Parallel()
+		topics := models.Topics{"user.*", "order.created"}
+		assert.False(t, topics.MatchTopic("user.created", false))
+		assert.True(t, topics.MatchTopic("user.created", true))
+		assert.True(t, topics.MatchTopic("order.created", false))
+	})
+
+	t.Run("subscribe-to-all still matches when wildcards are disabled", func(t *testing.T) {
+		t.Parallel()
+		topics := models.Topics{"user.*", "*"}
+		assert.True(t, topics.MatchTopic("user.created", false))
+	})
 }
 
 func BenchmarkTopics_MatchTopic(b *testing.B) {
@@ -420,25 +434,25 @@ func BenchmarkTopics_MatchTopic(b *testing.B) {
 
 	b.Run("exact match", func(b *testing.B) {
 		for range b.N {
-			_ = topicsExact.MatchTopic("order.updated")
+			_ = topicsExact.MatchTopic("order.updated", true)
 		}
 	})
 
 	b.Run("exact miss", func(b *testing.B) {
 		for range b.N {
-			_ = topicsExact.MatchTopic("payment.created")
+			_ = topicsExact.MatchTopic("payment.created", true)
 		}
 	})
 
 	b.Run("pattern match", func(b *testing.B) {
 		for range b.N {
-			_ = topicsPattern.MatchTopic("order.payment.completed")
+			_ = topicsPattern.MatchTopic("order.payment.completed", true)
 		}
 	})
 
 	b.Run("pattern miss", func(b *testing.B) {
 		for range b.N {
-			_ = topicsPattern.MatchTopic("order.payment.failed")
+			_ = topicsPattern.MatchTopic("order.payment.failed", true)
 		}
 	})
 }

--- a/internal/publishmq/eventhandler.go
+++ b/internal/publishmq/eventhandler.go
@@ -35,13 +35,14 @@ type HandleResult struct {
 }
 
 type eventHandler struct {
-	emeter      emetrics.OutpostMetrics
-	eventTracer eventtracer.EventTracer
-	logger      *logging.Logger
-	idempotence idempotence.Idempotence
-	deliveryMQ  *deliverymq.DeliveryMQ
-	tenantStore tenantstore.TenantStore
-	topics      []string
+	emeter               emetrics.OutpostMetrics
+	eventTracer          eventtracer.EventTracer
+	logger               *logging.Logger
+	idempotence          idempotence.Idempotence
+	deliveryMQ           *deliverymq.DeliveryMQ
+	tenantStore          tenantstore.TenantStore
+	topics               []string
+	topicsAllowWildcards bool
 }
 
 func NewEventHandler(
@@ -50,17 +51,19 @@ func NewEventHandler(
 	tenantStore tenantstore.TenantStore,
 	eventTracer eventtracer.EventTracer,
 	topics []string,
+	topicsAllowWildcards bool,
 	idempotence idempotence.Idempotence,
 ) EventHandler {
 	emeter, _ := emetrics.New()
 	eventHandler := &eventHandler{
-		logger:      logger,
-		idempotence: idempotence,
-		deliveryMQ:  deliveryMQ,
-		tenantStore: tenantStore,
-		eventTracer: eventTracer,
-		topics:      topics,
-		emeter:      emeter,
+		logger:               logger,
+		idempotence:          idempotence,
+		deliveryMQ:           deliveryMQ,
+		tenantStore:          tenantStore,
+		eventTracer:          eventTracer,
+		topics:               topics,
+		topicsAllowWildcards: topicsAllowWildcards,
+		emeter:               emeter,
 	}
 	return eventHandler
 }
@@ -125,7 +128,7 @@ func (h *eventHandler) Handle(ctx context.Context, event *models.Event) (*Handle
 			return nil, err
 		}
 	} else {
-		matched, err = h.tenantStore.MatchEvent(ctx, *event)
+		matched, err = h.tenantStore.MatchEvent(ctx, *event, h.topicsAllowWildcards)
 		if err != nil {
 			matchFailed = true
 			logger.Error("failed to match event destinations",
@@ -215,7 +218,7 @@ func (h *eventHandler) matchSpecificDestination(ctx context.Context, event *mode
 		return []string{}, nil
 	}
 
-	if !destination.MatchEvent(*event) {
+	if !destination.MatchEvent(*event, h.topicsAllowWildcards) {
 		return []string{}, nil
 	}
 

--- a/internal/publishmq/eventhandler_test.go
+++ b/internal/publishmq/eventhandler_test.go
@@ -18,6 +18,38 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
+func TestEventHandler_DisabledWildcardTopics(t *testing.T) {
+	ctx := t.Context()
+	store := tenantstore.NewMemTenantStore()
+	require.NoError(t, store.UpsertTenant(ctx, testutil.TenantFactory.Any(testutil.TenantFactory.WithID("tenant_1"))))
+	require.NoError(t, store.UpsertDestination(ctx, testutil.DestinationFactory.Any(
+		testutil.DestinationFactory.WithID("destination_1"),
+		testutil.DestinationFactory.WithTenantID("tenant_1"),
+		testutil.DestinationFactory.WithTopics([]string{"user.*"}),
+	)))
+
+	handler := publishmq.NewEventHandler(
+		testutil.CreateTestLogger(t),
+		nil,
+		store,
+		nil,
+		testutil.TestTopics,
+		false,
+		nil,
+	)
+
+	for _, destinationID := range []string{"", "destination_1"} {
+		event := testutil.EventFactory.AnyPointer(
+			testutil.EventFactory.WithTenantID("tenant_1"),
+			testutil.EventFactory.WithDestinationID(destinationID),
+			testutil.EventFactory.WithTopic("user.created"),
+		)
+		result, err := handler.Handle(ctx, event)
+		require.NoError(t, err)
+		require.Empty(t, result.DestinationIDs)
+	}
+}
+
 func TestIntegrationPublishMQEventHandler_Concurrency(t *testing.T) {
 	t.Cleanup(testinfra.Start(t))
 
@@ -38,6 +70,7 @@ func TestIntegrationPublishMQEventHandler_Concurrency(t *testing.T) {
 		tenantStore,
 		mockEventTracer,
 		testutil.TestTopics,
+		true,
 		idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(24*time.Hour)),
 	)
 
@@ -101,6 +134,7 @@ func TestEventHandler_WildcardTopic(t *testing.T) {
 		tenantStore,
 		mockEventTracer,
 		testutil.TestTopics,
+		true,
 		idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(24*time.Hour)),
 	)
 
@@ -230,6 +264,7 @@ func TestEventHandler_HandleResult(t *testing.T) {
 		tenantStore,
 		testutil.NewMockEventTracer(tracetest.NewInMemoryExporter()),
 		testutil.TestTopics,
+		true,
 		idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(24*time.Hour)),
 	)
 
@@ -460,6 +495,7 @@ func TestEventHandler_Filter(t *testing.T) {
 		tenantStore,
 		testutil.NewMockEventTracer(tracetest.NewInMemoryExporter()),
 		testutil.TestTopics,
+		true,
 		idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(24*time.Hour)),
 	)
 

--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -195,6 +195,7 @@ func (b *ServiceBuilder) BuildAPIWorkers(baseRouter *gin.Engine) error {
 		svc.tenantStore,
 		svc.eventTracer,
 		b.cfg.Topics,
+		b.cfg.TopicsAllowWildcards,
 		publishIdempotence,
 	)
 

--- a/internal/tenantstore/driver/driver.go
+++ b/internal/tenantstore/driver/driver.go
@@ -20,7 +20,7 @@ type TenantStore interface {
 	CreateDestination(ctx context.Context, destination models.Destination) error
 	UpsertDestination(ctx context.Context, destination models.Destination) error
 	DeleteDestination(ctx context.Context, tenantID, destinationID string) error
-	MatchEvent(ctx context.Context, event models.Event) ([]string, error)
+	MatchEvent(ctx context.Context, event models.Event, allowWildcards bool) ([]string, error)
 }
 
 var (
@@ -63,8 +63,9 @@ type TenantPaginatedResult struct {
 
 // ListDestinationRequest contains parameters for listing destinations.
 type ListDestinationRequest struct {
-	TenantID string   // required — destinations are always tenant-scoped
-	IDs      []string // optional — filter to these destination IDs only
-	Type     []string // optional — OR semantics (matches any)
-	Topics   []string // optional — AND semantics ("*" = wildcard-only)
+	TenantID       string   // required — destinations are always tenant-scoped
+	IDs            []string // optional — filter to these destination IDs only
+	Type           []string // optional — OR semantics (matches any)
+	Topics         []string // optional — AND semantics ("*" = wildcard-only)
+	AllowWildcards bool     // whether persisted wildcard patterns participate in topic matching
 }

--- a/internal/tenantstore/drivertest/list.go
+++ b/internal/tenantstore/drivertest/list.go
@@ -330,11 +330,19 @@ func testListDestination(t *testing.T, newHarness HarnessMaker) {
 		// The filter topic is treated as a concrete published topic. Destinations
 		// subscribed with wildcard patterns are included when they would receive it.
 		destinations, err = store.ListDestination(ctx, driver.ListDestinationRequest{
+			TenantID:       data.tenant.ID,
+			Topics:         []string{"user.created"},
+			AllowWildcards: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, destinations, 5)
+
+		destinations, err = store.ListDestination(ctx, driver.ListDestinationRequest{
 			TenantID: data.tenant.ID,
 			Topics:   []string{"user.created"},
 		})
 		require.NoError(t, err)
-		require.Len(t, destinations, 5)
+		require.Len(t, destinations, 3)
 	})
 }
 

--- a/internal/tenantstore/drivertest/match.go
+++ b/internal/tenantstore/drivertest/match.go
@@ -36,7 +36,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata: map[string]string{},
 				Data:     json.RawMessage(`{}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 3)
 			for _, id := range matched {
@@ -54,7 +54,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata:      map[string]string{},
 				Data:          json.RawMessage(`{}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 3)
 		})
@@ -69,7 +69,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata:      map[string]string{},
 				Data:          json.RawMessage(`{}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 3)
 		})
@@ -84,7 +84,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata:      map[string]string{},
 				Data:          json.RawMessage(`{}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 3)
 		})
@@ -111,7 +111,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata: map[string]string{},
 				Data:     json.RawMessage(`{}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 4)
 
@@ -124,7 +124,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata: map[string]string{},
 				Data:     json.RawMessage(`{}`),
 			}
-			matched, err = store.MatchEvent(ctx, event)
+			matched, err = store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 2)
 			for _, id := range matched {
@@ -176,9 +176,19 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				testutil.EventFactory.WithTenantID(tenant.ID),
 				testutil.EventFactory.WithTopic("user.created"),
 			)
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, []string{"dest_user_family", "dest_created_family", "dest_exact"}, matched)
+		})
+
+		t.Run("ignores wildcard subscriptions when disabled", func(t *testing.T) {
+			event := testutil.EventFactory.Any(
+				testutil.EventFactory.WithTenantID(tenant.ID),
+				testutil.EventFactory.WithTopic("user.created"),
+			)
+			matched, err := store.MatchEvent(ctx, event, false)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"dest_exact"}, matched)
 		})
 
 		t.Run("matches separator agnostic middle wildcard subscription", func(t *testing.T) {
@@ -186,7 +196,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				testutil.EventFactory.WithTenantID(tenant.ID),
 				testutil.EventFactory.WithTopic("order.payment.completed"),
 			)
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, []string{"dest_order_completed_family"}, matched)
 		})
@@ -196,7 +206,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				testutil.EventFactory.WithTenantID(tenant.ID),
 				testutil.EventFactory.WithTopic("order.payment.failed"),
 			)
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			assert.Empty(t, matched)
 		})
@@ -260,7 +270,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata: map[string]string{},
 				Data:     json.RawMessage(`{"type":"order.created"}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			assert.Len(t, matched, 2)
 			assert.Contains(t, matched, "dest_no_filter")
@@ -276,7 +286,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata: map[string]string{},
 				Data:     json.RawMessage(`{"type":"order.created","customer":{"id":"cust_123","tier":"premium"}}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			assert.Len(t, matched, 3)
 			assert.Contains(t, matched, "dest_no_filter")
@@ -303,7 +313,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				Metadata: map[string]string{},
 				Data:     json.RawMessage(`{"type":"order.created"}`),
 			}
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			for _, id := range matched {
 				assert.NotEqual(t, "dest_topic_and_filter", id)
@@ -326,7 +336,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				testutil.EventFactory.WithTenantID(data.tenant.ID),
 				testutil.EventFactory.WithTopic("user.deleted"),
 			)
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 2)
 			for _, id := range matched {
@@ -344,7 +354,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				testutil.EventFactory.WithTenantID(data.tenant.ID),
 				testutil.EventFactory.WithTopic("user.deleted"),
 			)
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 1)
 			require.Equal(t, data.destinations[3].ID, matched[0])
@@ -359,7 +369,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 				testutil.EventFactory.WithTenantID(data.tenant.ID),
 				testutil.EventFactory.WithTopic("user.deleted"),
 			)
-			matched, err := store.MatchEvent(ctx, event)
+			matched, err := store.MatchEvent(ctx, event, true)
 			require.NoError(t, err)
 			require.Len(t, matched, 2)
 		})
@@ -381,7 +391,7 @@ func testMatch(t *testing.T, newHarness HarnessMaker) {
 			testutil.EventFactory.WithTenantID(data.tenant.ID),
 			testutil.EventFactory.WithTopic("user.created"),
 		)
-		matched, err := store.MatchEvent(ctx, event)
+		matched, err := store.MatchEvent(ctx, event, true)
 		require.NoError(t, err)
 		require.Len(t, matched, 2)
 		for _, id := range matched {

--- a/internal/tenantstore/memtenantstore/memtenantstore.go
+++ b/internal/tenantstore/memtenantstore/memtenantstore.go
@@ -288,8 +288,9 @@ func (s *store) ListDestination(_ context.Context, req driver.ListDestinationReq
 	hasFilter := len(req.Type) > 0 || len(req.Topics) > 0
 	if hasFilter {
 		filter = &destinationFilter{
-			Type:   req.Type,
-			Topics: req.Topics,
+			Type:           req.Type,
+			Topics:         req.Topics,
+			AllowWildcards: req.AllowWildcards,
 		}
 	}
 
@@ -413,7 +414,7 @@ func (s *store) DeleteDestination(_ context.Context, tenantID, destinationID str
 	return nil
 }
 
-func (s *store) MatchEvent(_ context.Context, event models.Event) ([]string, error) {
+func (s *store) MatchEvent(_ context.Context, event models.Event, allowWildcards bool) ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -424,7 +425,7 @@ func (s *store) MatchEvent(_ context.Context, event models.Event) ([]string, err
 		if !ok || drec.deletedAt != nil {
 			continue
 		}
-		if drec.destination.MatchEvent(event) {
+		if drec.destination.MatchEvent(event, allowWildcards) {
 			matched = append(matched, destID)
 		}
 	}
@@ -463,8 +464,9 @@ func (s *store) computeTenantTopics(tenantID string) []string {
 
 // destinationFilter specifies criteria for filtering destinations (package-private).
 type destinationFilter struct {
-	Type   []string
-	Topics []string
+	Type           []string
+	Topics         []string
+	AllowWildcards bool
 }
 
 func matchDestFilter(filter *destinationFilter, dest models.Destination) bool {
@@ -478,7 +480,7 @@ func matchDestFilter(filter *destinationFilter, dest models.Destination) bool {
 				return false
 			}
 			for _, topic := range filter.Topics {
-				if !dest.Topics.MatchTopic(topic) {
+				if !dest.Topics.MatchTopic(topic, filter.AllowWildcards) {
 					return false
 				}
 			}

--- a/internal/tenantstore/redistenantstore/redistenantstore.go
+++ b/internal/tenantstore/redistenantstore/redistenantstore.go
@@ -431,8 +431,9 @@ func (s *store) ListDestination(ctx context.Context, req driver.ListDestinationR
 	hasFilter := len(req.Type) > 0 || len(req.Topics) > 0
 	if hasFilter {
 		filter = &destinationFilter{
-			Type:   req.Type,
-			Topics: req.Topics,
+			Type:           req.Type,
+			Topics:         req.Topics,
+			AllowWildcards: req.AllowWildcards,
 		}
 	}
 
@@ -642,7 +643,7 @@ func (s *store) DeleteDestination(ctx context.Context, tenantID, destinationID s
 	return err
 }
 
-func (s *store) MatchEvent(ctx context.Context, event models.Event) ([]string, error) {
+func (s *store) MatchEvent(ctx context.Context, event models.Event, allowWildcards bool) ([]string, error) {
 	destinationSummaryList, err := s.listDestinationSummaryByTenant(ctx, event.TenantID, nil)
 	if err != nil {
 		return nil, err
@@ -654,7 +655,7 @@ func (s *store) MatchEvent(ctx context.Context, event models.Event) ([]string, e
 		if ds.Disabled {
 			continue
 		}
-		if event.Topic != "" && !ds.Topics.MatchTopic(event.Topic) {
+		if event.Topic != "" && !ds.Topics.MatchTopic(event.Topic, allowWildcards) {
 			continue
 		}
 		if !models.MatchFilter(ds.Filter, event) {

--- a/internal/tenantstore/redistenantstore/serialization.go
+++ b/internal/tenantstore/redistenantstore/serialization.go
@@ -290,8 +290,9 @@ func parseResp3SearchResult(resultMap map[interface{}]interface{}) ([]models.Ten
 
 // destinationFilter specifies criteria for filtering destinations (package-private).
 type destinationFilter struct {
-	Type   []string
-	Topics []string
+	Type           []string
+	Topics         []string
+	AllowWildcards bool
 }
 
 // parseListDestinationSummaryByTenantCmd parses a Redis HGetAll command result into destination summaries.
@@ -368,7 +369,7 @@ func matchDestinationFilter(filter *destinationFilter, summary destinationSummar
 				return false
 			}
 			for _, topic := range filter.Topics {
-				if !summary.Topics.MatchTopic(topic) {
+				if !summary.Topics.MatchTopic(topic, filter.AllowWildcards) {
 					return false
 				}
 			}


### PR DESCRIPTION
## summary
​
makes `TOPICS_ALLOW_WILDCARDS` apply during topic matching, not only validation.
​
when the flag is disabled:
​
- persisted wildcard patterns like `user.*` are ignored during delivery matching
- exact topic subscriptions continue to work
- the standalone `*` still means subscribe to all topics
- stored wildcard topics are left untouched, so re-enabling the flag restores them
​
this also applies to destination filtering, direct destination publishes, and manual retries.
​
closes #991