### PR TITLE
fix(deliverymq): Add index to attempts_default partition

### DIFF
--- a/internal/migrator/migrations/postgres/000011_retry_attempt_lookup_index.down.sql
+++ b/internal/migrator/migrations/postgres/000011_retry_attempt_lookup_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS attempts_default_event_tenant_destination_time_id_idx;

--- a/internal/migrator/migrations/postgres/000011_retry_attempt_lookup_index.up.sql
+++ b/internal/migrator/migrations/postgres/000011_retry_attempt_lookup_index.up.sql
@@ -1,0 +1,5 @@
+-- Support retry scheduler lookups for the latest attempt by event, tenant, and
+-- destination. This is created on the default partition because PostgreSQL does
+-- not support CREATE INDEX CONCURRENTLY on a partitioned parent table.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS attempts_default_event_tenant_destination_time_id_idx
+ON attempts_default (event_id, tenant_id, destination_id, time DESC, id DESC);


### PR DESCRIPTION
## Summary

Adds a PostgreSQL composite index on `attempts_default` to optimize retry execution lookups for the latest attempt by event, tenant, and destination.

## Context

Retry execution fetches the latest prior attempt from logstore before publishing the next delivery task.
`deliverymq-retry task → retry scheduler → fetch latest attempt → execute delivery`

The query filters by:

- `event_id`
- `tenant_id`
- `destination_id`

and orders by:

- `time DESC`
- `id DESC`

with `LIMIT 1`.

Under high I/O load, PostgreSQL can choose an existing tenant/destination/time index and apply `event_id` as a heap filter. In large default partitions, that can require many page reads for a single retry lookup.

During an incident, slow Postgres retry lookups contributed to retry tasks running longer than the Redis retry visibility timeout `RETRY_VISIBILITY_TIMEOUT_SECONDS` (default 30 secs). That allowed the same retry task to become visible again and increased duplicate retry pressure.

## Changes

Adds this index:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS attempts_default_event_tenant_destination_time_id_idx
ON attempts_default (event_id, tenant_id, destination_id, time DESC, id DESC);
```

##  Operational notes

This index is created only on `attempts_default`, which matches the current production table layout.
`CREATE INDEX CONCURRENTLY` is used to avoid blocking writes while the index is built. Building the index can still be I/O intensive on large deployments, so it should be monitored during rollout.
Longer term, monthly partitions would make retention and table maintenance safer, since old attempts could be removed by dropping partitions instead of batched deletes.