### PR TITLE
fix(infra): scope the infrastructure lock key by deployment id

### DIFF
--- a/cmd/e2e/configs/basic.go
+++ b/cmd/e2e/configs/basic.go
@@ -100,8 +100,9 @@ func Basic(t *testing.T, opts BasicOpts) config.Config {
 			log.Println("Failed to create logger:", err)
 		}
 		outpostInfra := infra.NewInfra(infra.Config{
-			DeliveryMQ: c.MQs.ToInfraConfig("deliverymq"),
-			LogMQ:      c.MQs.ToInfraConfig("logmq"),
+			DeliveryMQ:   c.MQs.ToInfraConfig("deliverymq"),
+			LogMQ:        c.MQs.ToInfraConfig("logmq"),
+			DeploymentID: c.DeploymentID,
 		}, redisClient, logger, c.MQs.GetInfraType())
 		if err := outpostInfra.Teardown(context.Background()); err != nil {
 			log.Println("Teardown failed:", err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -220,6 +220,7 @@ func (a *App) initializeInfrastructure(ctx context.Context) error {
 		DeliveryMQ:    a.config.MQs.ToInfraConfig("deliverymq"),
 		LogMQ:         a.config.MQs.ToInfraConfig("logmq"),
 		AutoProvision: a.config.MQs.AutoProvision,
+		DeploymentID:  a.config.DeploymentID,
 	}, a.redisClient, a.logger, a.config.MQs.GetInfraType()); err != nil {
 		a.logger.Error("infrastructure initialization failed", zap.Error(err))
 		return err

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -44,6 +44,14 @@ type Config struct {
 	DeliveryMQ    *mqinfra.MQInfraConfig
 	LogMQ         *mqinfra.MQInfraConfig
 	AutoProvision *bool
+	DeploymentID  string
+}
+
+func LockKey(deploymentID string) string {
+	if deploymentID == "" {
+		return lockKey
+	}
+	return deploymentID + ":" + lockKey
 }
 
 func (cfg *Config) SetSensiblePolicyDefaults() {
@@ -168,7 +176,7 @@ func NewInfra(cfg Config, redisClient redis.Cmdable, logger *logging.Logger, mqT
 	}
 
 	return Infra{
-		lock:         redislock.New(redisClient, redislock.WithKey(lockKey), redislock.WithTTL(lockTTL)),
+		lock:         redislock.New(redisClient, redislock.WithKey(LockKey(cfg.DeploymentID)), redislock.WithTTL(lockTTL)),
 		provider:     provider,
 		shouldManage: shouldManage,
 		logger:       logger,

--- a/internal/infra/infra_test.go
+++ b/internal/infra/infra_test.go
@@ -80,6 +80,13 @@ func newTestInfraWithRedis(t *testing.T, provider infra.InfraProvider, lockKey s
 	return infra.NewInfraWithProvider(lock, provider, shouldManage, logger)
 }
 
+func TestLockKey(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "outpost:lock", infra.LockKey(""))
+	assert.Equal(t, "dep_1:outpost:lock", infra.LockKey("dep_1"))
+}
+
 func TestInfra_SingleNode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The infrastructure declaration lock always used the Redis key `outpost:lock`. Deployments that share a Redis instance via `DEPLOYMENT_ID` therefore contended on one global lock and could fail startup with `failed to acquire lock after 5 attempts` when several declared at the same time. The key is now `<DEPLOYMENT_ID>:outpost:lock`, matching the prefix used for the other deployment-scoped keys; it stays `outpost:lock` when `DEPLOYMENT_ID` is unset.

Testing: `go build ./...`, `go vet`, `go test -short ./internal/infra/... ./internal/app/...` pass; added `TestLockKey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSUm1ZBeUurupWpGWwE8NM
