### PR TITLE
fix(logmq): don't wait on in-flight exhausted-retries suppression

### DIFF
--- a/internal/logmq/batchprocessor.go
+++ b/internal/logmq/batchprocessor.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hookdeck/outpost/internal/alert"
-	"github.com/hookdeck/outpost/internal/idempotence"
 	"github.com/hookdeck/outpost/internal/logging"
 	"github.com/hookdeck/outpost/internal/models"
 	"github.com/hookdeck/outpost/internal/mqs"
@@ -64,7 +63,7 @@ type ReplayGate interface {
 
 // SuppressionWindow wraps one send in a keyed dedup window: within the window
 // the send is skipped and counts as delivered. Satisfied by
-// idempotence.Idempotence.
+// redisSuppressionWindow.
 type SuppressionWindow interface {
 	Exec(ctx context.Context, key string, exec func(context.Context) error) error
 }
@@ -500,11 +499,6 @@ func (bp *BatchProcessor) plan(ctx context.Context, eval alert.Evaluation, entry
 // one. A suppressed duplicate (Exec skips the emit) counts as delivered. The
 // emitter owns the delivery audit log — it fires iff an event actually went
 // out, so filtered topics and suppressed duplicates leave no line.
-//
-// An in-flight conflict (another exhaustion on the same destination is
-// emitting concurrently) also counts as delivered: nacking would re-emit the
-// entry's other events (attempt.failed) on redelivery, and the window's
-// contract is one alert per destination anyway.
 func (bp *BatchProcessor) send(ctx context.Context, de deliveryEvent) error {
 	emit := func(ctx context.Context) error {
 		return bp.alerts.Emitter.Emit(ctx, de.event)
@@ -512,11 +506,7 @@ func (bp *BatchProcessor) send(ctx context.Context, de deliveryEvent) error {
 	if de.suppressKey == "" {
 		return emit(ctx)
 	}
-	err := bp.alerts.ExhaustedIdemp.Exec(ctx, de.suppressKey, emit)
-	if errors.Is(err, idempotence.ErrConflict) {
-		return nil
-	}
-	return err
+	return bp.alerts.ExhaustedIdemp.Exec(ctx, de.suppressKey, emit)
 }
 
 // nackAlertFailure logs an alert-pipeline failure and nacks. InsertMany is

--- a/internal/logmq/characterization_harness_test.go
+++ b/internal/logmq/characterization_harness_test.go
@@ -76,6 +76,7 @@ type recordingSink struct {
 
 	inflight    atomic.Int32
 	maxInflight atomic.Int32
+	blocked     atomic.Int32 // sends that reached the block
 }
 
 func (s *recordingSink) Init(ctx context.Context) error { return nil }
@@ -109,6 +110,7 @@ func (s *recordingSink) Send(ctx context.Context, event *opevents.OperatorEvent)
 	// Honors ctx like a real sink call: a canceled send returns ctx.Err()
 	// (this is how the emit-timeout tests trip the deadline).
 	if s.blockCh != nil && (s.blockOn[attemptID] || s.blockOn[event.Topic]) {
+		s.blocked.Add(1)
 		select {
 		case <-s.blockCh:
 		case <-ctx.Done():
@@ -128,6 +130,12 @@ func (s *recordingSink) Send(ctx context.Context, event *opevents.OperatorEvent)
 // release unblocks every blocked (and future) matching send.
 func (s *recordingSink) release() {
 	s.releaseOnce.Do(func() { close(s.blockCh) })
+}
+
+// waitBlocked waits until at least one send is parked on the block.
+func (s *recordingSink) waitBlocked(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, func() bool { return s.blocked.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
 }
 
 func (s *recordingSink) inflightSends() int32    { return s.inflight.Load() }
@@ -320,7 +328,7 @@ type doublesConfig struct {
 	sinkBlockOn map[string]bool         // block sink.Send for these attemptIDs/topics until h.sink.release()
 	evalBlockOn map[string]bool         // block Evaluate for these attemptIDs until h.eval.release()
 	logStore    logmq.LogStore          // override the store (e.g. failingLogStore); nil = memlogstore
-	idemp       idempotence.Idempotence // exhausted-retries suppression; nil = unsuppressed
+	idemp       logmq.SuppressionWindow // exhausted-retries suppression; nil = unsuppressed
 	// failMarkProcessed makes every MarkProcessed call on the replay gate
 	// error (the Processed check still works). Simulates Redis failing after
 	// the attempt's events were delivered.

--- a/internal/logmq/delivery_suppression_test.go
+++ b/internal/logmq/delivery_suppression_test.go
@@ -1,15 +1,14 @@
 package logmq_test
 
 // Delivery-layer exhausted-retries suppression: the delivery worker wraps the
-// keyed exhausted event in an idempotence window. These tests exercise that
-// path (the characterization suite wires no idempotence, so it doesn't cover
-// it).
+// keyed exhausted event in a suppression window. These tests exercise that
+// path (the characterization suite wires no window, so it doesn't cover it).
 
 import (
 	"testing"
 	"time"
 
-	"github.com/hookdeck/outpost/internal/idempotence"
+	"github.com/hookdeck/outpost/internal/logmq"
 	"github.com/hookdeck/outpost/internal/models"
 	"github.com/hookdeck/outpost/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
@@ -47,20 +46,18 @@ func exhaustedAlertConfig() alertConfig {
 }
 
 // Two exhaustions on the same destination within the window → only the first
-// delivers; the second is suppressed by the idempotence key. Same event here
+// delivers; the second is suppressed by the window key. Same event here
 // (the replay case); distinct events are covered by PerDestination.
 func TestDelivery_ExhaustedRetries_WindowSuppression(t *testing.T) {
 	t.Parallel()
-	idemp := idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(10*time.Second))
+	idemp := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", 10*time.Second)
 	h := newHarness(t, harnessConfig{
 		batcher: batcherConfig{itemCount: 1},
 		alert:   exhaustedAlertConfig(),
 		doubles: doublesConfig{idemp: idemp},
 	})
 
-	// Paced one at a time: concurrent Execs on the same window key would hit
-	// the in-flight conflict path (sleep + ErrConflict) instead of the
-	// suppression this test pins.
+	// Paced one at a time so the first exhaustion is the one that delivers.
 	dest, tenant, eventID := "dest_ws", "tenant_ws", "evt_ws"
 	cm1, msg1 := newCountingMessage(makeExhaustedEntry(dest, tenant, eventID, "att_ws_1", 4))
 	cm2, msg2 := newCountingMessage(makeExhaustedEntry(dest, tenant, eventID, "att_ws_2", 5))
@@ -76,7 +73,7 @@ func TestDelivery_ExhaustedRetries_WindowSuppression(t *testing.T) {
 }
 
 // With no suppression window (idemp nil == WindowSeconds 0), every exhaustion
-// delivers — the key is present but there's no idempotence to enforce it.
+// delivers — the key is present but there's no window to enforce it.
 func TestDelivery_ExhaustedRetries_NoWindowEmitsEvery(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t, harnessConfig{
@@ -102,15 +99,14 @@ func TestDelivery_ExhaustedRetries_NoWindowEmitsEvery(t *testing.T) {
 // at most one alert per destination within the window.
 func TestDelivery_ExhaustedRetries_PerDestination(t *testing.T) {
 	t.Parallel()
-	idemp := idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(10*time.Second))
+	idemp := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", 10*time.Second)
 	h := newHarness(t, harnessConfig{
 		batcher: batcherConfig{itemCount: 1},
 		alert:   exhaustedAlertConfig(),
 		doubles: doublesConfig{idemp: idemp},
 	})
 
-	// Paced one at a time: concurrent Execs on the shared window key would hit
-	// the in-flight conflict path instead of the suppression this test pins.
+	// Paced one at a time so the first exhaustion is the one that delivers.
 	dest, tenant := "dest_pd", "tenant_pd"
 	cm1, msg1 := newCountingMessage(makeExhaustedEntry(dest, tenant, "evt_pd_1", "att_pd_1", 4))
 	cm2, msg2 := newCountingMessage(makeExhaustedEntry(dest, tenant, "evt_pd_2", "att_pd_2", 4))
@@ -129,7 +125,7 @@ func TestDelivery_ExhaustedRetries_PerDestination(t *testing.T) {
 // gets independent windows, so one tenant's alert never suppresses another's.
 func TestDelivery_ExhaustedRetries_TenantIsolation(t *testing.T) {
 	t.Parallel()
-	idemp := idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(10*time.Second))
+	idemp := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", 10*time.Second)
 	h := newHarness(t, harnessConfig{
 		batcher: batcherConfig{itemCount: 1},
 		alert:   exhaustedAlertConfig(),
@@ -151,15 +147,10 @@ func TestDelivery_ExhaustedRetries_TenantIsolation(t *testing.T) {
 }
 
 // Two events exhausting concurrently on one destination race on the shared
-// window key: exactly one alert delivers, and the loser — whether it lands on
-// the suppressed path or the in-flight conflict path — acks instead of nacking.
+// window key: exactly one alert delivers and the loser acks.
 func TestDelivery_ExhaustedRetries_ConcurrentConflictAcks(t *testing.T) {
 	t.Parallel()
-	idemp := idempotence.New(testutil.CreateTestRedisClient(t),
-		idempotence.WithSuccessfulTTL(10*time.Second),
-		// Short conflict wait so the losing Exec resolves quickly.
-		idempotence.WithTimeout(200*time.Millisecond),
-	)
+	idemp := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", 10*time.Second)
 	h := newHarness(t, harnessConfig{
 		batcher: batcherConfig{itemCount: 2},
 		alert:   exhaustedAlertConfig(),
@@ -183,7 +174,7 @@ func TestDelivery_ExhaustedRetries_ConcurrentConflictAcks(t *testing.T) {
 // destination re-delivers instead of being suppressed.
 func TestDelivery_ExhaustedRetries_EmitFailureClearsWindow(t *testing.T) {
 	t.Parallel()
-	idemp := idempotence.New(testutil.CreateTestRedisClient(t), idempotence.WithSuccessfulTTL(10*time.Second))
+	idemp := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", 10*time.Second)
 	h := newHarness(t, harnessConfig{
 		batcher: batcherConfig{itemCount: 1},
 		alert:   exhaustedAlertConfig(),
@@ -211,4 +202,37 @@ func TestDelivery_ExhaustedRetries_EmitFailureClearsWindow(t *testing.T) {
 	cmOK.requireAcked(t)
 	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust}, topics(h.sink.forDest(dest)),
 		"retry after emit failure re-delivers because the window key was cleared")
+}
+
+// The window loser acks while the winner's emit is still in flight. Before
+// the window owned its claim, the loser waited out a fixed conflict sleep as
+// long as the emit budget and nacked on the expired ctx instead.
+func TestDelivery_ExhaustedRetries_LoserAcksWhileWinnerInFlight(t *testing.T) {
+	t.Parallel()
+	idemp := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", 10*time.Second)
+	h := newHarness(t, harnessConfig{
+		batcher: batcherConfig{itemCount: 1},
+		alert:   exhaustedAlertConfig(),
+		doubles: doublesConfig{
+			idemp:       idemp,
+			sinkBlockOn: map[string]bool{topicExhaust: true},
+		},
+	})
+
+	dest, tenant := "dest_if", "tenant_if"
+	cm1, msg1 := newCountingMessage(makeExhaustedEntry(dest, tenant, "evt_if_1", "att_if_1", 4))
+	cm2, msg2 := newCountingMessage(makeExhaustedEntry(dest, tenant, "evt_if_2", "att_if_2", 4))
+	h.add(msg1)
+	// msg1's exhausted emit is parked on the sink with the claim held.
+	h.sink.waitBlocked(t)
+	h.add(msg2)
+	h.waitTerminal([]*countingMessage{cm2})
+	cm2.requireAcked(t)
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed}, topics(h.sink.forDest(dest)),
+		"loser acked before the winner's alert went out")
+
+	h.sink.release()
+	h.waitTerminal([]*countingMessage{cm1})
+	cm1.requireAcked(t)
+	assert.ElementsMatch(t, []string{topicFailed, topicFailed, topicExhaust}, topics(h.sink.forDest(dest)))
 }

--- a/internal/logmq/suppressionwindow.go
+++ b/internal/logmq/suppressionwindow.go
@@ -1,0 +1,52 @@
+package logmq
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hookdeck/outpost/internal/redis"
+)
+
+// redisSuppressionWindow is a SuppressionWindow over one Redis key per window:
+// SETNX with the window as TTL claims it; a caller that fails to claim skips
+// its send. The claim is the window — there is no separate in-flight state and
+// no waiting on another claimant, because the window's contract is one send
+// per key per window regardless of which caller wins. A failed send releases
+// the claim so the next caller in the window sends instead.
+type redisSuppressionWindow struct {
+	client       redis.Client
+	deploymentID string
+	window       time.Duration
+}
+
+func NewRedisSuppressionWindow(client redis.Client, deploymentID string, window time.Duration) SuppressionWindow {
+	return &redisSuppressionWindow{client: client, deploymentID: deploymentID, window: window}
+}
+
+func (w *redisSuppressionWindow) Exec(ctx context.Context, key string, exec func(context.Context) error) error {
+	key = w.prefixKey(key)
+	claimed, err := w.client.SetNX(ctx, key, "1", w.window).Result()
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return nil
+	}
+	if err := exec(ctx); err != nil {
+		// Release even when exec failed because ctx expired, or the claim
+		// suppresses every send until the window ends.
+		if delErr := w.client.Del(context.WithoutCancel(ctx), key).Err(); delErr != nil {
+			return errors.Join(err, delErr)
+		}
+		return err
+	}
+	return nil
+}
+
+func (w *redisSuppressionWindow) prefixKey(key string) string {
+	if w.deploymentID == "" {
+		return key
+	}
+	return w.deploymentID + ":" + key
+}

--- a/internal/logmq/suppressionwindow_test.go
+++ b/internal/logmq/suppressionwindow_test.go
@@ -1,0 +1,93 @@
+package logmq_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hookdeck/outpost/internal/logmq"
+	"github.com/hookdeck/outpost/internal/util/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisSuppressionWindow_SecondCallerSkips(t *testing.T) {
+	t.Parallel()
+	w := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "dep", time.Minute)
+	ctx := context.Background()
+
+	calls := 0
+	exec := func(context.Context) error { calls++; return nil }
+	require.NoError(t, w.Exec(ctx, "k", exec))
+	require.NoError(t, w.Exec(ctx, "k", exec))
+	assert.Equal(t, 1, calls)
+}
+
+func TestRedisSuppressionWindow_KeysAreIndependent(t *testing.T) {
+	t.Parallel()
+	w := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", time.Minute)
+	ctx := context.Background()
+
+	calls := 0
+	exec := func(context.Context) error { calls++; return nil }
+	require.NoError(t, w.Exec(ctx, "a", exec))
+	require.NoError(t, w.Exec(ctx, "b", exec))
+	assert.Equal(t, 2, calls)
+}
+
+// A caller that lands while another holds the claim returns immediately: the
+// window never waits on the in-flight send.
+func TestRedisSuppressionWindow_InFlightCallerSkipsWithoutWaiting(t *testing.T) {
+	t.Parallel()
+	w := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", time.Minute)
+	ctx := context.Background()
+
+	claimed := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- w.Exec(ctx, "k", func(context.Context) error {
+			close(claimed)
+			<-release
+			return nil
+		})
+	}()
+	<-claimed
+
+	start := time.Now()
+	require.NoError(t, w.Exec(ctx, "k", func(context.Context) error { t.Error("contender must not exec"); return nil }))
+	assert.Less(t, time.Since(start), 100*time.Millisecond)
+
+	close(release)
+	require.NoError(t, <-holderDone)
+}
+
+func TestRedisSuppressionWindow_FailedExecReleasesClaim(t *testing.T) {
+	t.Parallel()
+	w := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", time.Minute)
+	ctx := context.Background()
+
+	boom := errors.New("boom")
+	err := w.Exec(ctx, "k", func(context.Context) error { return boom })
+	require.ErrorIs(t, err, boom)
+
+	calls := 0
+	require.NoError(t, w.Exec(ctx, "k", func(context.Context) error { calls++; return nil }))
+	assert.Equal(t, 1, calls, "claim released on failure, next caller sends")
+}
+
+// The claim is released even when exec failed because ctx expired: the
+// release must not run on the dead ctx.
+func TestRedisSuppressionWindow_ExpiredCtxStillReleasesClaim(t *testing.T) {
+	t.Parallel()
+	w := logmq.NewRedisSuppressionWindow(testutil.CreateTestRedisClient(t), "", time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := w.Exec(ctx, "k", func(ctx context.Context) error { cancel(); return ctx.Err() })
+	require.ErrorIs(t, err, context.Canceled)
+
+	calls := 0
+	require.NoError(t, w.Exec(context.Background(), "k", func(context.Context) error { calls++; return nil }))
+	assert.Equal(t, 1, calls)
+}

--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -377,13 +377,11 @@ func (b *ServiceBuilder) BuildLogWorker(baseRouter *gin.Engine) error {
 
 	// Build a suppression window only when exhausted-retries alerting is enabled
 	// with a positive window. A zero window means "alert on every exhaustion"
-	// (no suppression), so we leave the idempotence instance nil.
-	var exhaustedRetriesIdemp idempotence.Idempotence
+	// (no suppression), so we leave the window nil.
+	var exhaustedRetriesWindow logmq.SuppressionWindow
 	if alertSettings.ExhaustedRetries.Enabled && alertSettings.ExhaustedRetries.WindowSeconds > 0 {
-		exhaustedRetriesIdemp = idempotence.New(svc.redisClient,
-			idempotence.WithSuccessfulTTL(time.Duration(alertSettings.ExhaustedRetries.WindowSeconds)*time.Second),
-			idempotence.WithDeploymentID(b.cfg.DeploymentID),
-		)
+		exhaustedRetriesWindow = logmq.NewRedisSuppressionWindow(svc.redisClient, b.cfg.DeploymentID,
+			time.Duration(alertSettings.ExhaustedRetries.WindowSeconds)*time.Second)
 	}
 	_, retryMaxLimit := b.cfg.GetRetryBackoff()
 	alertEvaluator := alert.NewEvaluator(
@@ -414,7 +412,7 @@ func (b *ServiceBuilder) BuildLogWorker(baseRouter *gin.Engine) error {
 		Emitter:        emitter,
 		Disabler:       disabler,
 		ProcessedIdemp: processedIdemp,
-		ExhaustedIdemp: exhaustedRetriesIdemp,
+		ExhaustedIdemp: exhaustedRetriesWindow,
 	}, logmq.BatchProcessorConfig{
 		ItemCountThreshold: batcherCfg.ItemCountThreshold,
 		DelayThreshold:     batcherCfg.DelayThreshold,


### PR DESCRIPTION
Fixes the `opevent delivery failed … context deadline exceeded` nack reported in #1050 for subscribers of `alert.attempt.exhausted_retries`. #1050 keeps unsubscribed events out of the window entirely; this covers the case where the event is subscribed.

## The failure

A destination goes down. Its queued events retry and exhaust around the same time, spread across the log service replicas. Every exhaustion on that destination wants to send one `exhausted_retries` alert through the same suppression key, `opevents:exhausted:<tenant>:<destination>`, so that only the first one in the window goes out.

The window was an `idempotence.Idempotence` configured with only the window TTL, so it inherited the package's 5s conflict wait, meant for delivery idempotency where the claimed work is an HTTP call. When two exhaustions overlap:

1. Replica A wins SETNX, key is `processing`, A emits (a few ms) and marks the key `processed`.
2. Replica B lands in those few ms, sees `processing`, and sleeps 5s before rechecking.
3. B's send ctx had a 5s emit budget when it entered, so the recheck runs on an expired ctx and returns `context deadline exceeded`.
4. `send()` returns the error, `sendAll` logs `opevent delivery failed`, and the whole log message nacks. `MarkProcessed` never runs.
5. Redelivery re-evaluates the attempt and re-plans its events, so already-sent siblings such as `attempt.failed` or `destination.disabled` can go out twice. The window key is `processed` by then, so the retry acks.

The `ErrConflict → delivered` branch in `send()` was written for this case but is unreachable: the sleep always outlives the ctx. One collision costs a goroutine parked 5s, an error log, a nack and redelivery, and possible duplicate alerts. The loser had nothing to wait for; the window's contract is one alert per destination per window, and A's alert is already on its way.

## The fix

Replaces the window with a SETNX-per-window type in `logmq`: losing the claim is the suppression, return immediately. A failed emit releases the claim so the next exhaustion re-alerts. `send()` drops its `ErrConflict` handling. Live windows reset once on upgrade since the key value changes, at worst one extra exhausted-retries alert per destination mid-window.