### PR TITLE
fix(gcppubsub): create subscriptions that never expire

### DIFF
--- a/docs/content/self-hosting/guides/byo-mqs.mdoc
+++ b/docs/content/self-hosting/guides/byo-mqs.mdoc
@@ -106,6 +106,7 @@ The following table shows the resources, default names, and configuration variab
 - Configure `DeadLetterPolicy` on main subscription
 - Set `ackDeadlineSeconds` for visibility timeout (default: 10 seconds)
 - Set `maxDeliveryAttempts` in DeadLetterPolicy
+- Disable `expirationPolicy` on both subscriptions; the default deletes a subscription after 31 days without a subscriber, and the DLQ subscription has none
 
 ### Azure Service Bus
 

--- a/internal/mqinfra/gcppubsub.go
+++ b/internal/mqinfra/gcppubsub.go
@@ -15,6 +15,11 @@ import (
 const (
 	defaultMinRetryBackoffSeconds = 10
 	defaultMaxRetryBackoffSeconds = 120
+
+	// Pub/Sub deletes subscriptions after 31 days without subscriber activity
+	// unless the expiration policy is explicitly disabled. A zero duration
+	// means never expire.
+	neverExpire = time.Duration(0)
 )
 
 type infraGCPPubSub struct {
@@ -165,7 +170,8 @@ func (infra *infraGCPPubSub) Declare(ctx context.Context) error {
 
 	if !dlqSubExists {
 		dlqSubConfig := pubsub.SubscriptionConfig{
-			Topic: dlqTopic,
+			Topic:            dlqTopic,
+			ExpirationPolicy: neverExpire,
 		}
 		_, err = client.CreateSubscription(ctx, dlqSubID, dlqSubConfig)
 		if err != nil {
@@ -203,8 +209,9 @@ func (infra *infraGCPPubSub) Declare(ctx context.Context) error {
 	if !subExists {
 		// Create new subscription with DLQ and retry settings
 		subConfig := pubsub.SubscriptionConfig{
-			Topic:       topic,
-			AckDeadline: getDuration(ackDeadline),
+			Topic:            topic,
+			AckDeadline:      getDuration(ackDeadline),
+			ExpirationPolicy: neverExpire,
 			DeadLetterPolicy: &pubsub.DeadLetterPolicy{
 				DeadLetterTopic:     dlqTopic.String(),
 				MaxDeliveryAttempts: maxDeliveryAttempts,

--- a/internal/mqinfra/mqinfra_test.go
+++ b/internal/mqinfra/mqinfra_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	pubsubapi "cloud.google.com/go/pubsub/apiv1"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"github.com/hookdeck/outpost/internal/idgen"
 	"github.com/hookdeck/outpost/internal/mqinfra"
 	"github.com/hookdeck/outpost/internal/mqs"
@@ -13,6 +15,9 @@ import (
 	"github.com/hookdeck/outpost/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const retryLimit = 5
@@ -648,4 +653,41 @@ func TestIntegrationMQInfra_AzureServiceBus(t *testing.T) {
 				}},
 		},
 	)
+}
+
+func TestIntegrationMQInfra_GCPPubSub_SubscriptionsNeverExpire(t *testing.T) {
+	testutil.CheckIntegrationTest(t)
+	emulatorHost := testinfra.EnsureGCP()
+	t.Cleanup(testinfra.Start(t))
+
+	ctx := context.Background()
+	topicID := "test-" + idgen.String()
+	subscriptionID := topicID + "-subscription"
+	infra := mqinfra.New(&mqinfra.MQInfraConfig{
+		GCPPubSub: &mqinfra.GCPPubSubInfraConfig{
+			ProjectID:      "test-project",
+			TopicID:        topicID,
+			SubscriptionID: subscriptionID,
+		},
+	})
+	require.NoError(t, infra.Declare(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, infra.TearDown(ctx))
+	})
+
+	client, err := pubsubapi.NewSubscriberClient(ctx,
+		option.WithEndpoint(emulatorHost),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	for _, subID := range []string{subscriptionID, mqinfra.DefaultGCPPubSubDLQSubscriptionName(mqinfra.DefaultGCPPubSubDLQTopicName(topicID))} {
+		sub, err := client.GetSubscription(ctx, &pubsubpb.GetSubscriptionRequest{
+			Subscription: "projects/test-project/subscriptions/" + subID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sub.ExpirationPolicy, "%s: expiration policy must be set explicitly", subID)
+		assert.Nil(t, sub.ExpirationPolicy.Ttl, "%s: expiration policy must be never (nil ttl)", subID)
+	}
 }


### PR DESCRIPTION
Pub/Sub applies a default expiration policy that deletes a subscription after 31 days without subscriber activity. The dead-letter subscription has no consumer, so it expires and dead-lettered messages are dropped until the next `Declare` recreates it. This sets `ExpirationPolicy` to never on both the main and dead-letter subscriptions.

Testing: `go build ./...`, `go vet ./internal/mqinfra/...`, `go test -short ./internal/mqinfra/...`; new `TestIntegrationMQInfra_GCPPubSub_SubscriptionsNeverExpire` passes against the emulator and fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSUm1ZBeUurupWpGWwE8NM
