### PR TITLE
feat(redis): configurable connection pool size

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@
 # REDIS_DATABASE="0"
 # REDIS_TLS_ENABLED="false"
 # REDIS_CLUSTER_ENABLED="false"
+# REDIS_POOL_SIZE="0"
 
 # ============================== Log Store ==============================
 

--- a/docs/content/self-hosting/configuration.mdoc
+++ b/docs/content/self-hosting/configuration.mdoc
@@ -17,6 +17,7 @@ These variables must be set for Outpost to start:
 | `REDIS_HOST` | Hostname of the Redis server (default: `127.0.0.1`) |
 | `REDIS_PORT` | Port of the Redis server (default: `6379`) |
 | `REDIS_DATABASE` | Redis database number (default: `0`) |
+| `REDIS_POOL_SIZE` | Optional. Connection pool size per Redis client (per node in cluster mode); default `0` uses go-redis's default of 10 per `GOMAXPROCS`. Raise it when Redis round-trip latency limits throughput; lower it to shrink the pool on hosts with many CPUs. |
 
 ## Message Queue
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,6 +128,7 @@ var (
 	ErrInvalidPortalProxyURL  = errors.New("config validation error: invalid portal proxy url")
 	ErrInvalidWebhookProxyURL = errors.New("config validation error: invalid webhook proxy url")
 	ErrInvalidDeploymentID    = errors.New("config validation error: deployment_id must contain only alphanumeric characters, hyphens, and underscores (max 64 characters)")
+	ErrInvalidRedisPoolSize   = errors.New("config validation error: redis pool_size must be >= 0")
 )
 
 func (c *Config) InitDefaults() {
@@ -423,6 +424,7 @@ type RedisConfig struct {
 	Database               int    `yaml:"database" env:"REDIS_DATABASE" desc:"Redis database number to select after connecting (ignored in cluster mode)." required:"Y"`
 	TLSEnabled             bool   `yaml:"tls_enabled" env:"REDIS_TLS_ENABLED" desc:"Enable TLS encryption for Redis connection." required:"N"`
 	ClusterEnabled         bool   `yaml:"cluster_enabled" env:"REDIS_CLUSTER_ENABLED" desc:"Enable Redis cluster mode for distributed Redis deployments." required:"N"`
+	PoolSize               int    `yaml:"pool_size" env:"REDIS_POOL_SIZE" desc:"Connection pool size per Redis client (per node in cluster mode). 0 uses go-redis's default of 10 per GOMAXPROCS." required:"N"`
 	DevClusterHostOverride bool   `yaml:"dev_cluster_host_override" env:"REDIS_DEV_CLUSTER_HOST_OVERRIDE" desc:"Development only: Force cluster to use original host for discovered nodes. DO NOT use in production." required:"N"`
 }
 
@@ -436,6 +438,7 @@ func (c *RedisConfig) ToConfig() *redis.RedisConfig {
 		TLSEnabled:             c.TLSEnabled,
 		ClusterEnabled:         c.ClusterEnabled,
 		DevClusterHostOverride: c.DevClusterHostOverride,
+		PoolSize:               c.PoolSize,
 	}
 }
 

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -79,6 +79,7 @@ func (c *Config) LogConfigurationSummary() []zap.Field {
 		zap.Int("redis_database", c.Redis.Database),
 		zap.Bool("redis_tls_enabled", c.Redis.TLSEnabled),
 		zap.Bool("redis_cluster_enabled", c.Redis.ClusterEnabled),
+		zap.Int("redis_pool_size", c.Redis.PoolSize),
 
 		// PostgreSQL
 		zap.Bool("postgres_configured", c.PostgresURL != ""),

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -108,6 +108,9 @@ func (c *Config) validateRedis() error {
 	if c.Redis.Host == "" {
 		return ErrMissingRedis
 	}
+	if c.Redis.PoolSize < 0 {
+		return ErrInvalidRedisPoolSize
+	}
 	return nil
 }
 

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -135,6 +135,24 @@ func TestRedis(t *testing.T) {
 			}(),
 			wantErr: config.ErrMissingRedis,
 		},
+		{
+			name: "custom redis pool size",
+			config: func() *config.Config {
+				c := validConfig()
+				c.Redis.PoolSize = 100
+				return c
+			}(),
+			wantErr: nil,
+		},
+		{
+			name: "negative redis pool size",
+			config: func() *config.Config {
+				c := validConfig()
+				c.Redis.PoolSize = -1
+				return c
+			}(),
+			wantErr: config.ErrInvalidRedisPoolSize,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/redis/config.go
+++ b/internal/redis/config.go
@@ -9,6 +9,10 @@ type RedisConfig struct {
 	TLSEnabled     bool
 	ClusterEnabled bool
 
+	// PoolSize is the connection pool size per client (per node in cluster
+	// mode). 0 uses go-redis's default of 10 per GOMAXPROCS.
+	PoolSize int
+
 	// DevClusterHostOverride when true, forces cluster node discovery to use the
 	// original Host value instead of discovered IPs. This is a development-only
 	// setting for Docker environments where nodes announce unreachable IPs.

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -67,6 +67,7 @@ func createClusterClient(ctx context.Context, config *RedisConfig) (Client, erro
 		Addrs:    []string{fmt.Sprintf("%s:%d", config.Host, config.Port)},
 		Username: config.Username,
 		Password: config.Password,
+		PoolSize: config.PoolSize,
 		// Note: Database is ignored in cluster mode
 	}
 
@@ -106,6 +107,7 @@ func createRegularClient(ctx context.Context, config *RedisConfig) (Client, erro
 		Username: config.Username,
 		Password: config.Password,
 		DB:       config.Database,
+		PoolSize: config.PoolSize,
 	}
 
 	if config.TLSEnabled {


### PR DESCRIPTION
Adds `REDIS_POOL_SIZE` (`redis.pool_size` in YAML) to configure the go-redis connection pool size per client. Unset or `0` keeps go-redis's default of 10 × GOMAXPROCS, so existing deployments are unaffected. In cluster mode the value applies per node.

The GOMAXPROCS-derived default cuts both ways: containers with small CPU limits get small pools that become a throughput ceiling when Redis round-trip latency is non-trivial, while large hosts hold hundreds of mostly idle connections per client. This exposes the standard knob to size the pool explicitly.