### PR TITLE
chore(deps): Go 1.27.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.27.1
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
       - name: Run GoReleaser

--- a/.github/workflows/spec-sdk-tests.yml
+++ b/.github/workflows/spec-sdk-tests.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.5"
+          go-version: "1.27.1"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.1'
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/build/Dockerfile.example
+++ b/build/Dockerfile.example
@@ -12,7 +12,7 @@
 
 # Stage 0
 # Build the binaries
-FROM golang:1.26-alpine
+FROM golang:1.27-alpine
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/build/dev/Dockerfile
+++ b/build/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS fetch
+FROM golang:1.27-alpine AS fetch
 RUN go install github.com/air-verse/air@v1.61.1
 WORKDIR /app
 COPY . .

--- a/build/test/Dockerfile.mock
+++ b/build/test/Dockerfile.mock
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine
+FROM golang:1.27-alpine
 WORKDIR /app
 COPY . .
 RUN go build -o /bin/mock ./cmd/destinations/mock

--- a/build/test/redis-cluster-compose.yml
+++ b/build/test/redis-cluster-compose.yml
@@ -23,7 +23,7 @@ services:
       - SLAVES_PER_MASTER=1 # 3 masters + 3 slaves = 6 nodes total
 
   test-runner:
-    image: golang:1.26-alpine
+    image: golang:1.27-alpine
     container_name: test-runner
     working_dir: /app
     volumes:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hookdeck/outpost
 
-go 1.26.5
+go 1.27.1
 
 require (
 	cloud.google.com/go/pubsub v1.51.0

--- a/loadtest/mock/webhook/Dockerfile
+++ b/loadtest/mock/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps the toolchain from 1.26.5 to 1.27.1 across go.mod, the CI workflows and the dev/test images. Closes #1054 (CVE-2026-56865, CVE-2026-56864, CVE-2026-33818).

Verified locally: `go vet`, `go test -short ./...`, dev image build, and the dev-stack smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6bSnhoJjMok3GG9GHUU4v