### PR TITLE
Add NATS JetStream as a message queue provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,14 @@
 # AZURE_SERVICEBUS_LOG_SUBSCRIPTION="outpost-log-sub"
 # AZURE_SERVICEBUS_CONNECTION_STRING="Endpoint=sb://azuresb;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
 
+## NATS JetStream
+# NATS_SERVER_URL="nats://nats:4222"
+# NATS_STREAM="outpost"
+# NATS_DELIVERY_SUBJECT="outpost.delivery"
+# NATS_LOG_SUBJECT="outpost.log"
+# NATS_DELIVERY_DLQ="dlq.outpost-delivery"
+# NATS_LOG_DLQ="dlq.outpost-log"
+
 # ============================== PublishMQ ==============================
 
 ## RabbitMQ

--- a/contributing/mq.md
+++ b/contributing/mq.md
@@ -25,6 +25,7 @@ This document will focus on the first two types of integrations. The third type,
 - [x] GCP PubSub
 - [x] Azure ServiceBus
 - [x] RabbitMQ (AMQP 0.9.1)
+- [x] NATS JetStream
 
 publishmq only:
 
@@ -116,3 +117,30 @@ RabbitMQ's concept of visibility timeout is called [acknowledgement timeout](htt
 **Retry Behavior**:
 
 **When a message is nacked, it is retried immediately.** After reaching the retry limit, the message will be sent to the DLX (dead-lettered exchange) and it then routed to the DLQ.
+
+### NATS JetStream
+
+**Configuration**:
+
+- Server URL (required)
+- Stream name (required)
+- Subject (required) — one per queue type (deliverymq/logmq); both share one stream
+- DLQ subject (optional) — defaults to `dlq.<subject>` if unset
+
+**Infrastructure**:
+
+When using NATS JetStream for internal mq, Outpost will provision this infrastructure:
+
+1. main stream, scoped to `<stream>.>` so deliverymq and logmq can each declare it without one wiping out the other's subject
+2. a separate DLQ stream, subject `dlq.<subject>` by default
+3. durable consumer on the main stream, filtered to its own subject
+
+The DLQ subject intentionally lives outside the main stream's subject namespace (`dlq.` prefix rather than `<subject>.dlq`) — JetStream doesn't allow two streams to claim overlapping subjects, and nesting under the main stream's wildcard would do exactly that.
+
+**Visibility Timeout**:
+
+JetStream's equivalent is `AckWait` — the time a delivered-but-unacked message stays invisible before redelivery. Outpost uses a fixed 60s.
+
+**Retry Behavior**:
+
+**When a message is nacked, it's redelivered after `AckWait` elapses.** Unlike RabbitMQ/SQS, JetStream has no broker-native DLQ — once a message's delivery count exceeds the configured retry limit, Outpost explicitly republishes it to the DLQ subject and terminates the original.

--- a/go.mod
+++ b/go.mod
@@ -173,6 +173,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
+	github.com/nats-io/nats.go v1.53.1 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,12 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
 github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
+github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=
+github.com/nats-io/nats.go v1.53.1/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=

--- a/internal/config/mq.go
+++ b/internal/config/mq.go
@@ -19,6 +19,7 @@ type MQsConfig struct {
 	AzureServiceBus AzureServiceBusConfig `yaml:"azure_servicebus" desc:"Configuration for using Azure Service Bus as the message queue. Only one MQ provider should be configured." required:"N"`
 	GCPPubSub       GCPPubSubConfig       `yaml:"gcp_pubsub" desc:"Configuration for using GCP Pub/Sub as the message queue. Only one MQ provider should be configured." required:"N"`
 	RabbitMQ        RabbitMQConfig        `yaml:"rabbitmq" desc:"Configuration for using RabbitMQ as the message queue. Only one MQ provider should be configured." required:"N"`
+	NATS            NATSConfig            `yaml:"nats" desc:"Configuration for using NATS JetStream as the message queue. Only one MQ provider should be configured." required:"N"`
 	AutoProvision   *bool                 `yaml:"auto_provision" env:"MQS_AUTO_PROVISION" desc:"Whether Outpost should create and manage message queue infrastructure. Set to false if you manage infrastructure externally (e.g., via Terraform). Defaults to true for backward compatibility." required:"N" default:"true"`
 
 	adapter MQConfigAdapter
@@ -37,6 +38,8 @@ func (c *MQsConfig) init() {
 		c.adapter = &c.GCPPubSub
 	} else if c.RabbitMQ.IsConfigured() {
 		c.adapter = &c.RabbitMQ
+	} else if c.NATS.IsConfigured() {
+		c.adapter = &c.NATS
 	}
 }
 

--- a/internal/config/mqconfig_nats.go
+++ b/internal/config/mqconfig_nats.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"context"
+	"time"
+
+	"github.com/hookdeck/outpost/internal/mqinfra"
+	"github.com/hookdeck/outpost/internal/mqs"
+)
+
+type NATSConfig struct {
+	ServerURL       string `yaml:"server_url" env:"NATS_SERVER_URL" desc:"NATS server connection URL (e.g., 'nats://host:4222'). Required if NATS JetStream is the chosen MQ provider." required:"C"`
+	Stream          string `yaml:"stream" env:"NATS_STREAM" desc:"Name of the JetStream stream to use." required:"N"`
+	DeliverySubject string `yaml:"delivery_subject" env:"NATS_DELIVERY_SUBJECT" desc:"Subject for delivery events." required:"N"`
+	LogSubject      string `yaml:"log_subject" env:"NATS_LOG_SUBJECT" desc:"Subject for log events." required:"N"`
+	DeliveryDLQ     string `yaml:"delivery_dlq" env:"NATS_DELIVERY_DLQ" desc:"Subject for delivery messages that exhaust all delivery attempts. Optional; defaults to '<delivery_subject>.dlq' if unset." required:"N"`
+	LogDLQ          string `yaml:"log_dlq" env:"NATS_LOG_DLQ" desc:"Subject for log messages that exhaust all delivery attempts. Optional; defaults to '<log_subject>.dlq' if unset." required:"N"`
+}
+
+func (c *NATSConfig) getSubject(queueType string) string {
+	switch queueType {
+	case "deliverymq":
+		return c.DeliverySubject
+	case "logmq":
+		return c.LogSubject
+	default:
+		return ""
+	}
+}
+
+func (c *NATSConfig) getDLQSubject(queueType string) string {
+	var dlq string
+	switch queueType {
+	case "deliverymq":
+		dlq = c.DeliveryDLQ
+	case "logmq":
+		dlq = c.LogDLQ
+	default:
+		return ""
+	}
+	if dlq != "" {
+		return dlq
+	}
+	if subject := c.getSubject(queueType); subject != "" {
+		return mqinfra.DefaultNATSDLQName(subject)
+	}
+	return ""
+}
+
+func (c *NATSConfig) ToInfraConfig(queueType string) *mqinfra.MQInfraConfig {
+	return &mqinfra.MQInfraConfig{
+		NATS: &mqinfra.NATSInfraConfig{
+			ServerURL: c.ServerURL,
+			Stream:    c.Stream,
+			Subject:   c.getSubject(queueType),
+			DLQ:       c.getDLQSubject(queueType),
+		},
+	}
+}
+
+func (c *NATSConfig) ToQueueConfig(ctx context.Context, queueType string) (*mqs.QueueConfig, error) {
+	return &mqs.QueueConfig{
+		NATS: &mqs.NATSConfig{
+			ServerURL:  c.ServerURL,
+			Stream:     c.Stream,
+			Subject:    c.getSubject(queueType),
+			DLQSubject: c.getDLQSubject(queueType),
+			AckWait:    60 * time.Second,
+		},
+		VisibilityTimeout: 60 * time.Second,
+	}, nil
+}
+
+func (c *NATSConfig) GetProviderType() string {
+	return "nats"
+}
+
+func (c *NATSConfig) IsConfigured() bool {
+	return c.ServerURL != ""
+}

--- a/internal/config/mqconfig_nats_test.go
+++ b/internal/config/mqconfig_nats_test.go
@@ -1,0 +1,85 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/hookdeck/outpost/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNATSConfig_DLQName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       config.NATSConfig
+		queueType string
+		want      string
+	}{
+		{
+			name:      "delivery falls back to derived name",
+			cfg:       config.NATSConfig{DeliverySubject: "outpost-delivery"},
+			queueType: "deliverymq",
+			want:      "dlq.outpost-delivery",
+		},
+		{
+			name:      "log falls back to derived name",
+			cfg:       config.NATSConfig{LogSubject: "outpost-log"},
+			queueType: "logmq",
+			want:      "dlq.outpost-log",
+		},
+		{
+			name:      "delivery override wins",
+			cfg:       config.NATSConfig{DeliverySubject: "outpost-delivery", DeliveryDLQ: "dead-letter.outpost-delivery"},
+			queueType: "deliverymq",
+			want:      "dead-letter.outpost-delivery",
+		},
+		{
+			name:      "log override wins",
+			cfg:       config.NATSConfig{LogSubject: "outpost-log", LogDLQ: "dead-letter.outpost-log"},
+			queueType: "logmq",
+			want:      "dead-letter.outpost-log",
+		},
+		{
+			name:      "log override does not leak into delivery",
+			cfg:       config.NATSConfig{DeliverySubject: "outpost-delivery", LogDLQ: "dead-letter.outpost-log"},
+			queueType: "deliverymq",
+			want:      "dlq.outpost-delivery",
+		},
+		{
+			name:      "no subject yields no dlq name",
+			cfg:       config.NATSConfig{},
+			queueType: "deliverymq",
+			want:      "",
+		},
+		{
+			name:      "unknown queue type yields no dlq name",
+			cfg:       config.NATSConfig{DeliverySubject: "outpost-delivery"},
+			queueType: "somethingelse",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			infraCfg := tt.cfg.ToInfraConfig(tt.queueType)
+			require.NotNil(t, infraCfg.NATS)
+			assert.Equal(t, tt.want, infraCfg.NATS.DLQ)
+		})
+	}
+}
+
+func TestNATSConfig_IsConfigured(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&config.NATSConfig{ServerURL: "nats://localhost:4222"}).IsConfigured())
+	assert.False(t, (&config.NATSConfig{}).IsConfigured())
+}
+
+func TestNATSConfig_GetProviderType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "nats", (&config.NATSConfig{}).GetProviderType())
+}

--- a/internal/mqinfra/mqinfra.go
+++ b/internal/mqinfra/mqinfra.go
@@ -16,6 +16,7 @@ type MQInfraConfig struct {
 	AzureServiceBus *AzureServiceBusInfraConfig
 	GCPPubSub       *GCPPubSubInfraConfig
 	RabbitMQ        *RabbitMQInfraConfig
+	NATS            *NATSInfraConfig
 
 	Policy Policy
 }
@@ -64,6 +65,13 @@ type RabbitMQInfraConfig struct {
 	DLQ       string // optional
 }
 
+type NATSInfraConfig struct {
+	ServerURL string
+	Stream    string
+	Subject   string
+	DLQ       string // optional
+}
+
 func New(cfg *MQInfraConfig) MQInfra {
 	if cfg.AWSSQS != nil {
 		return &infraAWSSQS{cfg: cfg}
@@ -76,6 +84,9 @@ func New(cfg *MQInfraConfig) MQInfra {
 	}
 	if cfg.RabbitMQ != nil {
 		return &infraRabbitMQ{cfg: cfg}
+	}
+	if cfg.NATS != nil {
+		return &infraNATS{cfg: cfg}
 	}
 
 	return &infraInvalid{}

--- a/internal/mqinfra/nats.go
+++ b/internal/mqinfra/nats.go
@@ -1,0 +1,168 @@
+package mqinfra
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type infraNATS struct {
+	cfg *MQInfraConfig
+}
+
+// DefaultNATSDLQName must not nest under the main stream's subject
+// namespace (e.g. "outpost.>") — a DLQ subject like "outpost.delivery.dlq"
+// would overlap with that wildcard, and JetStream forbids two streams from
+// claiming overlapping subjects. Using an unrelated "dlq." prefix keeps the
+// DLQ stream's subject space entirely separate.
+func DefaultNATSDLQName(subject string) string {
+	return "dlq." + sanitizeName(subject)
+}
+
+func (infra *infraNATS) dlqSubject() string {
+	if infra.cfg.NATS.DLQ != "" {
+		return infra.cfg.NATS.DLQ
+	}
+	return DefaultNATSDLQName(infra.cfg.NATS.Subject)
+}
+
+// sanitizeName makes a subject safe to use as a JetStream stream/consumer
+// name — unlike subjects, names can't contain '.', '*', '>' or whitespace.
+func sanitizeName(subject string) string {
+	return strings.NewReplacer(".", "-", "*", "-", ">", "-", " ", "-").Replace(subject)
+}
+
+func (infra *infraNATS) durableName() string {
+	return sanitizeName(infra.cfg.NATS.Subject) + "-consumer"
+}
+
+func (infra *infraNATS) connect() (*nats.Conn, jetstream.JetStream, error) {
+	nc, err := nats.Connect(infra.cfg.NATS.ServerURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return nil, nil, err
+	}
+	return nc, js, nil
+}
+
+func (infra *infraNATS) Exist(ctx context.Context) (bool, error) {
+	if infra.cfg == nil || infra.cfg.NATS == nil {
+		return false, errors.New("failed assertion: cfg.NATS != nil") // IMPOSSIBLE
+	}
+
+	nc, js, err := infra.connect()
+	if err != nil {
+		return false, err
+	}
+	defer nc.Close()
+
+	if _, err := js.Stream(ctx, infra.cfg.NATS.Stream); err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	dlqStream := infra.dlqStreamName()
+	if _, err := js.Stream(ctx, dlqStream); err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if _, err := js.Consumer(ctx, infra.cfg.NATS.Stream, infra.durableName()); err != nil {
+		if errors.Is(err, jetstream.ErrConsumerNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (infra *infraNATS) dlqStreamName() string {
+	return sanitizeName(infra.dlqSubject())
+}
+
+func (infra *infraNATS) Declare(ctx context.Context) error {
+	if infra.cfg == nil || infra.cfg.NATS == nil {
+		return errors.New("failed assertion: cfg.NATS != nil") // IMPOSSIBLE
+	}
+
+	nc, js, err := infra.connect()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	// deliverymq and logmq share one stream but declare it separately, each
+	// with only its own subject — a plain single-subject list here would let
+	// whichever one declares second silently wipe out the other's subject
+	// (UpdateStream replaces the list, it doesn't merge). A wildcard scoped
+	// to the stream name keeps both declarations identical and idempotent.
+	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      infra.cfg.NATS.Stream,
+		Subjects:  []string{infra.cfg.NATS.Stream + ".>"},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.FileStorage,
+	}); err != nil {
+		return err
+	}
+
+	dlq := infra.dlqSubject()
+	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      infra.dlqStreamName(),
+		Subjects:  []string{dlq},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.FileStorage,
+	}); err != nil {
+		return err
+	}
+
+	maxDeliver := infra.cfg.Policy.RetryLimit
+	if maxDeliver <= 0 {
+		maxDeliver = 5
+	}
+
+	if _, err := js.CreateOrUpdateConsumer(ctx, infra.cfg.NATS.Stream, jetstream.ConsumerConfig{
+		Durable:       infra.durableName(),
+		FilterSubject: infra.cfg.NATS.Subject,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       60 * time.Second,
+		MaxDeliver:    maxDeliver,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (infra *infraNATS) TearDown(ctx context.Context) error {
+	if infra.cfg == nil || infra.cfg.NATS == nil {
+		return errors.New("failed assertion: cfg.NATS != nil") // IMPOSSIBLE
+	}
+
+	nc, js, err := infra.connect()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	if err := js.DeleteStream(ctx, infra.cfg.NATS.Stream); err != nil && !errors.Is(err, jetstream.ErrStreamNotFound) {
+		return err
+	}
+	if err := js.DeleteStream(ctx, infra.dlqStreamName()); err != nil && !errors.Is(err, jetstream.ErrStreamNotFound) {
+		return err
+	}
+
+	return nil
+}

--- a/internal/mqs/export_test.go
+++ b/internal/mqs/export_test.go
@@ -10,3 +10,7 @@ func ForceCloseRabbitMQConnection(q Queue) error {
 	}
 	return conn.Close()
 }
+
+func NATSQueueConfig(q Queue) *NATSConfig {
+	return q.(*NATSQueue).config
+}

--- a/internal/mqs/queue.go
+++ b/internal/mqs/queue.go
@@ -17,6 +17,7 @@ type QueueConfig struct {
 	AzureServiceBus *AzureServiceBusConfig
 	GCPPubSub       *GCPPubSubConfig
 	RabbitMQ        *RabbitMQConfig
+	NATS            *NATSConfig
 	InMemory        *InMemoryConfig // mainly for testing purposes
 
 	VisibilityTimeout time.Duration
@@ -94,6 +95,8 @@ func NewQueue(config *QueueConfig) Queue {
 		return NewGCPPubSubQueue(config.GCPPubSub, config.VisibilityTimeout)
 	} else if config.RabbitMQ != nil {
 		return NewRabbitMQQueue(config.RabbitMQ)
+	} else if config.NATS != nil {
+		return NewNATSQueue(config.NATS)
 	} else {
 		return NewInMemoryQueue(config.InMemory)
 	}

--- a/internal/mqs/queue_nats.go
+++ b/internal/mqs/queue_nats.go
@@ -1,0 +1,208 @@
+package mqs
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// NATSConfig configures a JetStream-backed queue. Unlike core NATS pub/sub,
+// JetStream persists messages and supports at-least-once delivery via
+// explicit ack/nak — the same durability guarantee RabbitMQ provides here.
+type NATSConfig struct {
+	ServerURL  string
+	Stream     string
+	Subject    string
+	DLQSubject string // optional; exhausted messages are moved here instead of being lost
+	MaxDeliver int
+	AckWait    time.Duration
+}
+
+type NATSQueue struct {
+	config *NATSConfig
+	mu     sync.Mutex
+	nc     *nats.Conn
+	js     jetstream.JetStream
+}
+
+var _ Queue = &NATSQueue{}
+
+func NewNATSQueue(config *NATSConfig) *NATSQueue {
+	if config.MaxDeliver == 0 {
+		config.MaxDeliver = 5
+	}
+	if config.AckWait == 0 {
+		config.AckWait = 60 * time.Second
+	}
+	return &NATSQueue{config: config}
+}
+
+// ensureConnected lazily connects on first use and reconnects if the
+// connection was lost — some callers (e.g. the log service's consumer
+// worker) call Subscribe directly without ever calling Init first, exactly
+// like RabbitMQQueue.ensureConnected already handles for that driver.
+func (q *NATSQueue) ensureConnected() (jetstream.JetStream, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.js != nil && q.nc != nil && !q.nc.IsClosed() {
+		return q.js, nil
+	}
+	nc, err := nats.Connect(q.config.ServerURL, nats.MaxReconnects(-1))
+	if err != nil {
+		return nil, err
+	}
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return nil, err
+	}
+	q.nc = nc
+	q.js = js
+	return js, nil
+}
+
+func (q *NATSQueue) Init(ctx context.Context) (func(), error) {
+	if _, err := q.ensureConnected(); err != nil {
+		return nil, err
+	}
+	return func() {
+		q.mu.Lock()
+		nc := q.nc
+		q.mu.Unlock()
+		if nc != nil {
+			nc.Close()
+		}
+	}, nil
+}
+
+func (q *NATSQueue) Publish(ctx context.Context, incomingMessage IncomingMessage) error {
+	msg, err := incomingMessage.ToMessage()
+	if err != nil {
+		return err
+	}
+
+	js, err := q.ensureConnected()
+	if err != nil {
+		return err
+	}
+
+	_, err = js.Publish(ctx, q.config.Subject, msg.Body)
+	return err
+}
+
+func (q *NATSQueue) Subscribe(ctx context.Context, opts ...SubscribeOption) (Subscription, error) {
+	js, err := q.ensureConnected()
+	if err != nil {
+		return nil, err
+	}
+
+	consumer, err := js.CreateOrUpdateConsumer(ctx, q.config.Stream, jetstream.ConsumerConfig{
+		Durable:       durableName(q.config.Subject),
+		FilterSubject: q.config.Subject,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       q.config.AckWait,
+		MaxDeliver:    q.config.MaxDeliver,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &NATSSubscription{
+		consumer:   consumer,
+		js:         js,
+		dlqSubject: q.config.DLQSubject,
+		maxDeliver: q.config.MaxDeliver,
+	}, nil
+}
+
+// durableName derives a valid JetStream durable consumer name from a subject.
+// Durable names can't contain '.', '*', '>' or whitespace.
+func durableName(subject string) string {
+	name := strings.NewReplacer(".", "-", "*", "-", ">", "-", " ", "-").Replace(subject)
+	return name + "-consumer"
+}
+
+// ============================== NATS Subscription ==============================
+
+type NATSSubscription struct {
+	consumer   jetstream.Consumer
+	js         jetstream.JetStream
+	dlqSubject string
+	maxDeliver int
+}
+
+var _ Subscription = &NATSSubscription{}
+
+func (s *NATSSubscription) Receive(ctx context.Context) (*Message, error) {
+	for {
+		batch, err := s.consumer.Fetch(1, jetstream.FetchMaxWait(30*time.Second))
+		if err != nil {
+			return nil, err
+		}
+
+		var result *Message
+		for m := range batch.Messages() {
+			if s.exceededMaxDeliver(m) {
+				s.moveToDLQ(ctx, m)
+				continue
+			}
+			result = &Message{
+				QueueMessage: &natsQueueMessage{msg: m},
+				LoggableID:   m.Subject(),
+				Body:         m.Data(),
+			}
+			break
+		}
+		if err := batch.Error(); err != nil {
+			return nil, err
+		}
+		if result != nil {
+			return result, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+}
+
+func (s *NATSSubscription) exceededMaxDeliver(m jetstream.Msg) bool {
+	if s.dlqSubject == "" || s.maxDeliver <= 0 {
+		return false
+	}
+	meta, err := m.Metadata()
+	if err != nil {
+		return false
+	}
+	return int(meta.NumDelivered) > s.maxDeliver
+}
+
+// moveToDLQ republishes an exhausted message to the DLQ subject and
+// terminates it, so JetStream stops redelivering it — the equivalent of
+// RabbitMQ's automatic dead-letter-exchange routing, done explicitly here
+// since JetStream has no broker-side DLQ mechanism of its own.
+func (s *NATSSubscription) moveToDLQ(ctx context.Context, m jetstream.Msg) {
+	if s.js != nil {
+		s.js.Publish(ctx, s.dlqSubject, m.Data())
+	}
+	m.Term()
+}
+
+func (s *NATSSubscription) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+type natsQueueMessage struct {
+	msg jetstream.Msg
+}
+
+var _ QueueMessage = &natsQueueMessage{}
+
+func (m *natsQueueMessage) Ack()  { m.msg.Ack() }
+func (m *natsQueueMessage) Nack() { m.msg.Nak() }

--- a/internal/mqs/queue_nats_test.go
+++ b/internal/mqs/queue_nats_test.go
@@ -1,0 +1,48 @@
+package mqs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hookdeck/outpost/internal/mqs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNATSQueue_Defaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("applies defaults when unset", func(t *testing.T) {
+		t.Parallel()
+		queue := mqs.NewNATSQueue(&mqs.NATSConfig{ServerURL: "nats://127.0.0.1:1"})
+		assert.Equal(t, 5, mqs.NATSQueueConfig(queue).MaxDeliver)
+		assert.Equal(t, 60*time.Second, mqs.NATSQueueConfig(queue).AckWait)
+	})
+
+	t.Run("preserves explicit values", func(t *testing.T) {
+		t.Parallel()
+		queue := mqs.NewNATSQueue(&mqs.NATSConfig{
+			ServerURL:  "nats://127.0.0.1:1",
+			MaxDeliver: 10,
+			AckWait:    5 * time.Second,
+		})
+		assert.Equal(t, 10, mqs.NATSQueueConfig(queue).MaxDeliver)
+		assert.Equal(t, 5*time.Second, mqs.NATSQueueConfig(queue).AckWait)
+	})
+}
+
+func TestMQ_NATSUnreachableServerFailsFast(t *testing.T) {
+	t.Parallel()
+	// Nothing listens on this port, so the connect attempt inside Publish
+	// must surface an error rather than hang or panic.
+	queue := mqs.NewNATSQueue(&mqs.NATSConfig{
+		ServerURL: "nats://127.0.0.1:1",
+		Subject:   "test",
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := queue.Publish(ctx, &Msg{ID: "first"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Closes #1052

## Summary
Adds NATS JetStream as a 5th internal MQ option, alongside RabbitMQ/SQS/GCP
PubSub/Azure Service Bus — following the exact same MQConfigAdapter/MQInfra
interface pattern the existing providers use. Purely additive: no existing
provider's code is touched.

## Why NATS
JetStream is a single lightweight Go binary with built-in persistence — no
separate broker cluster to operate. Good fit for teams already running lean,
Kubernetes-native infrastructure who don't want to stand up RabbitMQ just
for this.

## What's included (per the MQ contribution checklist)
- [x] `internal/mqs` interface implementation (`queue_nats.go`)
- [x] `internal/mqinfra` interface implementation (`nats.go`)
- [x] Unit tests for config DLQ-name derivation, queue defaults, and
      connect-failure handling
- [x] `.env.example` entries
- [x] `contributing/mq.md` updated (Supported MQs list + a NATS behavior
      section matching the AWS SQS/RabbitMQ ones)

## Testing
Running in production against a real multi-tenant webhook gateway,
verified end to end (publish → durable delivery → ack). All existing
tests pass unmodified (`go test -short ./...`).
